### PR TITLE
CUMULUS-1087

### DIFF
--- a/app/scripts/components/app/oauth.js
+++ b/app/scripts/components/app/oauth.js
@@ -57,7 +57,19 @@ var OAuth = createReactClass({
     if (!api.authenticated && !api.inflight) {
       const origin = window.location.origin;
       const pathname = window.location.pathname;
-      const hash = window.location.hash;
+      let hash = window.location.hash;
+      const hasQuery = hash.indexOf('?');
+      if (hasQuery !== -1) {
+        hash = hash.substr(hash.indexOf('#') + 1);
+        const parsedUrl = url.parse(hash, true);
+        // Remove any ?token query parameter to avoid polluting
+        // the login link
+        delete parsedUrl.query.token;
+        hash = `#${url.format({
+          pathname: parsedUrl.pathname,
+          query: parsedUrl.query
+        })}`;
+      }
       const redirect = encodeURIComponent(url.resolve(origin, pathname) + hash);
       button = <div style={{textAlign: 'center'}}><a href={url.resolve(apiRoot, `token?state=${redirect}`)} >Login with Earthdata Login</a></div>;
     }

--- a/app/scripts/components/app/oauth.js
+++ b/app/scripts/components/app/oauth.js
@@ -6,6 +6,7 @@ import url from 'url';
 import createReactClass from 'create-react-class';
 import { login, setTokenState } from '../../actions';
 import { window } from '../../utils/browser';
+import { buildRedirectUrl } from '../../utils/format';
 import { updateDelay, apiRoot } from '../../config';
 import PropTypes from 'prop-types';
 import ErrorReport from '../errors/report';
@@ -55,22 +56,7 @@ var OAuth = createReactClass({
 
     let button;
     if (!api.authenticated && !api.inflight) {
-      const origin = window.location.origin;
-      const pathname = window.location.pathname;
-      let hash = window.location.hash;
-      const hasQuery = hash.indexOf('?');
-      if (hasQuery !== -1) {
-        hash = hash.substr(hash.indexOf('#') + 1);
-        const parsedUrl = url.parse(hash, true);
-        // Remove any ?token query parameter to avoid polluting
-        // the login link
-        delete parsedUrl.query.token;
-        hash = `#${url.format({
-          pathname: parsedUrl.pathname,
-          query: parsedUrl.query
-        })}`;
-      }
-      const redirect = encodeURIComponent(url.resolve(origin, pathname) + hash);
+      const redirect = buildRedirectUrl(window.location);
       button = <div style={{textAlign: 'center'}}><a href={url.resolve(apiRoot, `token?state=${redirect}`)} >Login with Earthdata Login</a></div>;
     }
     return (

--- a/app/scripts/utils/format.js
+++ b/app/scripts/utils/format.js
@@ -2,6 +2,7 @@
 import React from 'react';
 import moment from 'moment';
 import numeral from 'numeral';
+import url from 'url';
 import { Link } from 'react-router';
 
 export const nullValue = '--';
@@ -164,4 +165,20 @@ export const deleteText = function (name) {
 
 export const rerunText = function (name) {
   return `Are you sure you want to rerun ${name}?`;
+};
+
+export const buildRedirectUrl = function ({ origin, pathname, hash }) {
+  const hasQuery = hash.indexOf('?');
+  if (hasQuery !== -1) {
+    hash = hash.substr(hash.indexOf('#') + 1);
+    const parsedUrl = url.parse(hash, true);
+    // Remove any ?token query parameter to avoid polluting
+    // the login link
+    delete parsedUrl.query.token;
+    hash = `#${url.format({
+      pathname: parsedUrl.pathname,
+      query: parsedUrl.query
+    })}`;
+  }
+  return encodeURIComponent(url.resolve(origin, pathname) + hash);
 };

--- a/cypress/integration/main_page_spec.js
+++ b/cypress/integration/main_page_spec.js
@@ -1,4 +1,5 @@
 import {
+  shouldBeLoggedIn,
   shouldBeRedirectedToLogin,
   shouldHaveNoToken,
   shouldHaveDeletedToken
@@ -19,7 +20,7 @@ describe('Dashboard Home Page', () => {
       cy.get('a').click();
     });
 
-    cy.get('h1[class=heading--xlarge').should('have.text', 'CUMULUS Dashboard');
+    shouldBeLoggedIn();
     cy.get('nav')
       .contains('Collections')
       .should('have.attr', 'href')
@@ -28,6 +29,20 @@ describe('Dashboard Home Page', () => {
       .contains('Rules')
       .should('have.attr', 'href')
       .and('include', '/rules');
+  });
+
+  it('Logs in successfully after failed login', () => {
+    // simulate failed login
+    cy.visit('/#/auth')
+      .window().then(function (window) {
+        window.location.hash = '#/auth?token=failed-token';
+      });
+
+    cy.get('div[class=modal__internal]').within(() => {
+      cy.get('a').click();
+    });
+
+    shouldBeLoggedIn();
   });
 
   describe('When logged in', () => {

--- a/cypress/support/assertions.js
+++ b/cypress/support/assertions.js
@@ -1,3 +1,7 @@
+exports.shouldBeLoggedIn = () => {
+  cy.get('h1[class=heading--xlarge').should('have.text', 'CUMULUS Dashboard');
+};
+
 exports.shouldBeRedirectedToLogin = () => {
   cy.url().should('include', '/#/auth');
   cy.get('div[class=modal__internal]').within(() => {

--- a/fake-api.js
+++ b/fake-api.js
@@ -198,7 +198,7 @@ app.get('/token', (req, res) => {
   const url = req.query.state;
   if (url) {
     token = generateJWT();
-    res.redirect(`${url}?token=${token}`);
+    res.redirect(`${decodeURIComponent(url)}?token=${token}`);
   } else {
     res.write('state parameter is missing');
     res.status(400).end();

--- a/test/utils/format.js
+++ b/test/utils/format.js
@@ -1,0 +1,21 @@
+'use strict';
+import test from 'ava';
+import { buildRedirectUrl } from '../../app/scripts/utils/format.js';
+
+test('buildRedirectUrl() properly strips ?token query parameter', function (t) {
+  const redirect = buildRedirectUrl({
+    origin: 'http://localhost:3000',
+    pathname: '/',
+    hash: '#/auth?token=failed-token'
+  });
+  t.is(redirect, encodeURIComponent('http://localhost:3000/#/auth'));
+});
+
+test('buildRedirectUrl() does not strip arbitrary query parameter', function (t) {
+  const redirect = buildRedirectUrl({
+    origin: 'http://localhost:3000',
+    pathname: '/',
+    hash: '#/auth?foo=bar'
+  });
+  t.is(redirect, encodeURIComponent('http://localhost:3000/#/auth?foo=bar'));
+});


### PR DESCRIPTION
Currently, login failures may result in a state where the dashboard login URL contains a `?token=failed-token` query parameter. This query parameter then gets included in the `state` query parameter of the login link so that when the API redirects back to the dashboard even after successful login, the query parameter will be something like `?token=valid-token?token=failed-token`, which will confuse the dashboard's token parsing logic and cause a login failure.

To fix this problem, I've updated the code so that a `?token` query parameter is never included in the login link URL. And I've added tests to ensure the scenario is fixed.