### PR TITLE
[CUMULUS-1621] Prevent page reload when pressing enter in dropdown

### DIFF
--- a/app/src/js/components/Collections/granules.js
+++ b/app/src/js/components/Collections/granules.js
@@ -138,7 +138,7 @@ const CollectionGranules = ({
           <h2 className="heading--medium heading--shared-content with-description">
             {`${displayCase(view)} ${displayName} `}
             <span className="num--title">
-              {meta.count ? ` ${meta.count}` : null}
+              {`${meta.count && meta.count || 0}`}
             </span>
           </h2>
         </div>
@@ -156,15 +156,17 @@ const CollectionGranules = ({
               dispatch={dispatch}
               action={searchGranules}
               clear={clearGranulesSearch}
-              placeholder='Search Collections'
+              placeholder='Search Granules'
             />
             {view === 'all' && (
               <Dropdown
                 options={statusOptions}
                 action={filterGranules}
                 clear={clearGranulesFilter}
-                paramKey={'status'}
-                inputProps={{placeholder: 'Status'}}
+                paramKey='status'
+                inputProps={{
+                  placeholder: 'Status'
+                }}
               />
             )}
           </ListFilters>

--- a/app/src/js/components/Collections/list.js
+++ b/app/src/js/components/Collections/list.js
@@ -114,10 +114,12 @@ class CollectionList extends React.Component {
             sortIdx='duration'
           >
             <ListFilters>
-              <Search dispatch={this.props.dispatch}
+              <Search
+                dispatch={this.props.dispatch}
                 action={searchCollections}
                 format={collectionSearchResult}
                 clear={clearCollectionsSearch}
+                placeholder='Search Collections'
               />
             </ListFilters>
           </List>

--- a/app/src/js/components/Collections/overview.js
+++ b/app/src/js/components/Collections/overview.js
@@ -270,6 +270,7 @@ class CollectionOverview extends React.Component {
                   dispatch={this.props.dispatch}
                   action={searchGranules}
                   clear={clearGranulesSearch}
+                  placeholder='Search Granules'
                 />
               </li>
               <li>
@@ -277,8 +278,10 @@ class CollectionOverview extends React.Component {
                   options={statusOptions}
                   action={filterGranules}
                   clear={clearGranulesFilter}
-                  paramKey={'status'}
-                  label={'Status'}
+                  paramKey='status'
+                  inputProps={{
+                    placeholder: 'Status'
+                  }}
                 />
               </li>
               <li className="run_bulk">

--- a/app/src/js/components/DropDown/dropdown.js
+++ b/app/src/js/components/DropDown/dropdown.js
@@ -47,6 +47,7 @@ class Dropdown extends React.Component {
     this.state = { value };
     this.onSelect = this.onSelect.bind(this);
     this.onChange = this.onChange.bind(this);
+    this.onSubmit = this.onSubmit.bind(this);
   }
 
   componentDidUpdate (prevProps, prevState, snapshot) {
@@ -78,6 +79,7 @@ class Dropdown extends React.Component {
   }
 
   onChange (e) {
+    e.preventDefault();
     const { dispatch, clear, paramKey, setQueryParams } = this.props;
     const { value } = e.target;
     this.setState({ value });
@@ -85,6 +87,10 @@ class Dropdown extends React.Component {
       dispatch(clear(paramKey));
       setQueryParams({ [paramKey]: undefined });
     }
+  }
+
+  onSubmit (e) {
+    e.preventDefault();
   }
 
   render () {
@@ -101,7 +107,7 @@ class Dropdown extends React.Component {
     return (
       <div className='filter__item'>
         {label ? <label htmlFor={formID}>{label}</label> : null}
-        <form className='form-group__element' id={formID}>
+        <form className='form-group__element' id={formID} onSubmit={this.onSubmit}>
           <Autocomplete
             getItemValue={item => item.value}
             items={items}

--- a/app/src/js/components/Search/search.js
+++ b/app/src/js/components/Search/search.js
@@ -20,14 +20,14 @@ class Search extends React.Component {
   componentDidMount () {
     const { dispatch, action, paramKey, queryParams } = this.props;
     const queryValue = queryParams[paramKey];
-    if (queryValue) dispatch(action({value: queryValue}));
+    if (queryValue) dispatch(action(queryValue));
   }
 
   componentDidUpdate (prevProps, prevState, snapshot) {
     const {paramKey, dispatch, action, queryParams} = this.props;
     const queryValue = queryParams[paramKey];
     if (queryValue !== prevProps.queryParams[paramKey]) {
-      dispatch(action({ key: paramKey, queryValue }));
+      dispatch(action(queryValue));
       this.setState({queryValue}); // eslint-disable-line react/no-did-update-set-state
     }
   }
@@ -47,11 +47,6 @@ class Search extends React.Component {
 
   submit (e) {
     e.preventDefault();
-    const value = e.currentTarget.getAttribute('value') || null;
-    this.setState({ value });
-    const { dispatch, action } = this.props;
-    if (this.cancelDelay) { this.cancelDelay(); }
-    dispatch(action(value));
   }
 
   delayedQuery (value) {


### PR DESCRIPTION
This fixes the issue where submitting the dropdown input causes the page to reload with a `?` appended to the url.

Additionally, while working on this, I found when submitting the search input, it would clear whatever was typed.

In both cases, setting the `onSubmit` function for the wrapping form to only call `e.preventDefault()` resolved the issues.

Also in this PR, I added/updated the placeholders for the inputs on the Collections pages.