### PR TITLE
CUMULUS-649

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,7 +52,7 @@ jobs:
 
       - run:
           name: Run Validation Tests
-          command: docker run --link api:api --link dashboard:dashboard -e CYPRESS_BASE_URL=http://dashboard:3000 -e CYPRESS_APIROOT=http://api:5001 --rm -v /home/circleci/.cache:/root/.cache -v $(pwd):/home --workdir /home node:8.11.4 yarn validation
+          command: docker run --link api:api --link dashboard:dashboard -e CYPRESS_BASE_URL=http://dashboard:3000 --rm -v /home/circleci/.cache:/root/.cache -v $(pwd):/home --workdir /home node:8.11.4 yarn validation
 
       - run:
           name: Run Integration Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,13 +22,13 @@ jobs:
           paths:
             - ~/cumulus-dashboard/node_modules
             - ~/.cache
- 
+
       - run:
           name: Run tests
           command: docker run --rm -v /home/circleci/.cache:/root/.cache -v $(pwd):/home --workdir /home node:8.11.4 yarn test --cache-folder /root/.cache
 
       - run:
-          name: Prepare servers 
+          name: Prepare servers
           command: |
             # run fake api
             docker run -d --name api -v $(pwd):/home --workdir /home -p 5001:5001 node:8.11.4 node fake-api.js
@@ -49,11 +49,11 @@ jobs:
                 attempt_counter=$(($attempt_counter+1))
                 sleep 5
             done
-      
+
       - run:
           name: Run Validation Tests
-          command: docker run --link api:api --link dashboard:dashboard -e DASHBOARD_HOST=http://dashboard:3000 --rm -v /home/circleci/.cache:/root/.cache -v $(pwd):/home --workdir /home node:8.11.4 yarn validation
-      
+          command: docker run --link api:api --link dashboard:dashboard -e CYPRESS_BASE_URL=http://dashboard:3000 -e CYPRESS_APIROOT=http://api:5001 --rm -v /home/circleci/.cache:/root/.cache -v $(pwd):/home --workdir /home node:8.11.4 yarn validation
+
       - run:
           name: Run Integration Tests
-          command: docker run --link api:api --link dashboard:dashboard -e DASHBOARD_HOST=http://dashboard:3000 --rm -v /home/circleci/.cache:/root/.cache -v $(pwd):/home --workdir /home cypress/base:8 yarn cypress-ci 
+          command: docker run --link api:api --link dashboard:dashboard -e CYPRESS_BASE_URL=http://dashboard:3000 -e CYPRESS_APIROOT=http://api:5001 --rm -v /home/circleci/.cache:/root/.cache -v $(pwd):/home --workdir /home cypress/base:8 yarn cypress-ci

--- a/.eslintrc
+++ b/.eslintrc
@@ -34,6 +34,7 @@
       "react/react-in-jsx-scope": 2
     },
     "globals": {
-      "cy": true
+      "cy": true,
+      "Cypress": true
     }
 }

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -18,6 +18,10 @@ import config from './config';
 import reducers from './reducers';
 
 const store = createStore(reducers, applyMiddleware(thunkMiddleware));
+if (window.Cypress) {
+  // only available during E2E tests
+  window.appStore = store;
+}
 
 console.log.apply(console, config.consoleMessage);
 console.log('Environment', config.environment);

--- a/app/scripts/main.js
+++ b/app/scripts/main.js
@@ -18,10 +18,6 @@ import config from './config';
 import reducers from './reducers';
 
 const store = createStore(reducers, applyMiddleware(thunkMiddleware));
-if (window.Cypress) {
-  // only available during E2E tests
-  window.appStore = store;
-}
 
 console.log.apply(console, config.consoleMessage);
 console.log('Environment', config.environment);

--- a/cypress.json
+++ b/cypress.json
@@ -1,1 +1,3 @@
-{}
+{
+  "baseUrl": "http://localhost:3000"
+}

--- a/cypress.json
+++ b/cypress.json
@@ -1,3 +1,6 @@
 {
-  "baseUrl": "http://localhost:3000"
+  "baseUrl": "http://localhost:3000",
+  "env": {
+    "APIROOT": "http://localhost:5001"
+  }
 }

--- a/cypress/integration/main_page_spec.js
+++ b/cypress/integration/main_page_spec.js
@@ -10,9 +10,7 @@ describe('Dashboard Tests', () => {
   });
 
   it('Logging in successfully redirects to the Dashboard main page', () => {
-    cy.get('div[class=modal__internal]').within(() => {
-      cy.get('a').click();
-    });
+    cy.login();
 
     cy.get('h1[class=heading--xlarge').should('have.text', 'CUMULUS Dashboard');
     cy.get('li[class=nav__order-0]').within(() => {

--- a/cypress/integration/main_page_spec.js
+++ b/cypress/integration/main_page_spec.js
@@ -14,9 +14,7 @@ describe('Dashboard Tests', () => {
     });
 
     cy.get('h1[class=heading--xlarge').should('have.text', 'CUMULUS Dashboard');
-    cy.get('li[class=nav__order-0]').within(() => {
-      cy.get('a').should('have.attr', 'href').and('include', '/collections');
-    });
+    cy.contains('Collections').should('have.attr', 'href').and('include', '/collections');
     cy.contains('Rules').should('have.attr', 'href').and('include', '/rules');
   });
 

--- a/cypress/integration/main_page_spec.js
+++ b/cypress/integration/main_page_spec.js
@@ -14,8 +14,14 @@ describe('Dashboard Tests', () => {
     });
 
     cy.get('h1[class=heading--xlarge').should('have.text', 'CUMULUS Dashboard');
-    cy.contains('Collections').should('have.attr', 'href').and('include', '/collections');
-    cy.contains('Rules').should('have.attr', 'href').and('include', '/rules');
+    cy.get('nav')
+      .contains('Collections')
+      .should('have.attr', 'href')
+      .and('include', '/collections');
+    cy.get('nav')
+      .contains('Rules')
+      .should('have.attr', 'href')
+      .and('include', '/rules');
   });
 
   it('Logging out successfully redirects to the login screen', () => {

--- a/cypress/integration/main_page_spec.js
+++ b/cypress/integration/main_page_spec.js
@@ -1,7 +1,6 @@
 describe('Dashboard Tests', () => {
-  const host = process.env.DASHBOARD_HOST || 'http://localhost:3000/';
   it('When not logged in it should redirect to login page', () => {
-    cy.visit(host);
+    cy.visit('/');
     cy.url().should('include', '/#/auth');
     cy.get('div[class=modal__internal]').within(() => {
       cy.get('a').should('have.attr', 'href').and('include', 'token?');
@@ -10,20 +9,18 @@ describe('Dashboard Tests', () => {
   });
 
   it('Logging in successfully redirects to the Dashboard main page', () => {
-    cy.login();
+    cy.get('div[class=modal__internal]').within(() => {
+      cy.get('a').click();
+    });
 
     cy.get('h1[class=heading--xlarge').should('have.text', 'CUMULUS Dashboard');
     cy.get('li[class=nav__order-0]').within(() => {
       cy.get('a').should('have.attr', 'href').and('include', '/collections');
     });
+    cy.contains('Rules').should('have.attr', 'href').and('include', '/rules');
   });
 
   it('Logging out successfully redirects to the login screen', () => {
-    cy.visit(host);
-    cy.get('div[class=modal__internal]').within(() => {
-      cy.get('a').click();
-    });
-
     cy.get('h1[class=heading--xlarge').should('have.text', 'CUMULUS Dashboard');
 
     cy.get('nav li').last().within(() => {
@@ -31,8 +28,6 @@ describe('Dashboard Tests', () => {
     });
     cy.get('nav li').last().click();
     cy.url().should('include', '/#/auth');
-
-    cy.visit(`${host}#/collections`);
 
     cy.url().should('not.include', '/#/collections');
     cy.url().should('include', '/#/auth');

--- a/cypress/integration/main_page_spec.js
+++ b/cypress/integration/main_page_spec.js
@@ -1,11 +1,9 @@
+import { shouldBeRedirectedToLogin } from '../support/assertions';
+
 describe('Dashboard Tests', () => {
   it('When not logged in it should redirect to login page', () => {
     cy.visit('/');
-    cy.url().should('include', '/#/auth');
-    cy.get('div[class=modal__internal]').within(() => {
-      cy.get('a').should('have.attr', 'href').and('include', 'token?');
-      cy.get('a').should('have.text', 'Login with Earthdata Login');
-    });
+    shouldBeRedirectedToLogin();
   });
 
   it('Logging in successfully redirects to the Dashboard main page', () => {

--- a/cypress/integration/main_page_spec.js
+++ b/cypress/integration/main_page_spec.js
@@ -21,6 +21,11 @@ describe('Dashboard Tests', () => {
   });
 
   it('Logging out successfully redirects to the login screen', () => {
+    cy.visit('/');
+    cy.get('div[class=modal__internal]').within(() => {
+      cy.get('a').click();
+    });
+
     cy.get('h1[class=heading--xlarge').should('have.text', 'CUMULUS Dashboard');
 
     cy.get('nav li').last().within(() => {
@@ -28,6 +33,8 @@ describe('Dashboard Tests', () => {
     });
     cy.get('nav li').last().click();
     cy.url().should('include', '/#/auth');
+
+    cy.visit('#/collections');
 
     cy.url().should('not.include', '/#/collections');
     cy.url().should('include', '/#/auth');

--- a/cypress/integration/rules.spec.js
+++ b/cypress/integration/rules.spec.js
@@ -1,11 +1,9 @@
+import { shouldBeRedirectedToLogin } from '../support/assertions';
+
 describe('Rules page', () => {
   it('when not logged in it should redirect to login page', () => {
     cy.visit('#/rules');
-    cy.url().should('include', '/#/auth');
-    cy.get('div[class=modal__internal]').within(() => {
-      cy.get('a').should('have.attr', 'href').and('include', 'token?');
-      cy.get('a').should('have.text', 'Login with Earthdata Login');
-    });
+    shouldBeRedirectedToLogin();
   });
 
   describe('when logged in', () => {

--- a/cypress/integration/rules.spec.js
+++ b/cypress/integration/rules.spec.js
@@ -1,6 +1,6 @@
 describe('Rules page', () => {
   const host = process.env.DASHBOARD_HOST || 'http://localhost:3000/';
-  it('When not logged in it should redirect to login page', () => {
+  it('when not logged in it should redirect to login page', () => {
     cy.visit(`${host}#/rules`);
     cy.url().should('include', '/#/auth');
     cy.get('div[class=modal__internal]').within(() => {
@@ -9,13 +9,17 @@ describe('Rules page', () => {
     });
   });
 
-  it('visiting the Rules page', () => {
-    cy.login();
+  describe('when logged in', () => {
+    before(() => {
+      cy.login();
 
-    // cy.contains('Rules')
-    //   .click();
-    cy.visit('#/rules');
+      cy.contains('Rules')
+        .click();
+      // cy.visit('#/rules');
+    });
 
-    cy.get('table tbody tr').should('have.length', 1);
+    it('should display a list of rules', () => {
+      cy.get('table tbody tr').should('have.length', 1);
+    });
   });
 });

--- a/cypress/integration/rules.spec.js
+++ b/cypress/integration/rules.spec.js
@@ -9,13 +9,18 @@ describe('Rules page', () => {
   });
 
   describe('when logged in', () => {
-    before(() => {
+    beforeEach(() => {
       cy.login();
+    });
+
+    it('should display a link to view rules', () => {
       cy.visit('/');
-      cy.get('nav').contains('Rules').click();
+      cy.get('nav').contains('Rules').should('exist');
     });
 
     it('should display a list of rules', () => {
+      cy.get('nav').contains('Rules').click();
+      cy.url().should('include', '/#/rules');
       cy.get('table tbody tr').should('have.length', 1);
     });
   });

--- a/cypress/integration/rules.spec.js
+++ b/cypress/integration/rules.spec.js
@@ -57,7 +57,7 @@ describe('Rules page', () => {
           cy.get('dt')
             .contains('Provider')
             .next('dd')
-            .contains('PODAAC_SWOT')
+            .contains(testProviderId)
             .should('exist');
         });
     });

--- a/cypress/integration/rules.spec.js
+++ b/cypress/integration/rules.spec.js
@@ -19,6 +19,7 @@ describe('Rules page', () => {
     });
 
     it('should display a list of rules', () => {
+      cy.visit('/');
       cy.get('nav').contains('Rules').click();
       cy.url().should('include', '/#/rules');
       cy.get('table tbody tr').should('have.length', 1);

--- a/cypress/integration/rules.spec.js
+++ b/cypress/integration/rules.spec.js
@@ -1,7 +1,6 @@
 describe('Rules page', () => {
-  const host = process.env.DASHBOARD_HOST || 'http://localhost:3000/';
   it('when not logged in it should redirect to login page', () => {
-    cy.visit(`${host}#/rules`);
+    cy.visit('#/rules');
     cy.url().should('include', '/#/auth');
     cy.get('div[class=modal__internal]').within(() => {
       cy.get('a').should('have.attr', 'href').and('include', 'token?');
@@ -12,10 +11,7 @@ describe('Rules page', () => {
   describe('when logged in', () => {
     before(() => {
       cy.login();
-
-      cy.contains('Rules')
-        .click();
-      // cy.visit('#/rules');
+      cy.visit('#/rules');
     });
 
     it('should display a list of rules', () => {

--- a/cypress/integration/rules.spec.js
+++ b/cypress/integration/rules.spec.js
@@ -30,16 +30,19 @@ describe('Rules page', () => {
         .within(() => {
           cy.contains(testProviderId).should('exist');
           cy.contains(testCollectionId).should('exist');
-          // Has to be the last assertion so that this element
-          // is yielded to the click() command.
-          cy.contains(testRuleName).should('exist');
-        })
-        .click();
-      cy.url().should('include', `/#/rules/rule/${testRuleName}`);
+          cy.contains(testRuleName)
+            .should('exist')
+            .and('have.attr', 'href')
+            .and('equal', `#/rules/rule/${testRuleName}`);
+        });
     });
 
     it('display a rule with the correct data', () => {
-      cy.visit(`/#/rules/rule/${testRuleName}`);
+      cy.visit('/#/rules');
+      cy.get(`table tr[data-value="${testRuleName}"]`)
+        .contains(testRuleName)
+        .click();
+      cy.url().should('include', `/#/rules/rule/${testRuleName}`);
       cy.get('.metadata__details')
         .should('exist')
         .within(() => {

--- a/cypress/integration/rules.spec.js
+++ b/cypress/integration/rules.spec.js
@@ -32,8 +32,7 @@ describe('Rules page', () => {
           cy.contains(testCollectionId).should('exist');
           cy.contains(testRuleName)
             .should('exist')
-            .and('have.attr', 'href')
-            .and('equal', `#/rules/rule/${testRuleName}`);
+            .and('have.attr', 'href', `#/rules/rule/${testRuleName}`);
         });
     });
 
@@ -58,7 +57,8 @@ describe('Rules page', () => {
             .contains('Provider')
             .next('dd')
             .contains(testProviderId)
-            .should('exist');
+            .should('exist')
+            .and('have.attr', 'href', `#/providers/provider/${testProviderId}`);
         });
     });
   });

--- a/cypress/integration/rules.spec.js
+++ b/cypress/integration/rules.spec.js
@@ -9,8 +9,13 @@ describe('Rules page', () => {
     });
   });
 
-  it('Logging in successfully redirects to the Dashboard main page', () => {
+  it('visiting the Rules page', () => {
     cy.login();
-    cy.contains('Rules').should('have.attr', 'href').and('include', '/rules');
+
+    // cy.contains('Rules')
+    //   .click();
+    cy.visit('#/rules');
+
+    cy.get('table tbody tr').should('have.length', 1);
   });
 });

--- a/cypress/integration/rules.spec.js
+++ b/cypress/integration/rules.spec.js
@@ -7,6 +7,9 @@ describe('Rules page', () => {
   });
 
   describe('when logged in', () => {
+    const testProvider = 'PODAAC_SWOT';
+    const testCollection = 'MOD09GQ / 006';
+
     beforeEach(() => {
       cy.login();
     });
@@ -21,7 +24,12 @@ describe('Rules page', () => {
       cy.get('nav').contains('Rules').click();
       cy.url().should('include', '/#/rules');
       cy.get('table tbody tr').should('have.length', 1);
-      cy.get('table tr[data-value="MOD09GQ_TEST_kinesisRule"]').should('exist');
+      cy.get('table tr[data-value="MOD09GQ_TEST_kinesisRule"]')
+        .should('exist')
+        .within(() => {
+          cy.contains(testProvider).should('exist');
+          cy.contains(testCollection).should('exist');
+        });
     });
   });
 });

--- a/cypress/integration/rules.spec.js
+++ b/cypress/integration/rules.spec.js
@@ -1,0 +1,16 @@
+describe('Rules page', () => {
+  const host = process.env.DASHBOARD_HOST || 'http://localhost:3000/';
+  it('When not logged in it should redirect to login page', () => {
+    cy.visit(`${host}#/rules`);
+    cy.url().should('include', '/#/auth');
+    cy.get('div[class=modal__internal]').within(() => {
+      cy.get('a').should('have.attr', 'href').and('include', 'token?');
+      cy.get('a').should('have.text', 'Login with Earthdata Login');
+    });
+  });
+
+  it('Logging in successfully redirects to the Dashboard main page', () => {
+    cy.login();
+    cy.contains('Rules').should('have.attr', 'href').and('include', '/rules');
+  });
+});

--- a/cypress/integration/rules.spec.js
+++ b/cypress/integration/rules.spec.js
@@ -7,8 +7,9 @@ describe('Rules page', () => {
   });
 
   describe('when logged in', () => {
-    const testProvider = 'PODAAC_SWOT';
-    const testCollection = 'MOD09GQ / 006';
+    const testRuleName = 'MOD09GQ_TEST_kinesisRule';
+    const testProviderId = 'PODAAC_SWOT';
+    const testCollectionId = 'MOD09GQ / 006';
 
     beforeEach(() => {
       cy.login();
@@ -24,11 +25,37 @@ describe('Rules page', () => {
       cy.get('nav').contains('Rules').click();
       cy.url().should('include', '/#/rules');
       cy.get('table tbody tr').should('have.length', 1);
-      cy.get('table tr[data-value="MOD09GQ_TEST_kinesisRule"]')
+      cy.get(`table tr[data-value="${testRuleName}"]`)
         .should('exist')
         .within(() => {
-          cy.contains(testProvider).should('exist');
-          cy.contains(testCollection).should('exist');
+          cy.contains(testProviderId).should('exist');
+          cy.contains(testCollectionId).should('exist');
+          // Has to be the last assertion so that this element
+          // is yielded to the click() command.
+          cy.contains(testRuleName).should('exist');
+        })
+        .click();
+      cy.url().should('include', `/#/rules/rule/${testRuleName}`);
+    });
+
+    it('display a rule with the correct data', () => {
+      cy.visit(`/#/rules/rule/${testRuleName}`);
+      cy.get('.metadata__details')
+        .should('exist')
+        .within(() => {
+          cy.get('dt')
+            .contains('RuleName')
+            .next('dd')
+            .should('contain', testRuleName);
+          cy.get('dt')
+            .contains('Workflow')
+            .next('dd')
+            .should('contain', 'KinesisTriggerTest');
+          cy.get('dt')
+            .contains('Provider')
+            .next('dd')
+            .contains('PODAAC_SWOT')
+            .should('exist');
         });
     });
   });

--- a/cypress/integration/rules.spec.js
+++ b/cypress/integration/rules.spec.js
@@ -22,6 +22,7 @@ describe('Rules page', () => {
       cy.get('nav').contains('Rules').click();
       cy.url().should('include', '/#/rules');
       cy.get('table tbody tr').should('have.length', 1);
+      cy.get('table tr[data-value="MOD09GQ_TEST_kinesisRule"]').should('exist');
     });
   });
 });

--- a/cypress/integration/rules.spec.js
+++ b/cypress/integration/rules.spec.js
@@ -11,7 +11,8 @@ describe('Rules page', () => {
   describe('when logged in', () => {
     before(() => {
       cy.login();
-      cy.visit('#/rules');
+      cy.visit('/');
+      cy.get('nav').contains('Rules').click();
     });
 
     it('should display a list of rules', () => {

--- a/cypress/support/assertions.js
+++ b/cypress/support/assertions.js
@@ -1,0 +1,7 @@
+exports.shouldBeRedirectedToLogin = () => {
+  cy.url().should('include', '/#/auth');
+  cy.get('div[class=modal__internal]').within(() => {
+    cy.get('a').should('have.attr', 'href').and('include', 'token?');
+    cy.get('a').should('have.text', 'Login with Earthdata Login');
+  });
+};

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -25,7 +25,5 @@
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
 Cypress.Commands.add('login', () => {
-  cy.get('div[class=modal__internal]').within(() => {
-    cy.get('a').click();
-  });
+  return cy.visit('http://localhost:5001/token?state=http%3A%2F%2Flocalhost%3A3000%2F%23%2Fauth');
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -25,8 +25,9 @@
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
 Cypress.Commands.add('login', () => {
+  const authUrl = `${Cypress.config('baseUrl')}/#/auth`;
   return cy.request({
-    url: 'http://localhost:5001/token?state=http%3A%2F%2Flocalhost%3A3000%2F%23%2Fauth',
+    url: `${Cypress.env('APIROOT')}/token?state=${encodeURIComponent(authUrl)}`,
     followRedirect: false
   }).then((response) => {
     const query = response.redirectedToUrl.substr(response.redirectedToUrl.indexOf('?') + 1);

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -25,5 +25,12 @@
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
 
 Cypress.Commands.add('login', () => {
-  return cy.visit('http://localhost:5001/token?state=http%3A%2F%2Flocalhost%3A3000%2F%23%2Fauth');
+  return cy.request({
+    url: 'http://localhost:5001/token?state=http%3A%2F%2Flocalhost%3A3000%2F%23%2Fauth',
+    followRedirect: false
+  }).then((response) => {
+    const query = response.redirectedToUrl.substr(response.redirectedToUrl.indexOf('?') + 1);
+    const token = query.split('=')[1];
+    window.localStorage.setItem('auth-token', token);
+  });
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -23,3 +23,9 @@
 //
 // -- This is will overwrite an existing command --
 // Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })
+
+Cypress.Commands.add('login', () => {
+  cy.get('div[class=modal__internal]').within(() => {
+    cy.get('a').click();
+  });
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -35,9 +35,6 @@ Cypress.Commands.add('login', () => {
   }).then((response) => {
     const query = response.redirectedToUrl.substr(response.redirectedToUrl.indexOf('?') + 1);
     const token = query.split('=')[1];
-    cy.window().its('appStore').then(store => {
-      store.dispatch({ type: 'LOGIN' });
-    });
     cy.window()
       .its('localStorage')
       .invoke('setItem', 'auth-token', token);

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -26,12 +26,20 @@
 
 Cypress.Commands.add('login', () => {
   const authUrl = `${Cypress.config('baseUrl')}/#/auth`;
-  return cy.request({
-    url: `${Cypress.env('APIROOT')}/token?state=${encodeURIComponent(authUrl)}`,
+  cy.request({
+    url: `${Cypress.env('APIROOT')}/token`,
+    qs: {
+      state: encodeURIComponent(authUrl)
+    },
     followRedirect: false
   }).then((response) => {
     const query = response.redirectedToUrl.substr(response.redirectedToUrl.indexOf('?') + 1);
     const token = query.split('=')[1];
-    window.localStorage.setItem('auth-token', token);
+    cy.window().its('appStore').then(store => {
+      store.dispatch({ type: 'LOGIN' });
+    });
+    cy.window()
+      .its('localStorage')
+      .invoke('setItem', 'auth-token', token);
   });
 });

--- a/cypress/validation-tests/main-page.js
+++ b/cypress/validation-tests/main-page.js
@@ -4,7 +4,7 @@ import test from 'ava';
 import http from 'ava-http';
 
 test('POST, PUT, or DELETE operations with no session information are rejected', async (t) => {
-  const host = process.env.DASHBOARD_HOST || 'http://localhost:3000/';
+  const host = process.env.CYPRESS_BASE_URL || 'http://localhost:3000/';
   const res = await http.getResponse(host);
   t.is(res.statusCode, 200);
 

--- a/test/fake-api-fixtures/providers/PODAAC_SWOT/index.json
+++ b/test/fake-api-fixtures/providers/PODAAC_SWOT/index.json
@@ -1,0 +1,6 @@
+{
+  "globalConnectionLimit": 10,
+  "host": "test-bucket",
+  "id": "PODAAC_SWOT",
+  "protocol": "s3"
+}

--- a/test/fake-api-fixtures/providers/PODAAC_SWOT/index.json
+++ b/test/fake-api-fixtures/providers/PODAAC_SWOT/index.json
@@ -1,6 +1,8 @@
 {
-  "globalConnectionLimit": 10,
-  "host": "test-bucket",
-  "id": "PODAAC_SWOT",
-  "protocol": "s3"
+    "id": "PODAAC_SWOT",
+    "createdAt": 1524686535230,
+    "protocol": "s3",
+    "globalConnectionLimit": 10,
+    "host": "cumulus-test-sandbox-internal",
+    "updatedAt": 1525982459499
 }

--- a/test/fake-api-fixtures/rules/MOD09GQ_TEST_kinesisRule/index.json
+++ b/test/fake-api-fixtures/rules/MOD09GQ_TEST_kinesisRule/index.json
@@ -1,0 +1,21 @@
+{
+  "name": "MOD09GQ_TEST_kinesisRule",
+  "createdAt": 1538105473704,
+  "workflow": "KinesisTriggerTest",
+  "provider": "PODAAC_SWOT",
+  "meta": {
+    "cnmResponseStream": "test-src-integration-cnmResponseStream"
+  },
+  "rule": {
+    "type": "kinesis",
+    "arn": "12345678-1234-1234-abc1-1a2b3c4d5e6f",
+    "value": "arn:aws:kinesis:us-east-1:12345678:stream/test-src-integration-testStream-12345678-KinesisError"
+  },
+  "collection": {
+    "name": "MOD09GQ",
+    "version": "006"
+  },
+  "state": "ENABLED",
+  "updatedAt": 1538105473704,
+  "timestamp": 1538105475132
+}

--- a/test/fake-api-fixtures/rules/index.json
+++ b/test/fake-api-fixtures/rules/index.json
@@ -1,0 +1,33 @@
+{
+  "meta": {
+    "name": "cumulus-api",
+    "stack": "test-src-integration",
+    "table": "rule",
+    "limit": 10,
+    "page": 1,
+    "count": 1
+  },
+  "results": [
+    {
+      "name": "MOD09GQ_TEST_kinesisRule",
+      "createdAt": 1538105473704,
+      "workflow": "KinesisTriggerTest",
+      "provider": "PODAAC_SWOT",
+      "meta": {
+        "cnmResponseStream": "test-src-integration-cnmResponseStream"
+      },
+      "rule": {
+        "type": "kinesis",
+        "arn": "12345678-1234-1234-abc1-1a2b3c4d5e6f",
+        "value": "arn:aws:kinesis:us-east-1:12345678:stream/test-src-integration-testStream-12345678-KinesisError"
+      },
+      "collection": {
+        "name": "MOD09GQ",
+        "version": "006"
+      },
+      "state": "ENABLED",
+      "updatedAt": 1538105473704,
+      "timestamp": 1538105475132
+    }
+  ]
+}


### PR DESCRIPTION
- Add test for attempting to access Rules page when not logged in
- Add test for viewing rules when logged in
- Add login command to easily simulate login across multiple tests
  - Cypress recommends having one E2E test for login that performs the UI interaction for login, but [for subsequent tests to login programatically](https://docs.cypress.io/guides/references/best-practices.html#Organizing-Tests-Logging-In-Controlling-State)