### PR TITLE
[CUMULUS-1535] Add confirmation modal for editing a rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
+- **CUMULUS-1535**
+  - Adds a confirmation modal when editing a rule
+
 - **CUMULUS-1758**
   - Adds the ability to resize table columns
 

--- a/app/src/js/components/Collections/edit.js
+++ b/app/src/js/components/Collections/edit.js
@@ -13,60 +13,21 @@ import EditRaw from '../EditRaw/edit-raw';
 
 const SCHEMA_KEY = 'collection';
 
-const ModalBody = ({ isSuccess, isError, isInflight, error, name, version }) => {
-  return (
-    <div>
-      {isInflight
-        ? 'Processing...'
-        : <>
-        {`Collection ${name} / ${version} `}
-        {(isSuccess && !isError) && 'has been updated'}
-        {isError &&
-         <>
-          {'has encountered an error.'}
-          <div className="error">{error}</div>
-         </>
-        }
-        </>
-      }
-    </div>
-  );
-};
-
-ModalBody.propTypes = {
-  isError: PropTypes.bool,
-  isSuccess: PropTypes.bool,
-  isInflight: PropTypes.bool,
-  error: PropTypes.string,
-  name: PropTypes.string,
-  version: PropTypes.string
-};
-
 const EditCollection = ({ match, collections }) => {
   const { params: { name, version } } = match;
   const collectionId = getCollectionId({ name, version });
-
-  const wrapModalBody = ModalBody => ({ ...props }) => {
-    return (
-      <ModalBody name={name} version={version} {...props} />
-    );
-  };
-
-  const ModalBodyWrapper = wrapModalBody(ModalBody);
 
   return (
     <EditRaw
       pk={collectionId}
       schemaKey={SCHEMA_KEY}
-      primaryProperty={'name'}
+      primaryProperty='name'
       state={collections}
       getRecord={() => getCollection(name, version)}
       updateRecord={updateCollection}
       backRoute={`/collections/collection/${name}/${version}`}
       clearRecordUpdate={clearUpdateCollection}
       hasModal={true}
-      type='collection'
-      ModalBody={ModalBodyWrapper}
     />
   );
 };

--- a/app/src/js/components/EditRaw/edit-raw.js
+++ b/app/src/js/components/EditRaw/edit-raw.js
@@ -31,9 +31,7 @@ const EditRaw = ({
   pk,
   schema,
   schemaKey,
-  hasModal,
-  type,
-  ModalBody
+  hasModal
 }) => {
   const [record, setRecord] = useState(defaultState);
   const [showModal, setShowModal] = useState(false);
@@ -46,6 +44,7 @@ const EditRaw = ({
   const isError = !!error;
   const buttonText = isInflight ? 'loading...'
     : isSuccess ? 'Success!' : 'Submit';
+  const recordDisplayName = displayCase(schemaKey);
 
   // get record and schema
   // ported from componentDidMount
@@ -176,17 +175,31 @@ const EditRaw = ({
       {hasModal &&
       <DefaultModal
         showModal={showModal}
-        className={`edit-${type}`}
+        className={`edit-${schemaKey}`}
         onCloseModal={handleCloseModal}
         onConfirm={isError ? handleModalConfirm : handleCloseModal}
         onCancel={handleCancel}
-        title={`Edit ${displayCase(type)}`}
+        title={`Edit ${recordDisplayName}`}
         hasCancelButton={isError}
         cancelButtonText={isError ? 'Cancel Request' : null}
-        confirmButtonText={isError ? 'Go To Collection' : 'Close'}
+        confirmButtonText={isError ? `Edit ${recordDisplayName}` : 'Close'}
         confirmButtonClass={isError ? 'button__goto' : 'button--green button--close'}
       >
-        <ModalBody isError={isError} isSuccess={isSuccess} isInflight={isInflight} error={error} />
+        <div>
+          {isInflight
+            ? 'Processing...'
+            : <>
+            {`${recordDisplayName} ${recordPk} `}
+            {(isSuccess && !isError) && 'has been updated'}
+            {isError &&
+            <>
+              {'has encountered an error.'}
+              <div className="error">{error}</div>
+            </>
+            }
+            </>
+          }
+        </div>
       </DefaultModal>}
     </div>
   );
@@ -203,12 +216,7 @@ EditRaw.propTypes = {
   getRecord: PropTypes.func,
   updateRecord: PropTypes.func,
   clearRecordUpdate: PropTypes.func,
-  hasModal: PropTypes.bool,
-  type: PropTypes.string,
-  ModalBody: PropTypes.oneOfType([
-    PropTypes.node,
-    PropTypes.func
-  ])
+  hasModal: PropTypes.bool
 };
 
 export default withRouter(connect(state => ({

--- a/app/src/js/components/Rules/edit.js
+++ b/app/src/js/components/Rules/edit.js
@@ -13,23 +13,26 @@ import EditRaw from '../EditRaw/edit-raw';
 
 const SCHEMA_KEY = 'rule';
 
-class EditRule extends React.Component {
-  render () {
-    const { match: { params: { ruleName } }, rules } = this.props;
-    return (
-      <EditRaw
-        pk={ruleName}
-        schemaKey={SCHEMA_KEY}
-        primaryProperty={'name'}
-        state={rules}
-        getRecord={() => getRule(ruleName)}
-        updateRecord={updateRule}
-        backRoute={`/rules/rule/${ruleName}`}
-        clearRecordUpdate={clearUpdateRule}
-      />
-    );
-  }
-}
+const EditRule = ({
+  match,
+  rules
+}) => {
+  const { params: { ruleName } } = match;
+
+  return (
+    <EditRaw
+      pk={ruleName}
+      schemaKey={SCHEMA_KEY}
+      primaryProperty='name'
+      state={rules}
+      getRecord={() => getRule(ruleName)}
+      updateRecord={updateRule}
+      backRoute={`/rules/rule/${ruleName}`}
+      clearRecordUpdate={clearUpdateRule}
+      hasModal={true}
+    />
+  );
+};
 
 EditRule.propTypes = {
   match: PropTypes.object,

--- a/cypress/integration/collections_spec.js
+++ b/cypress/integration/collections_spec.js
@@ -327,6 +327,8 @@ describe('Dashboard Collections Page', () => {
       const version = '006';
 
       cy.visit(`/collections/collection/${name}/${version}`);
+      cy.wait('@getCollection');
+      cy.wait('@getGranules');
 
       // delete collection
       cy.get('.DeleteCollection > .button').click();
@@ -350,6 +352,8 @@ describe('Dashboard Collections Page', () => {
       const version = '006';
 
       cy.visit(`/collections/collection/${name}/${version}`);
+      cy.wait('@getCollection');
+      cy.wait('@getGranules');
 
       // delete collection
       cy.get('.DeleteCollection > .button').click();

--- a/cypress/integration/collections_spec.js
+++ b/cypress/integration/collections_spec.js
@@ -198,7 +198,7 @@ describe('Dashboard Collections Page', () => {
       cy.editJsonTextarea({ data: { duplicateHandling, meta }, update: true });
       cy.contains('form button', 'Submit').click();
       cy.contains('.default-modal .edit-collection__title', 'Edit Collection');
-      cy.contains('.default-modal .modal-body', `Collection ${name} / ${version} has been updated`);
+      cy.contains('.default-modal .modal-body', `Collection ${name}___${version} has been updated`);
       cy.contains('.modal-footer button', 'Close').click();
 
       // displays the updated collection and its granules
@@ -221,11 +221,11 @@ describe('Dashboard Collections Page', () => {
       cy.contains('.ace_variable', 'name');
       cy.editJsonTextarea({ data: { sampleFileName }, update: true });
 
-      // Go To Collection should allow for continued editing
+      // Edit Collection should allow for continued editing
       cy.contains('form button', 'Submit').click();
       cy.contains('.default-modal .edit-collection__title', 'Edit Collection');
-      cy.contains('.default-modal .modal-body', `Collection ${name} / ${version} has encountered an error.`);
-      cy.contains('.modal-footer button', 'Go To Collection').click();
+      cy.contains('.default-modal .modal-body', `Collection ${name}___${version} has encountered an error.`);
+      cy.contains('.modal-footer button', 'Edit Collection').click();
       cy.url().should('include', `collections/edit/${name}/${version}`);
 
       // Cancel Request should return to collection page

--- a/cypress/integration/rules_spec.js
+++ b/cypress/integration/rules_spec.js
@@ -126,19 +126,44 @@ describe('Rules page', () => {
       cy.contains('.ace_variable', 'name');
       cy.editJsonTextarea({ data: { provider }, update: true });
       cy.contains('form button', 'Submit').click();
+      cy.contains('.default-modal .edit-rule__title', 'Edit Rule');
+      cy.contains('.default-modal .modal-body', `Rule ${testRuleName} has been updated`);
+      cy.contains('.modal-footer button', 'Close').click();
+
+      // displays the updated rule
       cy.contains('.heading--large', testRuleName);
       cy.get('.metadata__details')
         .within(() => {
           cy.contains('Provider').next().should('have.text', provider);
         });
 
-      cy.contains('a', 'Back to Rules').click();
-      cy.contains('.heading--large', 'Rule Overview');
-      cy.contains('.table .tr', testRuleName)
-        .within(() => {
-          cy.contains(provider)
-            .should('have.attr', 'href', `/providers/provider/${provider}`);
-        });
+      // verify the collection is updated by looking at the Edit page
+      cy.contains('a', 'Edit').click();
+
+      cy.contains('.ace_variable', 'name');
+      cy.getJsonTextareaValue().then((ruleJson) => {
+        expect(ruleJson.provider).to.equal(provider);
+      });
+      cy.contains('.heading--large', testRuleName);
+
+      // Test error flow
+      const errorRuleType = 'test';
+      cy.contains('.ace_variable', 'name');
+      cy.editJsonTextarea({ data: { rule: { type: errorRuleType } }, update: true });
+
+      // Edit Rule should allow for continued editing
+      cy.contains('form button', 'Submit').click();
+      cy.contains('.default-modal .edit-rule__title', 'Edit Rule');
+      cy.contains('.default-modal .modal-body', `Rule ${testRuleName} has encountered an error.`);
+      cy.contains('.modal-footer button', 'Edit Rule').click();
+      cy.url().should('include', `rules/edit/${testRuleName}`);
+
+      // Cancel Request should return to rule page
+      cy.contains('form button', 'Submit').click();
+      cy.contains('.modal-footer button', 'Cancel Request').click();
+      // cy.wait('@getCollection');
+      cy.contains('.heading--xlarge', 'Rules');
+      cy.contains('.heading--large', `${testRuleName}`);
     });
 
     it('deleting a rule should remove it from the list', () => {


### PR DESCRIPTION
Adds a confirmation modal when editing a rule.

Also, updated edit-raw.js to have default modal content where we swap in the record type and name, since content otherwise shouldn't change. This simplifies the edit collection component.

To test:
Verify edit rule has a confirmation modal indicating success or error.
Verify edit collection still works as expected