### PR TITLE
use pdrs table-config for pdrs view

### DIFF
--- a/app/scripts/components/pdr/pdr.js
+++ b/app/scripts/components/pdr/pdr.js
@@ -26,7 +26,7 @@ import {
   bool,
   deleteText
 } from '../../utils/format';
-import { tableHeader, tableRow, tableSortProps, bulkActions } from '../../utils/table-config/granules';
+import { tableHeader, tableRow, tableSortProps, bulkActions } from '../../utils/table-config/pdrs';
 import { renderProgress } from '../../utils/table-config/pdr-progress';
 import List from '../table/list-view';
 import LogViewer from '../logs/viewer';


### PR DESCRIPTION
The PDR details view was broken because it imported the granules table-config rather than the pdr table-config. The granules table-config has bulk actions unsupported for the PDR view, so an error is thrown. This fixes the import.