### PR TITLE
CUMULUS-792: add warning message to granules `reingest` button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added Cypress for front-end testing. [Cumulus-918]
 - Added tests for the login page and dashboard home page. [Cumulus-638]
 - Added tests for the Collections page and Providers page. [Cumulus-643]
+- Added warning message to granules `reingest` button to indicates that existing data will be overwritten. [Cumulus-792]
 
 ## [v1.2.0] - 2018-08-08
 

--- a/app/scripts/utils/table-config/granules.js
+++ b/app/scripts/utils/table-config/granules.js
@@ -89,7 +89,7 @@ export const simpleDropdownOption = function (config) {
   );
 };
 
-const confirmReingest = (d) => `Reingest ${d} granules(s)? Note: the granule files will be overwritten.`
+const confirmReingest = (d) => `Reingest ${d} granules(s)? Note: the granule files will be overwritten.`;
 const confirmApply = (d) => `Run workflow on ${d} granules?`;
 const confirmRemove = (d) => `Remove ${d} granule(s) from ${strings.cmr}?`;
 const confirmDelete = (d) => `Delete ${d} granule(s)?`;

--- a/app/scripts/utils/table-config/granules.js
+++ b/app/scripts/utils/table-config/granules.js
@@ -89,7 +89,7 @@ export const simpleDropdownOption = function (config) {
   );
 };
 
-const confirmReingest = (d) => `Reingest ${d} granules(s)? Note, completed granules cannot be reingested.`;
+const confirmReingest = (d) => `Reingest ${d} granules(s)? Note: the granule files will be overwritten.`
 const confirmApply = (d) => `Run workflow on ${d} granules?`;
 const confirmRemove = (d) => `Remove ${d} granule(s) from ${strings.cmr}?`;
 const confirmDelete = (d) => `Delete ${d} granule(s)?`;


### PR DESCRIPTION
The AC says:
In the dashboard, when viewing the list of granules, hovering on a reingest button indicates that existing data will be overwritten

But I think it's better to add the warning message in the confirmation screen to be consistent with other buttons.
Also the `reingest` button by default is disabled, and only enabled when a granule is selected, so hovering over won't display message added.
