### PR TITLE
Fix pathing for logo and favicon

### DIFF
--- a/app/src/js/components/Header/header.js
+++ b/app/src/js/components/Header/header.js
@@ -68,10 +68,11 @@ class Header extends React.Component {
   render () {
     const { authenticated } = this.props.api;
     const activePaths = paths.filter(path => nav.exclude[path[0]] !== true);
+    const logoPath = graphicsPath.substr(-1) === '/' ? `${graphicsPath}${strings.logo}` : `${graphicsPath}/${strings.logo}`;
     return (
       <div className='header'>
         <div className='row'>
-          <h1 className='logo'><Link to={{pathname: '/', search: this.props.location.search}}><img alt="Logo" src={graphicsPath + strings.logo} /></Link></h1>
+          <h1 className='logo'><Link to={{pathname: '/', search: this.props.location.search}}><img alt="Logo" src={logoPath} /></Link></h1>
           <nav>
             { !this.props.minimal ? <ul>
               {activePaths.map(path => <li

--- a/app/src/template.html
+++ b/app/src/template.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="shortcut icon" href="favicon.ico" type="image/x-icon" />
+    <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon" />
     <meta
       name="description"
       content="Cumulus Dashboard"


### PR DESCRIPTION
Fix paths for logo and favicon

* Logo: if `graphicsPath` does not have a trailing slash, we need to add one.
* Favicon: made this an absolute path by adding `/`