### PR TITLE
CUMULUS-1456 Handle error messages from express

### DIFF
--- a/app/scripts/actions/helpers.js
+++ b/app/scripts/actions/helpers.js
@@ -13,21 +13,12 @@ export const formatError = (response = {}, body) => {
   return error;
 };
 
-export const getError = (response) => {
-  const { request, body } = response;
-  let error;
+export const getErrorMessage = (response) => {
+  const { body } = response;
+  const errorMessage = body && body.errorMessage || body && body.message || body && body.detail;
 
-  // TODO: is this still relevant?
-  if (request.method === 'DELETE' || request.method === 'POST') {
-    error = body.errorMessage || body.message;
-  } else if (request.method === 'PUT') {
-    error = body && body.errorMessage || body && body.message || body && body.detail;
-  }
-
-  if (error) return error;
-
-  error = new Error(formatError(response, body));
-  return error;
+  if (errorMessage) return errorMessage;
+  return formatError(response, body);
 };
 
 export const addRequestAuthorization = (config, state) => {

--- a/app/scripts/actions/helpers.js
+++ b/app/scripts/actions/helpers.js
@@ -19,9 +19,9 @@ export const getError = (response) => {
 
   // TODO: is this still relevant?
   if (request.method === 'DELETE' || request.method === 'POST') {
-    error = body.errorMessage;
+    error = body.errorMessage || body.message;
   } else if (request.method === 'PUT') {
-    error = body && body.errorMessage || body && body.detail;
+    error = body && body.errorMessage || body && body.message || body && body.detail;
   }
 
   if (error) return error;

--- a/app/scripts/actions/index.js
+++ b/app/scripts/actions/index.js
@@ -112,7 +112,7 @@ export const checkApiVersion = () => {
       dispatch({
         type: types.API_VERSION_INCOMPATIBLE,
         payload: {
-          warning: `Dashboard version incompatible with Cumulus API version (${versionNumber})`
+          warning: `Dashboard incompatible with Cumulus API version (${versionNumber}), dashboard requires (>= ${minCompatibleApiVersion})`
         }
       });
     }

--- a/test/actions/helpers.js
+++ b/test/actions/helpers.js
@@ -212,4 +212,16 @@ test('getError() returns correct errors', (t) => {
     body: { message: 'Test error' }
   });
   t.deepEqual(error, new Error('Test error'));
+
+  error = getError({
+    request: { method: 'PUT' },
+    body: { message: 'Test error' }
+  });
+  t.deepEqual(error, 'Test error');
+
+  error = getError({
+    request: { method: 'POST' },
+    body: { message: 'Test error' }
+  });
+  t.deepEqual(error, 'Test error');
 });

--- a/test/actions/helpers.js
+++ b/test/actions/helpers.js
@@ -5,7 +5,7 @@ import _config from '../../app/scripts/config';
 import {
   addRequestAuthorization,
   formatError,
-  getError,
+  getErrorMessage,
   configureRequest
 } from '../../app/scripts/actions/helpers';
 
@@ -182,44 +182,44 @@ test('configureRequest() should not overwrite auth headers', (t) => {
   t.deepEqual(requestConfig, expectedConfig);
 });
 
-test('getError() returns correct errors', (t) => {
-  let error = getError({
+test('getErrorMessage() returns correct errors', (t) => {
+  let error = getErrorMessage({
     request: { method: 'PUT' },
     body: { detail: 'Detail error' }
   });
   t.is(error, 'Detail error');
 
-  error = getError({
+  error = getErrorMessage({
     request: { method: 'PUT' },
     body: { errorMessage: 'PUT error' }
   });
   t.is(error, 'PUT error');
 
-  error = getError({
+  error = getErrorMessage({
     request: { method: 'DELETE' },
     body: { errorMessage: 'DELETE error' }
   });
   t.is(error, 'DELETE error');
 
-  error = getError({
+  error = getErrorMessage({
     request: { method: 'POST' },
     body: { errorMessage: 'POST error' }
   });
   t.is(error, 'POST error');
 
-  error = getError({
+  error = getErrorMessage({
     request: { method: 'GET' },
     body: { message: 'Test error' }
   });
-  t.deepEqual(error, new Error('Test error'));
+  t.deepEqual(error, 'Test error');
 
-  error = getError({
+  error = getErrorMessage({
     request: { method: 'PUT' },
     body: { message: 'Test error' }
   });
   t.deepEqual(error, 'Test error');
 
-  error = getError({
+  error = getErrorMessage({
     request: { method: 'POST' },
     body: { message: 'Test error' }
   });

--- a/test/middleware/request.js
+++ b/test/middleware/request.js
@@ -124,7 +124,7 @@ test.cb('should dispatch error action for failed request', (t) => {
 
   const expectedAction = {
     id: undefined,
-    error: new Error('Internal server error'),
+    error: 'Internal server error',
     config: {
       ...t.context.defaultConfig,
       ...requestAction,


### PR DESCRIPTION
Merged this PR to standardize the default error message from our API with the other error messages: https://github.com/nasa/cumulus/pull/1216

Before that, all the error messages that hit the default handler were being obscured.

Then did this update to make the dashboard work with what's coming back from express to show actual error messages.