### PR TITLE
CUMULUS-856: The rule should have default state ENABLED

### DIFF
--- a/app/scripts/components/rules/add.js
+++ b/app/scripts/components/rules/add.js
@@ -32,7 +32,8 @@ const AddRule = React.createClass({
       rule: {
         type: '',
         value: ''
-      }
+      },
+      state: 'ENABLED'
     };
     return (
       <AddRaw


### PR DESCRIPTION
1. When a rule is added, the rule should have default state `ENABLED`, otherwise, the state is not set currently.
2. A separate `cumulus` PR will be submitted to set the state of the rule to default value 'ENABLED' if the state is not provided in the request.