### PR TITLE
Suggest: add back tests for values in granule overview

### DIFF
--- a/cypress/integration/executions_spec.js
+++ b/cypress/integration/executions_spec.js
@@ -31,9 +31,9 @@ describe('Dashboard Executions Page', () => {
 
       // shows a summary count of completed and failed executions
       cy.get('.overview-num__wrapper ul li')
-        .first().contains('li', 'Completed')
-        .next().contains('li', 'Failed')
-        .next().contains('li', 'Running');
+        .first().contains('li', 'Completed').contains('li', 10)
+        .next().contains('li', 'Failed').contains('li', 3)
+        .next().contains('li', 'Running').contains('li', 3);
     });
 
     it('should display the correct executions with Ids and status ', () => {

--- a/cypress/integration/granules_spec.js
+++ b/cypress/integration/granules_spec.js
@@ -27,12 +27,9 @@ describe('Dashboard Granules Page', () => {
 
       // shows a summary count of completed and failed granules
       cy.get('.overview-num__wrapper ul li')
-        .first()
-        .contains('li', 'Completed')
-        .next()
-        .contains('li', 'Failed')
-        .next()
-        .contains('li', 'Running');
+        .first().contains('li', 'Completed').contains('li', 10)
+        .next().contains('li', 'Failed').contains('li', 3)
+        .next().contains('li', 'Running').contains('li', 3);
 
       // shows a list of granules
       cy.getFakeApiFixture('granules').as('granulesListFixture');


### PR DESCRIPTION
I'm not sure if these are actually important, but this will at least test them
again.