### PR TITLE
Adds collapsed logs to output.

### DIFF
--- a/app/scripts/middleware/request.js
+++ b/app/scripts/middleware/request.js
@@ -44,7 +44,7 @@ const handleError = ({ id, type, error, requestAction }, next) => {
     id,
     config: requestAction,
     type: errorType,
-    error
+    error: error.message
   });
 };
 

--- a/app/scripts/middleware/request.js
+++ b/app/scripts/middleware/request.js
@@ -11,6 +11,12 @@ import log from '../utils/log';
 import { isValidApiRequestAction } from './validate';
 
 const handleError = ({ id, type, error, requestAction }, next) => {
+  console.groupCollapsed('handleError');
+  console.log(`id: ${id}`);
+  console.log(`type: ${type}`);
+  console.dir(error);
+  console.dir(requestAction);
+  console.groupEnd();
   if (error.message) {
     // Temporary fix until the 'logs' endpoint is fixed
     // TODO: is this still relevant?


### PR DESCRIPTION
@laurenfrederick also logs?

Adds logs that are by default collapsed, but can be opened to examine details about the error and requestAction.  I think this will be useful when we get more bad logs in the future.