### PR TITLE
[cumulus-1729] Wrap getStats action creator in a thunk to get current date params.

### DIFF
--- a/app/src/js/actions/index.js
+++ b/app/src/js/actions/index.js
@@ -455,14 +455,19 @@ export const getOptionsCollectionName = (options) => ({
   }
 });
 
-export const getStats = (options) => ({
-  [CALL_API]: {
-    type: types.STATS,
-    method: 'GET',
-    url: url.resolve(root, 'stats'),
-    qs: options
-  }
-});
+export const getStats = (options) => {
+  return (dispatch, getState) => {
+    const timeFilters = fetchCurrentTimeFilters(getState().datepicker);
+    return dispatch({
+      [CALL_API]: {
+        type: types.STATS,
+        method: 'GET',
+        url: url.resolve(root, 'stats'),
+        qs: {...options, ...timeFilters}
+      }
+    });
+  };
+};
 
 export const getDistApiGatewayMetrics = (cumulusInstanceMeta) => {
   const stackName = cumulusInstanceMeta.stackName;

--- a/test/actions/datefilters.js
+++ b/test/actions/datefilters.js
@@ -6,6 +6,7 @@ import thunk from 'redux-thunk';
 import {
   getExecutionLogs,
   getLogs,
+  getStats,
   listCollections,
   listExecutions,
   listGranules,
@@ -67,7 +68,8 @@ test('Each of these list action creators will pull data from datepicker state wh
     { action: 'OPERATIONS_INFLIGHT', dispatcher: listOperations },
     { action: 'PDRS_INFLIGHT', dispatcher: listPdrs },
     { action: 'PROVIDERS_INFLIGHT', dispatcher: listProviders },
-    { action: 'RULES_INFLIGHT', dispatcher: listRules }
+    { action: 'RULES_INFLIGHT', dispatcher: listRules },
+    { action: 'STATS_INFLIGHT', dispatcher: getStats }
   ];
 
   endpoints.forEach((e) => {


### PR DESCRIPTION
Use the state's current startDateTime and endDateTime when making calls to the
stats endpoint.

This will need an update to the stats endpoint to parse the dates properly.