### PR TITLE
CUMULUS-1075

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,3 +113,9 @@ jobs:
               --workdir /home \
               cypress/base:8 \
               yarn cypress-ci
+
+      - store_artifacts:
+          path: cypress/videos
+
+      - store_artifacts:
+          path: cypress/screenshots

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,15 +70,19 @@ jobs:
       - run:
           name: Run Integration Tests
           command: docker run --link api:api --link dashboard:dashboard -e CYPRESS_BASE_URL=http://dashboard:3000 -e CYPRESS_APIROOT=http://api:5001 --rm -v /home/circleci/.cache:/root/.cache -v $(pwd):/home --workdir /home cypress/base:8 yarn cypress-ci
-  build:
+  build2:
     machine: true
-    branches: CUMULUS-1075
+    branches:
+        only: CUMULUS-1075
     working_directory: ~/cumulus-dashboard
-    command: |
-        # build dashboard
-        docker run --rm \
-            -v /home/circleci/.cache:/root/.cache \
-            -v $(pwd):/home \
-            --workdir /home \
-            node:8.11.4 \
-            yarn run build
+    steps:
+      - run:
+          name: Build dashboard
+          command: |
+            # build dashboard
+            docker run --rm \
+                -v /home/circleci/.cache:/root/.cache \
+                -v $(pwd):/home \
+                --workdir /home \
+                node:8.11.4 \
+                yarn run build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,8 +31,7 @@ jobs:
           name: Prepare servers
           command: |
             # run fake api
-            docker run \
-                -d \
+            docker run -d \
                 --name api \
                 -v $(pwd):/home \
                 --workdir /home \
@@ -53,9 +52,7 @@ jobs:
             ./bin/build_docker_image.sh cumulus-dashboard:ci
 
             # run dashboard
-            docker run \
-                # run in detached mode or else subsequent commands will not be reached
-                -d \
+            docker run -d \
                 --rm \
                 --name dashboard \
                 -e PORT=3000 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,10 +102,13 @@ jobs:
               --workdir /home \
               cypress/base:8 \
               yarn cypress-ci
+
   build2:
     machine: true
     working_directory: ~/cumulus-dashboard
     steps:
+      - checkout
+
       - run:
           name: Build dashboard
           command: |
@@ -116,6 +119,7 @@ jobs:
               --workdir /home \
               node:8.11.4 \
               yarn run build
+
 workflows:
   version: 2
   build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
             # run fake api
             docker run -d --name api -v $(pwd):/home --workdir /home -p 5001:5001 node:8.11.4 node fake-api.js
 
-            # run dashboard
+            # build dashboard
             docker run --rm \
                 -v /home/circleci/.cache:/root/.cache \
                 -v $(pwd):/home \
@@ -41,21 +41,18 @@ jobs:
                 -e APIROOT=http://api:5001 \
                 node:8.11.4 \
                 yarn run build
+
+            # build dashboard image
             ./bin/build_docker_image.sh cumulus-dashboard:ci
+
+            # run dashboard
             docker run \
                 --rm \
                 --name dashboard \
+                -d \ # run in detached mode or else subsequent commands won't be reached
                 -e PORT=3000 \
                 -p 3000:3000 \
                 cumulus-dashboard:ci
-            # docker run -d \
-            #     --name dashboard \
-            #     -v $(pwd):/home \
-            #     --workdir /home \
-            #     -e APIROOT=http://api:5001 \
-            #     -p 3000:3000 \
-            #     node:8.11.4 \
-            #     yarn serve
 
             attempt_counter=0
             max_attempts=20

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,12 +116,12 @@ jobs:
               --workdir /home \
               node:8.11.4 \
               yarn run build
-  workflows:
-    version: 2
-    build_and_test:
-      jobs:
-        - build
-        - build2:
-          filters:
-            branches:
-              only: CUMULUS-1075
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build
+      - build2:
+        filters:
+          branches:
+            only: CUMULUS-1075

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,19 +85,19 @@ jobs:
               sleep 5
             done
 
-      # - run:
-      #     name: Run Validation Tests
-      #     command: |
-      #       docker run \
-      #         --link api:api \
-      #         --link dashboard:dashboard \
-      #         -e CYPRESS_BASE_URL=http://dashboard:3000 \
-      #         --rm \
-      #         -v /home/circleci/.cache:/root/.cache \
-      #         -v $(pwd):/home \
-      #         --workdir /home \
-      #         node:8.11.4 \
-      #         yarn validation
+      - run:
+          name: Run Validation Tests
+          command: |
+            docker run \
+              --link api:api \
+              --link dashboard:dashboard \
+              -e CYPRESS_BASE_URL=http://dashboard:3000 \
+              --rm \
+              -v /home/circleci/.cache:/root/.cache \
+              -v $(pwd):/home \
+              --workdir /home \
+              node:8.11.4 \
+              yarn validation
 
       - run:
           name: Run Integration Tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,6 @@ version: 2
 jobs:
   build:
     machine: true
-
     working_directory: ~/cumulus-dashboard
     steps:
       - checkout
@@ -14,7 +13,13 @@ jobs:
 
       - run:
           name: Install dependencies
-          command: docker run --rm -v /home/circleci/.cache:/root/.cache -v $(pwd):/home --workdir /home node:8.11.4 yarn install --frozen-lockfile --cache-folder /root/.cache
+          command: |
+            docker run --rm \
+              -v /home/circleci/.cache:/root/.cache \
+              -v $(pwd):/home \
+              --workdir /home \
+              node:8.11.4 \
+              yarn install --frozen-lockfile --cache-folder /root/.cache
 
       # save node_module folders
       - save_cache:
@@ -25,55 +30,80 @@ jobs:
 
       - run:
           name: Run tests
-          command: docker run --rm -v /home/circleci/.cache:/root/.cache -v $(pwd):/home --workdir /home node:8.11.4 yarn test --cache-folder /root/.cache
+          command: |
+            docker run --rm \
+              -v /home/circleci/.cache:/root/.cache \
+              -v $(pwd):/home \
+              --workdir /home \
+              node:8.11.4 \
+              yarn test --cache-folder /root/.cache
 
       - run:
           name: Prepare servers
           command: |
             # run fake api
             docker run -d \
-                --name api \
-                -v $(pwd):/home \
-                --workdir /home \
-                -p 5001:5001 \
-                node:8.11.4 \
-                node fake-api.js
+              --name api \
+              -v $(pwd):/home \
+              --workdir /home \
+              -p 5001:5001 \
+              node:8.11.4 \
+              node fake-api.js
 
             # run dashboard
             docker run -d \
-                --name dashboard \
-                -v $(pwd):/home \
-                --workdir /home \
-                -e APIROOT=http://api:5001 \
-                -p 3000:3000 \
-                node:8.11.4 \
-                yarn serve
+              --name dashboard \
+              -v $(pwd):/home \
+              --workdir /home \
+              -e APIROOT=http://api:5001 \
+              -p 3000:3000 \
+              node:8.11.4 \
+              yarn serve
 
             attempt_counter=0
             max_attempts=20
 
             until $(curl --output /dev/null --silent --head --fail http://localhost:3000); do
-                if [ ${attempt_counter} -eq ${max_attempts} ];then
-                  echo "Max attempts reached"
-                  exit 1
-                fi
+              if [ ${attempt_counter} -eq ${max_attempts} ];then
+                echo "Max attempts reached"
+                exit 1
+              fi
 
-                printf '.'
-                attempt_counter=$(($attempt_counter+1))
-                sleep 5
+              printf '.'
+              attempt_counter=$(($attempt_counter+1))
+              sleep 5
             done
 
       - run:
           name: Run Validation Tests
-          command: docker run --link api:api --link dashboard:dashboard -e CYPRESS_BASE_URL=http://dashboard:3000 --rm -v /home/circleci/.cache:/root/.cache -v $(pwd):/home --workdir /home node:8.11.4 yarn validation
+          command: |
+            docker run \
+              --link api:api \
+              --link dashboard:dashboard \
+              -e CYPRESS_BASE_URL=http://dashboard:3000 \
+              --rm \
+              -v /home/circleci/.cache:/root/.cache \
+              -v $(pwd):/home \
+              --workdir /home \
+              node:8.11.4 \
+              yarn validation
 
       - run:
           name: Run Integration Tests
-          command: docker run --link api:api --link dashboard:dashboard -e CYPRESS_BASE_URL=http://dashboard:3000 -e CYPRESS_APIROOT=http://api:5001 --rm -v /home/circleci/.cache:/root/.cache -v $(pwd):/home --workdir /home cypress/base:8 yarn cypress-ci
+          command: |
+            docker run \
+              --link api:api \
+              --link dashboard:dashboard \
+              -e CYPRESS_BASE_URL=http://dashboard:3000 \
+              -e CYPRESS_APIROOT=http://api:5001 \
+              --rm \
+              -v /home/circleci/.cache:/root/.cache \
+              -v $(pwd):/home \
+              --workdir /home \
+              cypress/base:8 \
+              yarn cypress-ci
   build2:
     machine: true
-    # branches:
-    #     only: CUMULUS-1075
     working_directory: ~/cumulus-dashboard
     steps:
       - run:
@@ -81,8 +111,17 @@ jobs:
           command: |
             # build dashboard
             docker run --rm \
-                -v /home/circleci/.cache:/root/.cache \
-                -v $(pwd):/home \
-                --workdir /home \
-                node:8.11.4 \
-                yarn run build
+              -v /home/circleci/.cache:/root/.cache \
+              -v $(pwd):/home \
+              --workdir /home \
+              node:8.11.4 \
+              yarn run build
+  workflows:
+    version: 2
+    build_and_test:
+      jobs:
+        - build
+        - build2:
+          filters:
+            branches:
+              only: CUMULUS-1075

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,13 @@ jobs:
             docker run -d --name api -v $(pwd):/home --workdir /home -p 5001:5001 node:8.11.4 node fake-api.js
 
             # run dashboard
-            APIROOT=http://api:5001 yarn run build
+            docker run --rm \
+                -v /home/circleci/.cache:/root/.cache \
+                -v $(pwd):/home \
+                --workdir /home \
+                -e APIROOT=http://api:5001 \
+                node:8.11.4 \
+                yarn run build
             ./bin/build_docker_image.sh cumulus-dashboard:ci
             docker run \
                 --rm \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,15 +50,26 @@ jobs:
               node:8.11.4 \
               node fake-api.js
 
+            # build dashboard
+            docker run --rm \
+                -v /home/circleci/.cache:/root/.cache \
+                -v $(pwd):/home \
+                --workdir /home \
+                -e APIROOT=http://api:5001 \
+                node:8.11.4 \
+                yarn run build
+
+            # build dashboard image
+            ./bin/build_docker_image.sh cumulus-dashboard:ci
+
             # run dashboard
-            docker run -d \
-              --name dashboard \
-              -v $(pwd):/home \
-              --workdir /home \
-              -e APIROOT=http://api:5001 \
-              -p 3000:3000 \
-              node:8.11.4 \
-              yarn serve
+            docker run \
+                -d \
+                --rm \
+                --name dashboard \
+                -e PORT=3000 \
+                -p 3000:3000 \
+                cumulus-dashboard:ci
 
             attempt_counter=0
             max_attempts=20
@@ -74,19 +85,19 @@ jobs:
               sleep 5
             done
 
-      - run:
-          name: Run Validation Tests
-          command: |
-            docker run \
-              --link api:api \
-              --link dashboard:dashboard \
-              -e CYPRESS_BASE_URL=http://dashboard:3000 \
-              --rm \
-              -v /home/circleci/.cache:/root/.cache \
-              -v $(pwd):/home \
-              --workdir /home \
-              node:8.11.4 \
-              yarn validation
+      # - run:
+      #     name: Run Validation Tests
+      #     command: |
+      #       docker run \
+      #         --link api:api \
+      #         --link dashboard:dashboard \
+      #         -e CYPRESS_BASE_URL=http://dashboard:3000 \
+      #         --rm \
+      #         -v /home/circleci/.cache:/root/.cache \
+      #         -v $(pwd):/home \
+      #         --workdir /home \
+      #         node:8.11.4 \
+      #         yarn validation
 
       - run:
           name: Run Integration Tests
@@ -102,27 +113,3 @@ jobs:
               --workdir /home \
               cypress/base:8 \
               yarn cypress-ci
-
-  build2:
-    machine: true
-    working_directory: ~/cumulus-dashboard
-    steps:
-      - checkout
-
-      - run:
-          name: Build dashboard
-          command: |
-            # build dashboard
-            docker run --rm \
-              -v /home/circleci/.cache:/root/.cache \
-              -v $(pwd):/home \
-              --workdir /home \
-              node:8.11.4 \
-              yarn run build
-
-workflows:
-  version: 2
-  build_and_test:
-    jobs:
-      - build
-      - build2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,8 +72,8 @@ jobs:
           command: docker run --link api:api --link dashboard:dashboard -e CYPRESS_BASE_URL=http://dashboard:3000 -e CYPRESS_APIROOT=http://api:5001 --rm -v /home/circleci/.cache:/root/.cache -v $(pwd):/home --workdir /home cypress/base:8 yarn cypress-ci
   build2:
     machine: true
-    branches:
-        only: CUMULUS-1075
+    # branches:
+    #     only: CUMULUS-1075
     working_directory: ~/cumulus-dashboard
     steps:
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,14 @@ jobs:
           name: Prepare servers
           command: |
             # run fake api
-            docker run -d --name api -v $(pwd):/home --workdir /home -p 5001:5001 node:8.11.4 node fake-api.js
+            docker run \
+                -d \
+                --name api \
+                -v $(pwd):/home \
+                --workdir /home \
+                -p 5001:5001 \
+                node:8.11.4 \
+                node fake-api.js
 
             # build dashboard
             docker run --rm \
@@ -47,9 +54,10 @@ jobs:
 
             # run dashboard
             docker run \
+                # run in detached mode or else subsequent commands will not be reached
+                -d \
                 --rm \
                 --name dashboard \
-                -d \ # run in detached mode or else subsequent commands won't be reached
                 -e PORT=3000 \
                 -p 3000:3000 \
                 cumulus-dashboard:ci

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,22 @@ jobs:
             docker run -d --name api -v $(pwd):/home --workdir /home -p 5001:5001 node:8.11.4 node fake-api.js
 
             # run dashboard
-            docker run -d --name dashboard -v $(pwd):/home --workdir /home -e APIROOT=http://api:5001 -p 3000:3000 node:8.11.4 yarn serve
+            APIROOT=http://api:5001 yarn run build
+            ./bin/build_docker_image.sh cumulus-dashboard:ci
+            docker run \
+                --rm \
+                --name dashboard \
+                -e PORT=3000 \
+                -p 3000:3000 \
+                cumulus-dashboard:ci
+            # docker run -d \
+            #     --name dashboard \
+            #     -v $(pwd):/home \
+            #     --workdir /home \
+            #     -e APIROOT=http://api:5001 \
+            #     -p 3000:3000 \
+            #     node:8.11.4 \
+            #     yarn serve
 
             attempt_counter=0
             max_attempts=20

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,7 +121,4 @@ workflows:
   build_and_test:
     jobs:
       - build
-      - build2:
-        filters:
-          branches:
-            only: CUMULUS-1075
+      - build2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,25 +39,15 @@ jobs:
                 node:8.11.4 \
                 node fake-api.js
 
-            # build dashboard
-            docker run --rm \
-                -v /home/circleci/.cache:/root/.cache \
+            # run dashboard
+            docker run -d \
+                --name dashboard \
                 -v $(pwd):/home \
                 --workdir /home \
                 -e APIROOT=http://api:5001 \
-                node:8.11.4 \
-                yarn run build
-
-            # build dashboard image
-            ./bin/build_docker_image.sh cumulus-dashboard:ci
-
-            # run dashboard
-            docker run -d \
-                --rm \
-                --name dashboard \
-                -e PORT=3000 \
                 -p 3000:3000 \
-                cumulus-dashboard:ci
+                node:8.11.4 \
+                yarn serve
 
             attempt_counter=0
             max_attempts=20
@@ -80,3 +70,15 @@ jobs:
       - run:
           name: Run Integration Tests
           command: docker run --link api:api --link dashboard:dashboard -e CYPRESS_BASE_URL=http://dashboard:3000 -e CYPRESS_APIROOT=http://api:5001 --rm -v /home/circleci/.cache:/root/.cache -v $(pwd):/home --workdir /home cypress/base:8 yarn cypress-ci
+  build:
+    machine: true
+    branches: CUMULUS-1075
+    working_directory: ~/cumulus-dashboard
+    command: |
+        # build dashboard
+        docker run --rm \
+            -v /home/circleci/.cache:/root/.cache \
+            -v $(pwd):/home \
+            --workdir /home \
+            node:8.11.4 \
+            yarn run build

--- a/cypress/validation-tests/main-page.js
+++ b/cypress/validation-tests/main-page.js
@@ -8,23 +8,26 @@ test('POST, PUT, or DELETE operations with no session information are rejected',
   const res = await http.getResponse(host);
   t.is(res.statusCode, 200);
 
-  try{
+  try {
     await http.putResponse(host);
+    t.fail('Expected error to be thrown');
   } catch (err) {
-    t.true(err.error.includes('Cannot PUT /'));
+    // Error code is 405 from when running in Docker/nginx and
+    // 404 from gulp serve
+    t.true([405, 404].includes(err.statusCode));
   }
 
-  try{
+  try {
     await http.postResponse(host);
+    t.fail('Expected error to be thrown');
   } catch (err) {
-    t.true(err.error.includes('Cannot POST /'));
+    t.true([405, 404].includes(err.statusCode));
   }
 
-  try{
+  try {
     await http.delResponse(host);
+    t.fail('Expected error to be thrown');
   } catch (err) {
-    t.true(err.error.includes('Cannot DELETE /'));
+    t.true([405, 404].includes(err.statusCode));
   }
 });
-
-


### PR DESCRIPTION
The goal of the ticket was to add something for CI to test the `yarn run build` process, since that is what the DAACs use to build their dashboards before deploying them to S3. I initially planned to implement that as a separate task in the CI job, but it quickly became evident that would require repeating almost all of the steps of the existing task. 

Since `yarn run serve` is only used for local development and any problems with it would surface locally, I decided to just update the CI job to run the dashboard via `yarn run build` and Docker. 

As part of this change, I had to update the validation tests, since the error messages/codes returned are different when running the dashboard via Docker/nginx vs `yarn run serve`.