### PR TITLE
[CUMULUS-1738] Add provider form in dashboard is missing the global connection limit

### DIFF
--- a/app/src/js/components/FormSchema/schema.js
+++ b/app/src/js/components/FormSchema/schema.js
@@ -125,6 +125,7 @@ export const createFormConfig = function (data, schema, include) {
       case 'string':
         fields.push(textfield(config, property, (required && isText)));
         break;
+      case 'integer':
       case 'number':
         fields.push(numberfield(config, property, (required && isNumber)));
         break;

--- a/cypress/integration/providers_spec.js
+++ b/cypress/integration/providers_spec.js
@@ -38,9 +38,7 @@ describe('Dashboard Providers Page', () => {
 
     it('should add a new provider', () => {
       const name = 'TESTPROVIDER';
-      // TODO [MHS, 2020-01-14]  Set Back to 5 when CUMULUS-1738 is fixed to show the globalCollection limit.
-      // const connectionLimit = 5;
-      const connectionLimit = 10;
+      const connectionLimit = 5;
       const protocol = 's3';
       const host = 'test-host';
 
@@ -60,12 +58,11 @@ describe('Dashboard Providers Page', () => {
         .contains('Provider Name')
         .siblings('input')
         .type(name);
-      // TODO [MHS, 2020-01-14] Fix this so that it shows up as part of CUMULUS-1738
-      // cy.get('@providerinput')
-      //   .contains('Concurrent Connnection Limit')
-      //   .siblings('input')
-      //   .clear()
-      //   .type(connectionLimit);
+      cy.get('@providerinput')
+        .contains('Concurrent Connnection Limit')
+        .siblings('input')
+        .clear()
+        .type(connectionLimit);
       cy.get('@providerinput')
         .contains('label', 'Protocol')
         .siblings()
@@ -110,9 +107,7 @@ describe('Dashboard Providers Page', () => {
 
     it('should edit a provider', () => {
       const name = 's3_provider';
-      const connectionLimit = 10;
-      // TODO [MHS, 2020-01-14]  set back to 12 when CUMULUS-1738 is fixed.
-      // const connectionLimit = 12;
+      const connectionLimit = 12;
       const host = 'test-host-new';
 
       cy.visit(`/providers/provider/${name}`);
@@ -126,12 +121,11 @@ describe('Dashboard Providers Page', () => {
       cy.contains('.heading--large', `Edit ${name}`);
 
       cy.get('form div ul').as('providerinput');
-      // TODO [MHS, 2020-01-14]  Fix this when CUMULUS-1738 is fixed.
-      // cy.get('@providerinput')
-      //   .contains('Concurrent Connnection Limit')
-      //   .siblings('input')
-      //   .clear()
-      //   .type(connectionLimit);
+      cy.get('@providerinput')
+        .contains('Concurrent Connnection Limit')
+        .siblings('input')
+        .clear()
+        .type(connectionLimit);
       cy.get('@providerinput')
         .contains('Host')
         .siblings('input')


### PR DESCRIPTION
Updates the Schema component to recognize 'integer' as a number field. This causes the global connection limit field to appear in the "Add Provider" form.