### PR TITLE
Save snapshots by using correct path.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ jobs:
             npm run validation-tests
 
       - store_artifacts:
-          path: /home/cypress/screenshots
+          path: ~/cumulus-dashboard/cypress/screenshots
 
   deploy:
     machine: true


### PR DESCRIPTION
Error snapshots weren't being saved because I was uploading the wrong path. 