### PR TITLE
webpack environment: fix the default value lookup for HIDE_PDR

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -148,7 +148,7 @@ const CommonConfig = {
         APIROOT: config.apiRoot,
         DAAC_NAME: config.target,
         STAGE: config.environment,
-        HIDE_PDR: config.nav.exclude.pdrs,
+        HIDE_PDR: config.nav.exclude.PDRs,
         AUTH_METHOD: config.oauthMethod,
         KIBANAROOT: config.kibanaRoot,
         ESROOT: config.esRoot,


### PR DESCRIPTION
In [`app/src/js/config/config.js`](https://github.com/nasa/cumulus-dashboard/blob/v1.7.1/app/src/js/config/config.js#L7), the key is "PDRs", not "pdrs".

This resolves the following warning presented during an `npm run build` when
`HIDE_PDR` is not set as part of the environment:

    WARNING in EnvironmentPlugin - HIDE_PDR environment variable is undefined.

I encountered this warning while working through the [Deploy Cumulus Dashboard](https://nasa.github.io/cumulus/docs/deployment/deployment-readme#deploy-cumulus-dashboard) instructions.
