### PR TITLE
Cumulus 1790 Update stats to work with datepicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+
 ### Added
 
 - **CUMULUS-1526**
   - Add a copy rule button
+
+### Changed
+
+
+- **CUMULUS-1790**
+  - Changes default values and visuals for home page's datepicker. Now defaults to last 24 hours. Selecting "All" shows the actual representation of data from Jan 1, 1970 through approximately now.
 
 ## [v1.7.2] - 2020-03-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 - **CUMULUS-1790**
-  - Changes default values and visuals for home page's datepicker. Now defaults to last 24 hours. Selecting "All" shows the actual representation of data from Jan 1, 1970 through approximately now.
+  - Changes default values and visuals for home page's datepicker. When the page loads, it defauls to display "Recent" data, which is the previous 24 hours with no end time.
 
 ## [v1.7.2] - 2020-03-16
 

--- a/app/src/js/actions/datepicker.js
+++ b/app/src/js/actions/datepicker.js
@@ -1,0 +1,8 @@
+'use strict';
+
+import { DATEPICKER_DATECHANGE } from './types';
+
+export const setEndDateTimeToNow = () => ({
+  type: DATEPICKER_DATECHANGE,
+  data: {endDateTime: new Date(Date.now() + 10000)}
+});

--- a/app/src/js/actions/datepicker.js
+++ b/app/src/js/actions/datepicker.js
@@ -1,8 +1,0 @@
-'use strict';
-
-import { DATEPICKER_DATECHANGE } from './types';
-
-export const setEndDateTimeToNow = () => ({
-  type: DATEPICKER_DATECHANGE,
-  data: {endDateTime: new Date(Date.now() + 10000)}
-});

--- a/app/src/js/actions/index.js
+++ b/app/src/js/actions/index.js
@@ -18,6 +18,7 @@ import { apiGatewaySearchTemplate } from './action-config/apiGatewaySearch';
 import { apiLambdaSearchTemplate } from './action-config/apiLambdaSearch';
 import { teaLambdaSearchTemplate } from './action-config/teaLambdaSearch';
 import { s3AccessSearchTemplate } from './action-config/s3AccessSearch';
+import { setEndDateTimeToNow } from './datepicker';
 import * as types from './types';
 
 const CALL_API = types.CALL_API;
@@ -144,15 +145,19 @@ export const listCollections = (options) => {
   };
 };
 
-export const createCollection = (payload) => ({
-  [CALL_API]: {
-    type: types.NEW_COLLECTION,
-    method: 'POST',
-    id: getCollectionId(payload),
-    path: 'collections',
-    body: payload
-  }
-});
+export const createCollection = (payload) => {
+  return (dispatch) => {
+    return dispatch({
+      [CALL_API]: {
+        type: types.NEW_COLLECTION,
+        method: 'POST',
+        id: getCollectionId(payload),
+        path: 'collections',
+        body: payload
+      }
+    }).then(() => dispatch(setEndDateTimeToNow()));
+  };
+};
 
 export const updateCollection = (payload) => ({
   [CALL_API]: {

--- a/app/src/js/actions/index.js
+++ b/app/src/js/actions/index.js
@@ -596,15 +596,19 @@ export const getProvider = (providerId) => ({
   }
 });
 
-export const createProvider = (providerId, payload) => ({
-  [CALL_API]: {
-    type: types.NEW_PROVIDER,
-    id: providerId,
-    method: 'POST',
-    path: 'providers',
-    body: payload
-  }
-});
+export const createProvider = (providerId, payload) => {
+  return (dispatch) => {
+    return dispatch({
+      [CALL_API]: {
+        type: types.NEW_PROVIDER,
+        id: providerId,
+        method: 'POST',
+        path: 'providers',
+        body: payload
+      }
+    }).then(() => dispatch(setEndDateTimeToNow()));
+  };
+};
 
 export const updateProvider = (providerId, payload) => ({
   [CALL_API]: {

--- a/app/src/js/actions/index.js
+++ b/app/src/js/actions/index.js
@@ -11,7 +11,7 @@ import clonedeep from 'lodash.clonedeep';
 import { configureRequest } from './helpers';
 import _config from '../config';
 import { getCollectionId, collectionNameVersion } from '../utils/format';
-import { fetchCurrentTimeFilters } from '../utils/datepicker';
+import { fetchCurrentTimeFilters, msPerDay } from '../utils/datepicker';
 import log from '../utils/log';
 import { authHeader } from '../utils/basic-auth';
 import { apiGatewaySearchTemplate } from './action-config/apiGatewaySearch';
@@ -29,8 +29,6 @@ const {
   pageLimit,
   minCompatibleApiVersion
 } = _config;
-
-const millisecondsPerDay = 24 * 60 * 60 * 1000;
 
 /**
  * match MMT to CMR environment.
@@ -457,7 +455,7 @@ export const getStats = (options) => {
 export const getDistApiGatewayMetrics = (cumulusInstanceMeta) => {
   const stackName = cumulusInstanceMeta.stackName;
   const now = Date.now();
-  const twentyFourHoursAgo = now - millisecondsPerDay;
+  const twentyFourHoursAgo = now - msPerDay;
   if (!esRoot) return { type: types.NOOP };
   return {
     [CALL_API]: {
@@ -474,7 +472,7 @@ export const getDistApiGatewayMetrics = (cumulusInstanceMeta) => {
 export const getDistApiLambdaMetrics = (cumulusInstanceMeta) => {
   const stackName = cumulusInstanceMeta.stackName;
   const now = Date.now();
-  const twentyFourHoursAgo = now - millisecondsPerDay;
+  const twentyFourHoursAgo = now - msPerDay;
   if (!esRoot) return { type: types.NOOP };
   if (!showDistributionAPIMetrics) return {type: types.NOOP};
   return {
@@ -492,7 +490,7 @@ export const getDistApiLambdaMetrics = (cumulusInstanceMeta) => {
 export const getTEALambdaMetrics = (cumulusInstanceMeta) => {
   const stackName = cumulusInstanceMeta.stackName;
   const now = Date.now();
-  const twentyFourHoursAgo = now - millisecondsPerDay;
+  const twentyFourHoursAgo = now - msPerDay;
   if (!esRoot) return { type: types.NOOP };
   if (!showTeaMetrics) return { type: types.NOOP };
   return {
@@ -510,7 +508,7 @@ export const getTEALambdaMetrics = (cumulusInstanceMeta) => {
 export const getDistS3AccessMetrics = (cumulusInstanceMeta) => {
   const stackName = cumulusInstanceMeta.stackName;
   const now = Date.now();
-  const twentyFourHoursAgo = now - millisecondsPerDay;
+  const twentyFourHoursAgo = now - msPerDay;
   if (!esRoot) return { type: types.NOOP };
   return {
     [CALL_API]: {

--- a/app/src/js/actions/index.js
+++ b/app/src/js/actions/index.js
@@ -18,7 +18,6 @@ import { apiGatewaySearchTemplate } from './action-config/apiGatewaySearch';
 import { apiLambdaSearchTemplate } from './action-config/apiLambdaSearch';
 import { teaLambdaSearchTemplate } from './action-config/teaLambdaSearch';
 import { s3AccessSearchTemplate } from './action-config/s3AccessSearch';
-import { setEndDateTimeToNow } from './datepicker';
 import * as types from './types';
 
 const CALL_API = types.CALL_API;
@@ -145,19 +144,15 @@ export const listCollections = (options) => {
   };
 };
 
-export const createCollection = (payload) => {
-  return (dispatch) => {
-    return dispatch({
-      [CALL_API]: {
-        type: types.NEW_COLLECTION,
-        method: 'POST',
-        id: getCollectionId(payload),
-        path: 'collections',
-        body: payload
-      }
-    }).then(() => dispatch(setEndDateTimeToNow()));
-  };
-};
+export const createCollection = (payload) => ({
+  [CALL_API]: {
+    type: types.NEW_COLLECTION,
+    method: 'POST',
+    id: getCollectionId(payload),
+    path: 'collections',
+    body: payload
+  }
+});
 
 export const updateCollection = (payload) => ({
   [CALL_API]: {
@@ -596,19 +591,15 @@ export const getProvider = (providerId) => ({
   }
 });
 
-export const createProvider = (providerId, payload) => {
-  return (dispatch) => {
-    return dispatch({
-      [CALL_API]: {
-        type: types.NEW_PROVIDER,
-        id: providerId,
-        method: 'POST',
-        path: 'providers',
-        body: payload
-      }
-    }).then(() => dispatch(setEndDateTimeToNow()));
-  };
-};
+export const createProvider = (providerId, payload) => ({
+  [CALL_API]: {
+    type: types.NEW_PROVIDER,
+    id: providerId,
+    method: 'POST',
+    path: 'providers',
+    body: payload
+  }
+});
 
 export const updateProvider = (providerId, payload) => ({
   [CALL_API]: {

--- a/app/src/js/components/Datepicker/Datepicker.js
+++ b/app/src/js/components/Datepicker/Datepicker.js
@@ -8,21 +8,7 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import withQueryParams from 'react-router-query-params';
 import { DATEPICKER_DATECHANGE, DATEPICKER_DROPDOWN_FILTER, DATEPICKER_HOUR_FORMAT } from '../../actions/types';
-import { urlDateFormat, urlDateProps } from '../../utils/datepicker';
-
-const allDateRanges = [
-  {value: 'All', label: 'All'},
-  {value: 'Custom', label: 'Custom'},
-  {value: 1 / 24.0, label: 'Last hour'},
-  {value: 1, label: 'Last 24 hours'},
-  {value: 7, label: 'Last week'},
-  {value: 30, label: 'Last 30 Days'},
-  {value: 60, label: 'Last 60 days'},
-  {value: 180, label: 'Last 180 days'},
-  {value: 366, label: 'Last year'}
-];
-const allHourFormats = ['12HR', '24HR'];
-const dateTimeFormat = 'YYYY-MM-DDTHH:mm:ss.sss';
+import { allDateRanges, allHourFormats, dateTimeFormat, urlDateFormat, urlDateProps } from '../../utils/datepicker';
 
 /*
  * If this is a shared URL, grab the date and time and update the datepicker
@@ -38,6 +24,8 @@ const updateDatepickerStateFromQueryParams = (props) => {
         values[value] = moment.utc(values[value], urlDateFormat).toDate();
       }
     }
+    // TODO [MHS, 2020-03-16] see if we can't solve the problem with using a
+    // time delta to select correct label.
     values.dateRange = {value: 'Custom', label: 'Custom'};
     props.dispatch({type: 'DATEPICKER_DATECHANGE', data: {...props.datepicker, ...values}});
   }
@@ -62,7 +50,7 @@ class Datepicker extends React.PureComponent {
   }
 
   clear () {
-    const { value, label } = allDateRanges.find(a => a.label === 'All');
+    const { value, label } = allDateRanges.find(a => a.label === 'Last 24 hours');
     this.props.dispatch(this.dispatchDropdownUpdate(value, label));
   }
 

--- a/app/src/js/components/Datepicker/Datepicker.js
+++ b/app/src/js/components/Datepicker/Datepicker.js
@@ -50,7 +50,7 @@ class Datepicker extends React.PureComponent {
   }
 
   clear () {
-    const { value, label } = allDateRanges.find(a => a.label === 'Recent');
+    const { value, label } = allDateRanges.find(a => a.label === 'Custom');
     this.props.dispatch(this.dispatchDropdownUpdate(value, label));
   }
 

--- a/app/src/js/components/Datepicker/Datepicker.js
+++ b/app/src/js/components/Datepicker/Datepicker.js
@@ -24,8 +24,6 @@ const updateDatepickerStateFromQueryParams = (props) => {
         values[value] = moment.utc(values[value], urlDateFormat).toDate();
       }
     }
-    // TODO [MHS, 2020-03-16] see if we can't solve the problem with using a
-    // time delta to select correct label.
     values.dateRange = dropdownValue(values);
     props.dispatch({type: 'DATEPICKER_DATECHANGE', data: {...props.datepicker, ...values}});
   }

--- a/app/src/js/components/Datepicker/Datepicker.js
+++ b/app/src/js/components/Datepicker/Datepicker.js
@@ -50,7 +50,7 @@ class Datepicker extends React.PureComponent {
   }
 
   clear () {
-    const { value, label } = allDateRanges.find(a => a.label === 'Last 24 hours');
+    const { value, label } = allDateRanges.find(a => a.label === 'Recent');
     this.props.dispatch(this.dispatchDropdownUpdate(value, label));
   }
 

--- a/app/src/js/components/Datepicker/Datepicker.js
+++ b/app/src/js/components/Datepicker/Datepicker.js
@@ -8,7 +8,7 @@ import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import withQueryParams from 'react-router-query-params';
 import { DATEPICKER_DATECHANGE, DATEPICKER_DROPDOWN_FILTER, DATEPICKER_HOUR_FORMAT } from '../../actions/types';
-import { allDateRanges, allHourFormats, dateTimeFormat, urlDateFormat, urlDateProps } from '../../utils/datepicker';
+import { allDateRanges, allHourFormats, dropdownValue, dateTimeFormat, urlDateFormat, urlDateProps } from '../../utils/datepicker';
 
 /*
  * If this is a shared URL, grab the date and time and update the datepicker
@@ -26,7 +26,7 @@ const updateDatepickerStateFromQueryParams = (props) => {
     }
     // TODO [MHS, 2020-03-16] see if we can't solve the problem with using a
     // time delta to select correct label.
-    values.dateRange = {value: 'Custom', label: 'Custom'};
+    values.dateRange = dropdownValue(values);
     props.dispatch({type: 'DATEPICKER_DATECHANGE', data: {...props.datepicker, ...values}});
   }
 };

--- a/app/src/js/components/Datepicker/Datepicker.scss
+++ b/app/src/js/components/Datepicker/Datepicker.scss
@@ -38,7 +38,7 @@
     font-size: 2em;
     margin-right: .25em;
   }
-  
+
   &__internal .selector__hrformat{
     display: block;
     position: relative;

--- a/app/src/js/reducers/datepicker.js
+++ b/app/src/js/reducers/datepicker.js
@@ -5,15 +5,20 @@ import {
   DATEPICKER_DROPDOWN_FILTER,
   DATEPICKER_HOUR_FORMAT
 } from '../actions/types';
+import { secondsPerDay, allDateRanges } from '../utils/datepicker';
+const earliestDate = new Date(0);
 
-const daysToMilliseconds = 1000 * 60 * 60 * 24;
+const daysToMilliseconds = 1000 * secondsPerDay;
 
 // Also becomes default props for Datepicker
-export const initialState = {
-  startDateTime: null,
-  endDateTime: null,
-  dateRange: {value: 'All', label: 'All'},
-  hourFormat: '12HR'
+export const initialState = () => {
+  const now = new Date(Date.now());
+  return {
+    startDateTime: new Date(now - daysToMilliseconds),
+    endDateTime: new Date(now),
+    dateRange: allDateRanges.find((a) => a.value === 1),
+    hourFormat: '12HR'
+  };
 };
 
 /**
@@ -36,13 +41,25 @@ const computeDateTimeDelta = (timeDeltaInDays) => {
   return { startDateTime, endDateTime };
 };
 
-export default function reducer (state = initialState, action) {
+const allData = () => {
+  const endDateTime = new Date(Date.now());
+  const startDateTime = new Date(earliestDate);
+  return {startDateTime, endDateTime, dateRange: allDateRanges.find((a) => a.value === 1)};
+};
+
+export default function reducer (state = initialState(), action) {
   state = { ...state };
   const { data } = action;
   switch (action.type) {
     case DATEPICKER_DROPDOWN_FILTER:
-      state = {...state, ...computeDateTimeDelta(data.dateRange.value), ...data};
-      break;
+      switch (data.dateRange.label) {
+        case 'Custom':
+          return {...state, ...data};
+        case 'All':
+          return {...state, ...allData(), ...data};
+        default:
+          return {...state, ...computeDateTimeDelta(data.dateRange.value), ...data};
+      }
     case DATEPICKER_DATECHANGE:
       state = { ...state, ...data };
       break;

--- a/app/src/js/reducers/datepicker.js
+++ b/app/src/js/reducers/datepicker.js
@@ -41,6 +41,11 @@ const computeDateTimeDelta = (timeDeltaInDays) => {
   return { startDateTime, endDateTime };
 };
 
+/**
+* Sets the state for all data between Jan 1, 1970 and now.
+*
+* @returns {Object} with startDateTime, endDateTime and dateRange set to "All"
+*/
 const allData = () => {
   const endDateTime = new Date(Date.now());
   const startDateTime = new Date(earliestDate);

--- a/app/src/js/reducers/datepicker.js
+++ b/app/src/js/reducers/datepicker.js
@@ -6,7 +6,6 @@ import {
   DATEPICKER_HOUR_FORMAT
 } from '../actions/types';
 import { secondsPerDay, allDateRanges } from '../utils/datepicker';
-const earliestDate = new Date(0);
 
 const daysToMilliseconds = 1000 * secondsPerDay;
 
@@ -15,8 +14,8 @@ export const initialState = () => {
   const now = new Date(Date.now());
   return {
     startDateTime: new Date(now - daysToMilliseconds),
-    endDateTime: new Date(now),
-    dateRange: allDateRanges.find((a) => a.value === 1),
+    endDateTime: null,
+    dateRange: allDateRanges.find((a) => a.value === 'Recent'),
     hourFormat: '12HR'
   };
 };
@@ -42,14 +41,14 @@ const computeDateTimeDelta = (timeDeltaInDays) => {
 };
 
 /**
-* Sets the state for all data between Jan 1, 1970 and now.
+* Sets the state for recent data start time is 24 hours ago, end time is null
 *
-* @returns {Object} with startDateTime, endDateTime and dateRange set to "All"
+* @returns {Object} with startDateTime and dateRange set to "Recent"
 */
-const allData = () => {
-  const endDateTime = new Date(Date.now());
-  const startDateTime = new Date(earliestDate);
-  return {startDateTime, endDateTime, dateRange: allDateRanges.find((a) => a.value === 1)};
+const recentData = () => {
+  const endDateTime = null;
+  const startDateTime = new Date(Date.now() - secondsPerDay * 1000);
+  return {startDateTime, endDateTime, dateRange: allDateRanges.find((a) => a.value === 'Recent')};
 };
 
 export default function reducer (state = initialState(), action) {
@@ -59,9 +58,10 @@ export default function reducer (state = initialState(), action) {
     case DATEPICKER_DROPDOWN_FILTER:
       switch (data.dateRange.label) {
         case 'Custom':
-          return {...state, ...data};
         case 'All':
-          return {...state, ...allData(), ...data};
+          return {...state, ...data, ...{startDateTime: null, endDateTime: null}};
+        case 'Recent':
+          return {...state, ...data, ...recentData()};
         default:
           return {...state, ...computeDateTimeDelta(data.dateRange.value), ...data};
       }

--- a/app/src/js/reducers/datepicker.js
+++ b/app/src/js/reducers/datepicker.js
@@ -5,15 +5,13 @@ import {
   DATEPICKER_DROPDOWN_FILTER,
   DATEPICKER_HOUR_FORMAT
 } from '../actions/types';
-import { secondsPerDay, allDateRanges } from '../utils/datepicker';
-
-const daysToMilliseconds = 1000 * secondsPerDay;
+import { msPerDay, allDateRanges } from '../utils/datepicker';
 
 // Also becomes default props for Datepicker
 export const initialState = () => {
   const now = new Date(Date.now());
   return {
-    startDateTime: new Date(now - daysToMilliseconds),
+    startDateTime: new Date(now - msPerDay),
     endDateTime: null,
     dateRange: allDateRanges.find((a) => a.value === 'Recent'),
     hourFormat: '12HR'
@@ -34,7 +32,7 @@ const computeDateTimeDelta = (timeDeltaInDays) => {
   if (!isNaN(timeDeltaInDays)) {
     endDateTime = new Date(Date.now());
     startDateTime = new Date(
-      endDateTime - timeDeltaInDays * daysToMilliseconds
+      endDateTime - timeDeltaInDays * msPerDay
     );
   }
   return { startDateTime, endDateTime };
@@ -47,7 +45,7 @@ const computeDateTimeDelta = (timeDeltaInDays) => {
 */
 const recentData = () => {
   const endDateTime = null;
-  const startDateTime = new Date(Date.now() - secondsPerDay * 1000);
+  const startDateTime = new Date(Date.now() - msPerDay);
   return {startDateTime, endDateTime, dateRange: allDateRanges.find((a) => a.value === 'Recent')};
 };
 

--- a/app/src/js/utils/datepicker.js
+++ b/app/src/js/utils/datepicker.js
@@ -1,6 +1,21 @@
 'use strict';
 
 export const urlDateFormat = 'YYYYMMDDHHmmSS';
+export const secondsPerDay = 60.0 * 60.0 * 24.0;
+
+export const allDateRanges = [
+  {value: 'All', label: 'All'},
+  {value: 'Custom', label: 'Custom'},
+  {value: 1 / 24.0, label: 'Last hour'},
+  {value: 1, label: 'Last 24 hours'},
+  {value: 7, label: 'Last week'},
+  {value: 30, label: 'Last 30 Days'},
+  {value: 60, label: 'Last 60 days'},
+  {value: 180, label: 'Last 180 days'},
+  {value: 366, label: 'Last year'}
+];
+export const allHourFormats = ['12HR', '24HR'];
+export const dateTimeFormat = 'YYYY-MM-DDTHH:mm:ss.sss';
 
 // These are created as lists of objects so that we can keep them together when
 // mapping over the possible values.

--- a/app/src/js/utils/datepicker.js
+++ b/app/src/js/utils/datepicker.js
@@ -1,7 +1,8 @@
 'use strict';
 
 export const urlDateFormat = 'YYYYMMDDHHmmSS';
-export const secondsPerDay = 60.0 * 60.0 * 24.0;
+const secondsPerDay = 60.0 * 60.0 * 24.0;
+export const msPerDay = secondsPerDay * 1000.0;
 
 export const allDateRanges = [
   {value: 'Custom', label: 'Custom'},
@@ -34,7 +35,7 @@ export const urlDateProps = matchObjects.map((o) => o.dateProp);
 export const dropdownValue = (values) => {
   let dropdownInfo = {value: 'Custom', label: 'Custom'};
   if (!!values.startDateTime && !!values.endDateTime) {
-    const durationDays = ((values.endDateTime.valueOf() - values.startDateTime.valueOf()) / 1000.0) / secondsPerDay;
+    const durationDays = (values.endDateTime.valueOf() - values.startDateTime.valueOf()) / msPerDay;
     dropdownInfo = allDateRanges.find((r) => r.value === durationDays) || dropdownInfo;
   }
   return dropdownInfo;

--- a/app/src/js/utils/datepicker.js
+++ b/app/src/js/utils/datepicker.js
@@ -27,6 +27,20 @@ const matchObjects = [
 export const urlDateProps = matchObjects.map((o) => o.dateProp);
 
 /**
+ * look and see if the start/end times of the input object match a dropdown label and return it.
+ * @param {Object} values - can contain startDateTime endDateTime
+ * @return {Object} returns a matching daterange object, or the custom value if no matches found.
+ */
+export const dropdownValue = (values) => {
+  let dropdownInfo = {value: 'Custom', label: 'Custom'};
+  if (!!values.startDateTime && !!values.endDateTime) {
+    const durationDays = ((values.endDateTime.valueOf() - values.startDateTime.valueOf()) / 1000.0) / secondsPerDay;
+    dropdownInfo = allDateRanges.find((r) => r.value === durationDays) || dropdownInfo;
+  }
+  return dropdownInfo;
+};
+
+/**
  * Build a timefilter object that will be passed to the cumulus core API calls as part of the querystring.
  *
  * @param {Object} datepicker - redux datepicker state.

--- a/app/src/js/utils/datepicker.js
+++ b/app/src/js/utils/datepicker.js
@@ -4,15 +4,16 @@ export const urlDateFormat = 'YYYYMMDDHHmmSS';
 export const secondsPerDay = 60.0 * 60.0 * 24.0;
 
 export const allDateRanges = [
-  {value: 'All', label: 'All'},
   {value: 'Custom', label: 'Custom'},
-  {value: 1 / 24.0, label: 'Last hour'},
-  {value: 1, label: 'Last 24 hours'},
-  {value: 7, label: 'Last week'},
-  {value: 30, label: 'Last 30 Days'},
-  {value: 60, label: 'Last 60 days'},
-  {value: 180, label: 'Last 180 days'},
-  {value: 366, label: 'Last year'}
+  {value: 'Recent', label: 'Recent'},
+  {value: 'All', label: 'All'},
+  {value: 1 / 24.0, label: '1 hour'},
+  {value: 1, label: '1 day'},
+  {value: 7, label: '1 week'},
+  {value: 30, label: '1 month'},
+  {value: 90, label: '90 days'},
+  {value: 180, label: '180 days'},
+  {value: 366, label: '1 year'}
 ];
 export const allHourFormats = ['12HR', '24HR'];
 export const dateTimeFormat = 'YYYY-MM-DDTHH:mm:ss.sss';

--- a/app/src/js/utils/datepicker.js
+++ b/app/src/js/utils/datepicker.js
@@ -6,13 +6,12 @@ export const secondsPerDay = 60.0 * 60.0 * 24.0;
 export const allDateRanges = [
   {value: 'Custom', label: 'Custom'},
   {value: 'Recent', label: 'Recent'},
-  {value: 'All', label: 'All'},
   {value: 1 / 24.0, label: '1 hour'},
   {value: 1, label: '1 day'},
   {value: 7, label: '1 week'},
   {value: 30, label: '1 month'},
-  {value: 90, label: '90 days'},
-  {value: 180, label: '180 days'},
+  {value: 90, label: '3 months'},
+  {value: 180, label: '6 months'},
   {value: 366, label: '1 year'}
 ];
 export const allHourFormats = ['12HR', '24HR'];

--- a/cypress/integration/main_page_spec.js
+++ b/cypress/integration/main_page_spec.js
@@ -71,12 +71,12 @@ describe('Dashboard Home Page', () => {
     });
 
     it('Updates start and end time components when dropdown is selected', () => {
-      const now = Date.UTC(2009, 0, 5, 13, 35, 3);
+      const now = Date.UTC(2009, 0, 5, 13, 35, 3); // 2009-01-05T13:35:03.000Z
       cy.clock(now);
       cy.get('main[class=main] section').eq(1).within(() => {
         cy.get('h3').should('have.text', 'Date and Time Range');
         cy.get('[data-cy=datetime-dropdown]').as('dateRange');
-        cy.get('@dateRange').select('Last week');
+        cy.get('@dateRange').select('1 week');
 
         cy.get('[data-cy=endDateTime]').within(() => {
           cy.get('.react-datetime-picker__inputGroup__year').should('have.value', '2009');
@@ -110,12 +110,12 @@ describe('Dashboard Home Page', () => {
     });
 
     it('should retain query parameters when moving between pages.', () => {
-      const now = Date.UTC(2015, 2, 17, 16, 0, 0);
+      const now = Date.UTC(2015, 2, 17, 16, 0, 0); // 2015-03-17T16:00:00.000Z
       cy.clock(now);
       cy.get('main[class=main] section').eq(1).within(() => {
         cy.get('h3').should('have.text', 'Date and Time Range');
         cy.get('[data-cy=datetime-dropdown]').as('dateRange');
-        cy.get('@dateRange').select('Last hour');
+        cy.get('@dateRange').select('1 hour');
 
         cy.url().should('include', 'startDateTime=201503171500');
         cy.url().should('include', 'endDateTime=201503171600');

--- a/test/reducers/datepicker.js
+++ b/test/reducers/datepicker.js
@@ -9,19 +9,24 @@ import {
   DATEPICKER_HOUR_FORMAT
 } from '../../app/src/js/actions/types';
 
+const secondsPerDay = 60 * 60 * 24;
+
 test('verify initial state', (t) => {
   const inputstate = { some: 'initialState' };
   const actual = reducer(inputstate, { data: {}, type: 'ANY' });
   t.deepEqual(actual, inputstate);
 });
 
-test('reducer sets initial state of all data on first run with no input', (t) => {
+test('reducer sets initial state to last 24 hours data on first initialization run.', (t) => {
+  const testStart = Date.now();
+  sinon.useFakeTimers(testStart);
   const actual = reducer(undefined, { type: 'ANY' });
-  t.is(actual.dateRange.label, 'All');
-  t.is(actual.dateRange.value, 'All');
-  t.is(actual.startDateTime, null);
-  t.is(actual.endDateTime, null);
+  t.is(actual.dateRange.label, 'Last 24 hours');
+  t.is(actual.dateRange.value, 1);
+  t.is(actual.startDateTime.valueOf(), (new Date(testStart - secondsPerDay * 1000)).valueOf());
+  t.is(actual.endDateTime.valueOf(), (new Date(testStart)).valueOf());
   t.is(actual.hourFormat, '12HR');
+  sinon.restore();
 });
 
 test('dropdown event sets the start and end time time to reflect the daterange.value in days', (t) => {
@@ -33,7 +38,7 @@ test('dropdown event sets the start and end time time to reflect the daterange.v
     data: { dateRange: { value, label: 'Last 130 Days' } }
   };
 
-  const actual = reducer(initialState, action);
+  const actual = reducer(initialState(), action);
   t.not(actual.startDateTime, null);
   t.not(actual.endDateTime, null);
   t.is(actual.dateRange.label, 'Last 130 Days');
@@ -43,10 +48,46 @@ test('dropdown event sets the start and end time time to reflect the daterange.v
   sinon.restore();
 });
 
+test('Dropdown set to "all" sets start time to unix epoch and end time to now.', (t) => {
+  const testNow = Date.now();
+  sinon.useFakeTimers(testNow);
+  const value = 'All';
+  const label = 'All';
+  const action = {
+    type: DATEPICKER_DROPDOWN_FILTER,
+    data: { dateRange: { value, label } }
+  };
+
+  const actual = reducer(initialState(), action);
+  t.is(actual.dateRange.label, 'All');
+  t.is(actual.dateRange.value, 'All');
+  t.is(actual.endDateTime.valueOf(), testNow);
+  t.is(actual.startDateTime.valueOf(), (new Date(0)).valueOf());
+  sinon.restore();
+});
+
+test('Dropdown set to "Custom" does not change any current state value.', (t) => {
+  const state = initialState();
+  state.startDateTime = new Date('2020-03-16T19:50:24.757Z');
+  state.endDateTime = new Date('2020-03-17T00:00:00.000Z');
+  const value = 'Custom';
+  const label = 'Custom';
+  const action = {
+    type: DATEPICKER_DROPDOWN_FILTER,
+    data: { dateRange: { value, label } }
+  };
+
+  const actual = reducer(state, action);
+  t.is(actual.dateRange.label, 'Custom');
+  t.is(actual.dateRange.value, 'Custom');
+  t.is(actual.endDateTime.valueOf(), state.endDateTime.valueOf());
+  t.is(actual.startDateTime.valueOf(), state.startDateTime.valueOf());
+});
+
 test('datechange event updates state', (t) => {
   const startDateTime = new Date('2000-01-15T12:50:01');
   const endDateTime = new Date('2013-12-10T10:00:00');
-  const state = { ...initialState };
+  const state = { ...initialState() };
   const action = {
     type: DATEPICKER_DATECHANGE,
     data: { startDateTime, endDateTime }
@@ -63,7 +104,7 @@ test('datechange event updates state', (t) => {
 });
 
 test('datepicker Hour format, updates state', (t) => {
-  const state = { ...initialState };
+  const state = { ...initialState() };
   const action = {
     type: DATEPICKER_HOUR_FORMAT,
     data: 'any string'

--- a/test/reducers/datepicker.js
+++ b/test/reducers/datepicker.js
@@ -3,14 +3,12 @@
 import test from 'ava';
 import sinon from 'sinon';
 import reducer, { initialState } from '../../app/src/js/reducers/datepicker';
-import { allDateRanges } from '../../app/src/js/utils/datepicker';
+import { allDateRanges, msPerDay } from '../../app/src/js/utils/datepicker';
 import {
   DATEPICKER_DATECHANGE,
   DATEPICKER_DROPDOWN_FILTER,
   DATEPICKER_HOUR_FORMAT
 } from '../../app/src/js/actions/types';
-
-const secondsPerDay = 60 * 60 * 24;
 
 test('verify initial state', (t) => {
   const inputstate = { some: 'initialState' };
@@ -24,7 +22,7 @@ test('reducer sets initial state to "Recent" on first initialization run.', (t) 
   const actual = reducer(undefined, { type: 'ANY' });
   t.is(actual.dateRange.label, 'Recent');
   t.is(actual.dateRange.value, 'Recent');
-  t.is(actual.startDateTime.valueOf(), (new Date(testStart - secondsPerDay * 1000)).valueOf());
+  t.is(actual.startDateTime.valueOf(), (new Date(testStart - msPerDay)).valueOf());
   t.is(actual.endDateTime, null);
   t.is(actual.hourFormat, '12HR');
   sinon.restore();
@@ -49,7 +47,7 @@ test('Dropdown: "Recent" sets start time to 24 hours ago and unsets end time.', 
 
   t.is(actual.dateRange.label, 'Recent');
   t.is(actual.dateRange.value, 'Recent');
-  t.is(actual.startDateTime.valueOf(), (new Date(testStart - secondsPerDay * 1000)).valueOf());
+  t.is(actual.startDateTime.valueOf(), (new Date(testStart - msPerDay)).valueOf());
   t.is(actual.endDateTime, null);
   sinon.restore();
 });

--- a/test/utils/datepicker.js
+++ b/test/utils/datepicker.js
@@ -6,17 +6,24 @@ import { fetchCurrentTimeFilters } from '../../app/src/js/utils/datepicker';
 
 import { initialState } from '../../app/src/js/reducers/datepicker';
 
+const testState = initialState();
+
 test('returns empty object if no start and end times provided', (t) => {
   const expected = {};
-  const actual = fetchCurrentTimeFilters(initialState);
+  let state = {...testState};
+  state.startDateTime = null;
+  state.endDateTime = null;
+
+  const actual = fetchCurrentTimeFilters(state);
   t.deepEqual(expected, actual);
 });
 
 test('creates object with "timestamp__to" if endDateTime time is provided.', (t) => {
-  const state = { ...initialState };
+  let state = { ...testState };
   const valueOfDate = 1582307006281;
   const endDateTime = new Date(valueOfDate);
   state.endDateTime = endDateTime;
+  state.startDateTime = null;
 
   const expected = { timestamp__to: valueOfDate };
 
@@ -25,9 +32,10 @@ test('creates object with "timestamp__to" if endDateTime time is provided.', (t)
 });
 
 test('creates an object with "timestamp__from" if startDateTime time is provided.', (t) => {
-  const state = { ...initialState };
+  let state = { ...testState };
   const valueOfDate = 1582307006281;
   const startDateTime = new Date(valueOfDate);
+  state.endDateTime = null;
   state.startDateTime = startDateTime;
 
   const expected = { timestamp__from: valueOfDate };
@@ -37,7 +45,7 @@ test('creates an object with "timestamp__from" if startDateTime time is provided
 });
 
 test('creates an object with both timestamp__from and timestamp__to if start and end dates are provided.', (t) => {
-  const state = { ...initialState };
+  const state = { ...initialState() };
   const valueOfStartDate = 1501907006251;
   const valueOfEndDate = 1582307006281;
 

--- a/test/utils/datepicker.js
+++ b/test/utils/datepicker.js
@@ -2,15 +2,20 @@
 
 import test from 'ava';
 
-import { fetchCurrentTimeFilters } from '../../app/src/js/utils/datepicker';
+import {
+  fetchCurrentTimeFilters,
+  dropdownValue,
+  allDateRanges,
+  secondsPerDay
+} from '../../app/src/js/utils/datepicker';
 
 import { initialState } from '../../app/src/js/reducers/datepicker';
 
 const testState = initialState();
 
-test('returns empty object if no start and end times provided', (t) => {
+test('fetchCurrentTimeFilters returns empty object if no start and end times provided', (t) => {
   const expected = {};
-  let state = {...testState};
+  let state = { ...testState };
   state.startDateTime = null;
   state.endDateTime = null;
 
@@ -18,7 +23,7 @@ test('returns empty object if no start and end times provided', (t) => {
   t.deepEqual(expected, actual);
 });
 
-test('creates object with "timestamp__to" if endDateTime time is provided.', (t) => {
+test('fetchCurrentTimeFilters creates object with "timestamp__to" if endDateTime time is provided.', (t) => {
   let state = { ...testState };
   const valueOfDate = 1582307006281;
   const endDateTime = new Date(valueOfDate);
@@ -31,7 +36,7 @@ test('creates object with "timestamp__to" if endDateTime time is provided.', (t)
   t.deepEqual(expected, actual);
 });
 
-test('creates an object with "timestamp__from" if startDateTime time is provided.', (t) => {
+test('fetchCurrentTimeFilters creates an object with "timestamp__from" if startDateTime time is provided.', (t) => {
   let state = { ...testState };
   const valueOfDate = 1582307006281;
   const startDateTime = new Date(valueOfDate);
@@ -44,7 +49,7 @@ test('creates an object with "timestamp__from" if startDateTime time is provided
   t.deepEqual(expected, actual);
 });
 
-test('creates an object with both timestamp__from and timestamp__to if start and end dates are provided.', (t) => {
+test('fetchCurrentTimeFilters creates an object with both timestamp__from and timestamp__to if start and end dates are provided.', (t) => {
   const state = { ...initialState() };
   const valueOfStartDate = 1501907006251;
   const valueOfEndDate = 1582307006281;
@@ -61,4 +66,39 @@ test('creates an object with both timestamp__from and timestamp__to if start and
 
   const actual = fetchCurrentTimeFilters(state);
   t.deepEqual(expected, actual);
+});
+
+test('dropdownValue returns the "Custom" value/label if object is missing a date.', (t) => {
+  const values = { startDateTime: new Date(Date.now()) };
+  const expected = allDateRanges.find((e) => e.value === 'Custom');
+  const actual = dropdownValue(values);
+  t.deepEqual(expected, actual);
+});
+
+test('dropdownValue returns the "Custom" value/label if datetimes do not match any dropdown values.', (t) => {
+  const values = {
+    startDateTime: new Date(Date.now()),
+    endDateTime: new Date(Date.now())
+  };
+  const expected = allDateRanges.find((e) => e.value === 'Custom');
+  const actual = dropdownValue(values);
+  t.deepEqual(expected, actual);
+});
+
+test('dropdownValue returns the correct value/label when datetimes match a dropdown value.', (t) => {
+  const testValues = [1 / 24, 1, 7, 30, 90, 180, 366];
+
+  testValues.forEach((testValue) => {
+    const endDateTime = new Date(Date.now());
+    const startDateTime = new Date(
+      endDateTime.valueOf() - testValue * secondsPerDay * 1000
+    );
+    const values = {
+      endDateTime,
+      startDateTime
+    };
+    const expected = allDateRanges.find((e) => e.value === testValue);
+    const actual = dropdownValue(values);
+    t.deepEqual(expected, actual);
+  });
 });

--- a/test/utils/datepicker.js
+++ b/test/utils/datepicker.js
@@ -6,7 +6,7 @@ import {
   fetchCurrentTimeFilters,
   dropdownValue,
   allDateRanges,
-  secondsPerDay
+  msPerDay
 } from '../../app/src/js/utils/datepicker';
 
 import { initialState } from '../../app/src/js/reducers/datepicker';
@@ -91,7 +91,7 @@ test('dropdownValue returns the correct value/label when datetimes match a dropd
   testValues.forEach((testValue) => {
     const endDateTime = new Date(Date.now());
     const startDateTime = new Date(
-      endDateTime.valueOf() - testValue * secondsPerDay * 1000
+      endDateTime.valueOf() - testValue * msPerDay
     );
     const values = {
       endDateTime,


### PR DESCRIPTION
This updates the functionality of the Datepicker and stats endpoints.

- Datepicker now defaults to "Recent" data when loading the dashboard.
- The Clear selection button resets both start and end datetimes and brings you to the "Custom" dropdown.
- URL params will load the correct dropdown values.
- tests added 