### PR TITLE
Switch eslint-loader to warnings.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "build": "NODE_ENV=production webpack --config webpack.prod.js",
     "watch": "webpack --watch",
     "lint": "eslint app/src/js/ --ext .js",
+    "lint-fix": "eslint --fix app/src/js/ --ext .js",
     "cypress": "LOCALSTACK_HOST=localhost LOCAL_ES_HOST=localhost CYPRESS_TESTING=true NODE_ENV=test cypress open",
     "cypress-ci": "LOCALSTACK_HOST=localhost LOCAL_ES_HOST=localhost CYPRESS_TESTING=true NODE_ENV=test cypress run --spec 'cypress/integration/*' --config video=true",
     "validate": "ava cypress/validation-tests/*.js",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -52,7 +52,10 @@ const CommonConfig = {
             }
           },
           {
-            loader: 'eslint-loader'
+            loader: 'eslint-loader',
+            options: {
+              emitWarning: true
+            }
           }
         ]
       },


### PR DESCRIPTION
We already have a lint to prevent badly linted code to production. So this will
save frustration during devlopment.

:raised hands: