### PR TITLE
default selection is null when opening dropdown

### DIFF
--- a/app/scripts/utils/table-config/granules.js
+++ b/app/scripts/utils/table-config/granules.js
@@ -84,7 +84,7 @@ export const simpleDropdownOption = function (config) {
       options={config.options}
       id={config.label}
       onChange={config.handler}
-      noNull={true}
+      noNull={false}
     />
   );
 };


### PR DESCRIPTION
The `Execute` dropdown modal populated its list with choices, but the workflow that is initially displayed is not set as the selected workflow in the back end. If the initial workflow is used, the command will fail as the selection would still be `undefined`, resulting in the following error:
```
Error: "Bad Request: Workflow doesn't exist: s3://system-bucket/deployment/workflows/undefined.json for undefined."
```
This change updates the modal to show an empty selection so that this behavior is represented in the UI, and an operator is forced to manually select an option. Switching to an explicit null selection also reduces the potential for accidental workflow starts (i.e. mistakenly clicking 'Confirm' instead of 'Cancel'). 
![null_selection](https://user-images.githubusercontent.com/14986053/46168860-37e16480-c25f-11e8-89ae-6b6fc5a9ceac.png)
