### PR TITLE
Use babel to translate es6 operators in libraries.

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
           "presets": [
             "@babel/preset-env",
             "@babel/preset-react"
+          ],
+          "plugins": [
+            "@babel/plugin-transform-spread"
           ]
         }
       ],
@@ -105,6 +108,7 @@
     "watchify": "^3.7.0"
   },
   "dependencies": {
+    "@babel/plugin-transform-spread": "^7.2.2",
     "@cumulus/cmrjs": "^1.11.0",
     "assert": "^1.4.1",
     "body-parser": "^1.18.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -553,6 +553,13 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/plugin-transform-spread@^7.2.2":
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-spread/-/plugin-transform-spread-7.2.2.tgz#3103a9abe22f742b6d406ecd3cd49b774919b406"
+  integrity sha512-KWfky/58vubwtS0hLqEnrWJjsMGaOeSBn90Ezn5Jeg9Z8KKHmELbP1yGylMlm5N6TPKeY9A2+UaSYLdxahg01w==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.0.0"
+
 "@babel/plugin-transform-sticky-regex@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/@babel/plugin-transform-sticky-regex/-/plugin-transform-sticky-regex-7.0.0.tgz#30a9d64ac2ab46eec087b8530535becd90e73366"


### PR DESCRIPTION
I was getting errors with libraries that used the spread operator but only with electron 59 headless (not chrome interactive).  Google suggested this would help and it appears to do so.