### PR TITLE
Add configuration for building dashboard to be served by the cumulus API

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,13 @@ To build the dashboard:
 
 ```bash
   $ nvm use
-  $ [DAAC_NAME=LPDAAC] [STAGE=production] [HIDE_PDR=false] [LABELS=daac] APIROOT=https://myapi.com npm run build
+  $ [SERVED_BY_CUMULUS_API=true] [DAAC_NAME=LPDAAC] [STAGE=production] [HIDE_PDR=false] [LABELS=daac] APIROOT=https://myapi.com npm run build
 ```
 **NOTE**: Only the `APIROOT` environment variable is required.
+
+#### Build the dashboard to be served by the Cumulus API.
+
+With the Cumulus API it is possible to [serve the dashboard from an s3 Bucket](https://nasa.github.io/cumulus-api/#serve-the-dashboard-from-a-bucket).  If you wish to do this, you must build the dashboard with the environment variable `SERVED_BY_CUMULUS_API` set to `true`.  This configures the dashboard to work from the Cumulus `dashboard` endpoint.
 
 The compiled files will be placed in the `dist` directory.
 

--- a/app/src/js/config/config.js
+++ b/app/src/js/config/config.js
@@ -17,7 +17,8 @@ const config = {
   graphicsPath: (process.env.BUCKET || ''),
   enableRecovery: process.env.ENABLE_RECOVERY || false,
   esUser: process.env.ES_USER || '',
-  esPassword: process.env.ES_PASSWORD || ''
+  esPassword: process.env.ES_PASSWORD || '',
+  servedByCumulusAPI: process.env.SERVED_BY_CUMULUS_API || ''
 };
 
 module.exports = config;

--- a/app/src/js/store/configureStore.js
+++ b/app/src/js/store/configureStore.js
@@ -1,4 +1,4 @@
-import { createBrowserHistory } from 'history';
+import { createHashHistory, createBrowserHistory } from 'history';
 import { applyMiddleware, compose, createStore } from 'redux';
 import { routerMiddleware } from 'connected-react-router';
 import { createRootReducer } from '../reducers';
@@ -11,7 +11,12 @@ import config from '../config';
 
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
 
-export const history = createBrowserHistory();
+export let history;
+if (config.servedByCumulusAPI) {
+  history = createHashHistory({});
+} else {
+  history = createBrowserHistory({});
+}
 
 // redirect to login when not auth'd
 export const requireAuth = (store) => (nextState, replace) => {

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -157,7 +157,8 @@ const CommonConfig = {
         BUCKET: config.graphicsPath,
         ENABLE_RECOVERY: config.enableRecovery,
         ES_USER: config.esUser,
-        ES_PASSWORD: config.esPassword
+        ES_PASSWORD: config.esPassword,
+        SERVED_BY_CUMULUS_API: config.servedByCumulusAPI
       }
     )
   ]

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -16,7 +16,7 @@ const DevConfig = merge.smartStrategy(
     hot: false,
     historyApiFallback: true,
     // host: '0.0.0.0', // Required for Docker -- someone will need to link this somehow
-    publicPath: './',
+    publicPath: '/',
     watchContentBase: true,
     compress: true,
     port: process.env.PORT || 3000,

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -16,7 +16,7 @@ const DevConfig = merge.smartStrategy(
     hot: false,
     historyApiFallback: true,
     // host: '0.0.0.0', // Required for Docker -- someone will need to link this somehow
-    publicPath: '/',
+    publicPath: './',
     watchContentBase: true,
     compress: true,
     port: process.env.PORT || 3000,

--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -20,7 +20,7 @@ const MainConfig = merge.smartStrategy({
     filename: '[name].[contenthash].bundle.js',
     chunkFilename: '[name].[contenthash].bundle.js',
     path: path.resolve(__dirname, 'dist'),
-    publicPath: '/'
+    publicPath: './'
   },
   optimization: {
     nodeEnv: 'production',


### PR DESCRIPTION
This PR:

1. Sets the path to webpack bundles to be relative.
2. Adds new optional environmental variable `SERVED_BY_CUMULUS_API` that when set, will build a Cumulus dashboard configured with a hashHistory that allows the app to be served from a single endpoint.