### PR TITLE
Update api-version's reducer to not modify state.

### DIFF
--- a/app/src/js/reducers/api-version.js
+++ b/app/src/js/reducers/api-version.js
@@ -12,24 +12,36 @@ export const initialState = {
 };
 
 export default function reducer (state = initialState, action) {
-  state = {...state};
+  let newState = null;
   switch (action.type) {
     case API_VERSION:
-      state.versionNumber = action.payload.versionNumber;
-      state.warning = '';
+      newState = {
+        ...state,
+        versionNumber: action.payload.versionNumber,
+        warning: ''
+      };
       break;
     case API_VERSION_ERROR:
-      state.apiVersion = action.payload.error.message;
-      state.warning = 'Failed to acquire Cumulus API Version';
+      newState = {
+        ...state,
+        apiVersion: action.payload.error.message,
+        warning: 'Failed to acquire Cumulus API Version'
+      };
       break;
     case API_VERSION_COMPATIBLE:
-      state.isCompatible = true;
-      state.warning = '';
+      newState = {
+        ...state,
+        isCompatible: true,
+        warning: ''
+      };
       break;
     case API_VERSION_INCOMPATIBLE:
-      state.isCompatible = false;
-      state.warning = action.payload.warning;
+      newState = {
+        ...state,
+        isCompatible: false,
+        warning: action.payload.warning
+      };
       break;
   }
-  return state;
+  return newState || state;
 }

--- a/app/src/js/reducers/mmtLinks.js
+++ b/app/src/js/reducers/mmtLinks.js
@@ -9,13 +9,14 @@ import {
 const initialState = {};
 
 export default function reducer (state = initialState, action) {
-  state = Object.assign({}, state);
+  let newState;
   const { data } = action;
   switch (action.type) {
     case ADD_MMTLINK:
+      newState = {...state};
       const collectionId = getCollectionId(data);
-      set(state, [collectionId], data.url);
+      set(newState, [collectionId], data.url);
       break;
   }
-  return state;
+  return newState || state;
 }

--- a/test/reducers/api-version.js
+++ b/test/reducers/api-version.js
@@ -1,0 +1,76 @@
+'use strict';
+import test from 'ava';
+import reducer, { initialState } from '../../app/src/js/reducers/api-version';
+import {
+  API_VERSION,
+  API_VERSION_ERROR,
+  API_VERSION_COMPATIBLE,
+  API_VERSION_INCOMPATIBLE
+} from '../../app/src/js/actions/types';
+
+test('verify initial state', (t) => {
+  const newState = reducer(initialState, { data: {}, type: 'ANY_OTHER_TYPE' });
+  t.is(newState, initialState);
+});
+
+test('set the version', (t) => {
+  const expected = { ...initialState, versionNumber: 'cumulus-version' };
+  const action = {
+    type: API_VERSION,
+    payload: { versionNumber: 'cumulus-version' }
+  };
+  const actual = reducer(initialState, action);
+  t.deepEqual(expected, actual);
+});
+
+test('version error', (t) => {
+  const testInitialState = {
+    ...initialState,
+    apiVersion: undefined
+  };
+
+  const actionErrorMessage = 'an error';
+  const expected = {
+    ...testInitialState,
+    apiVersion: actionErrorMessage,
+    warning: 'Failed to acquire Cumulus API Version'
+  };
+
+  const action = {
+    type: API_VERSION_ERROR,
+    payload: { error: { message: actionErrorMessage } }
+  };
+
+  const actual = reducer(testInitialState, action);
+  t.deepEqual(expected, actual);
+});
+
+test('version compatable', (t) => {
+  const testInitialState = { isCompatable: false, warning: 'hmmm' };
+  const action = {
+    type: API_VERSION_COMPATIBLE
+  };
+  const expected = { ...testInitialState, isCompatible: true, warning: '' };
+  const actual = reducer(testInitialState, action);
+
+  t.deepEqual(expected, actual);
+});
+
+test('version incompatable', (t) => {
+  const testInitialState = { isCompatible: true, warning: '' };
+  const warningMessage = 'warning message';
+  const action = {
+    type: API_VERSION_INCOMPATIBLE,
+    payload: {
+      warning: warningMessage
+    }
+  };
+
+  const expected = {
+    ...testInitialState,
+    isCompatible: false,
+    warning: warningMessage
+  };
+  const actual = reducer(testInitialState, action);
+  t.deepEqual(expected, actual);
+});

--- a/test/reducers/mmtLinks.js
+++ b/test/reducers/mmtLinks.js
@@ -5,8 +5,9 @@ import { ADD_MMTLINK } from '../../app/src/js/actions/types';
 import { getCollectionId } from '../../app/src/js/utils/format';
 
 test('verify initial state', (t) => {
-  const newState = reducer({}, {data: {}, type: 'ANY'});
-  t.deepEqual(newState, {});
+  const initialState = {};
+  const newState = reducer(initialState, {data: {}, type: 'ANY'});
+  t.is(newState, initialState);
 });
 
 test('reducers/mmtLinks', (t) => {


### PR DESCRIPTION
This PR came about after talking with Mark about reducers and mutating state.

This particluar PR is an example of what I was thinking of doing for all of the reducers.

The command `state = {...state}` creates a new shallow object of the state, and then returned it at the end.

React-redux does a shallowEqual to determine if an object has changed, this will prevent a rerender if it is not changed.  For this reducer, there are no functional differences.  The state passed in to the reducer is completely flat, and shallowEqual used by react-redux (https://github.com/reduxjs/react-redux/blob/master/src/utils/shallowEqual.js) will return unchanged even though the returned object is a strictly different object.  statein !=== stateout.


But. That said, we have a number of places where we are mutating state in reducers, which means that the shallowCompare is returning equal when the state is different and the data should be updated, but is not.  This is the case for every time we call `set(object, [multiple keys], value)`

I was hoping that we could agree to a standard reducer pattern that would prevent both over-rendering (returning objects that are different even when no changes have occurred) but also under-rendering (and BUGGY behavior) when state is mutated in a reducer.

I have another branch that fixes a lot of these problems, but wanted to get eyes on this particular solution before moving forward.

Mark B suggested he liked returning a new object from each case statement better than setting `let newState=null` and then returning `return newState || state` at the end.  for example.





