### PR TITLE
Cumulus 1796 fix datepicker state dates

### DIFF
--- a/app/src/js/components/Datepicker/Datepicker.js
+++ b/app/src/js/components/Datepicker/Datepicker.js
@@ -1,7 +1,7 @@
 import isEmpty from 'lodash.isempty';
 import isNil from 'lodash.isnil';
 import moment from 'moment';
-import PropTypes from 'prop-types';
+import PropTypes, { string } from 'prop-types';
 import React from 'react';
 import DateTimePicker from 'react-datetime-picker';
 import { connect } from 'react-redux';
@@ -34,7 +34,7 @@ const updateDatepickerStateFromQueryParams = (props) => {
 
     for (const value in values) {
       if (urlDateProps.includes(value)) {
-        values[value] = moment.utc(values[value], urlDateFormat).toDate();
+        values[value] = moment.utc(values[value], urlDateFormat).valueOf();
       }
     }
 
@@ -106,7 +106,7 @@ class Datepicker extends React.PureComponent {
     // data as local time.  So we need convert the Date value to UTC.
     let utcValue = null;
     if (newValue !== null) {
-      utcValue = moment.utc(moment(newValue).format(dateTimeFormat)).toDate();
+      utcValue = moment.utc(moment(newValue).format(dateTimeFormat)).valueOf();
       if (isNaN(utcValue)) return;
     }
     const updatedProps = {
@@ -274,8 +274,8 @@ Datepicker.propTypes = {
     value: PropTypes.node,
     label: PropTypes.string
   }),
-  startDateTime: PropTypes.instanceOf(Date),
-  endDateTime: PropTypes.instanceOf(Date),
+  startDateTime: PropTypes.instanceOf(string),
+  endDateTime: PropTypes.instanceOf(string),
   hourFormat: PropTypes.oneOf(allHourFormats.map((a) => a.label)),
   queryParams: PropTypes.object,
   setQueryParams: PropTypes.func,

--- a/app/src/js/components/Datepicker/Datepicker.js
+++ b/app/src/js/components/Datepicker/Datepicker.js
@@ -1,7 +1,7 @@
 import isEmpty from 'lodash.isempty';
 import isNil from 'lodash.isnil';
 import moment from 'moment';
-import PropTypes, { string } from 'prop-types';
+import PropTypes, { number } from 'prop-types';
 import React from 'react';
 import DateTimePicker from 'react-datetime-picker';
 import { connect } from 'react-redux';
@@ -274,8 +274,8 @@ Datepicker.propTypes = {
     value: PropTypes.node,
     label: PropTypes.string
   }),
-  startDateTime: PropTypes.instanceOf(string),
-  endDateTime: PropTypes.instanceOf(string),
+  startDateTime: PropTypes.instanceOf(number),
+  endDateTime: PropTypes.instanceOf(number),
   hourFormat: PropTypes.oneOf(allHourFormats.map((a) => a.label)),
   queryParams: PropTypes.object,
   setQueryParams: PropTypes.func,

--- a/app/src/js/reducers/assign-date.js
+++ b/app/src/js/reducers/assign-date.js
@@ -1,6 +1,4 @@
 'use strict';
 export default function assignDate (object) {
-  return Object.assign({
-    queriedAt: new Date(Date.now())
-  }, object);
+  return Object.assign({ queriedAt: Date.now() }, object);
 }

--- a/app/src/js/reducers/datepicker.js
+++ b/app/src/js/reducers/datepicker.js
@@ -10,9 +10,9 @@ import { createReducer } from '@reduxjs/toolkit';
 
 // Also becomes default props for Datepicker
 export const initialState = () => {
-  const now = new Date(Date.now());
+  const now = Date.now();
   return {
-    startDateTime: new Date(now - msPerDay),
+    startDateTime: now - msPerDay,
     endDateTime: null,
     dateRange: allDateRanges.find((a) => a.value === 'Recent'),
     hourFormat: '12HR'
@@ -31,10 +31,8 @@ const computeDateTimeDelta = (timeDeltaInDays) => {
   let startDateTime = null;
 
   if (!isNaN(timeDeltaInDays)) {
-    endDateTime = new Date(Date.now());
-    startDateTime = new Date(
-      endDateTime - timeDeltaInDays * msPerDay
-    );
+    endDateTime = Date.now();
+    startDateTime = endDateTime - timeDeltaInDays * msPerDay;
   }
   return { startDateTime, endDateTime };
 };
@@ -46,7 +44,7 @@ const computeDateTimeDelta = (timeDeltaInDays) => {
 */
 const recentData = () => {
   const endDateTime = null;
-  const startDateTime = new Date(Date.now() - msPerDay);
+  const startDateTime = Date.now() - msPerDay;
   return {startDateTime, endDateTime, dateRange: allDateRanges.find((a) => a.value === 'Recent')};
 };
 

--- a/app/src/js/reducers/dist.js
+++ b/app/src/js/reducers/dist.js
@@ -38,7 +38,7 @@ export default createReducer(initialState, {
   [DIST_APIGATEWAY]: (state, action) => {
     set(state, 'apiGateway.error', null);
     set(state, 'apiGateway.inflight', false);
-    set(state, 'apiGateway.queriedAt', new Date(Date.now()));
+    set(state, 'apiGateway.queriedAt', Date.now());
     set(
       state,
       'apiGateway.access.errors',
@@ -70,7 +70,7 @@ export default createReducer(initialState, {
   [DIST_API_LAMBDA]: (state, action) => {
     set(state, 'apiLambda.error', null);
     set(state, 'apiLambda.inflight', false);
-    set(state, 'apiLambda.queriedAt', new Date(Date.now()));
+    set(state, 'apiLambda.queriedAt', Date.now());
     set(
       state,
       'apiLambda.errors',
@@ -92,7 +92,7 @@ export default createReducer(initialState, {
   [DIST_TEA_LAMBDA]: (state, action) => {
     set(state, 'teaLambda.error', null);
     set(state, 'teaLambda.inflight', false);
-    set(state, 'teaLambda.queriedAt', new Date(Date.now()));
+    set(state, 'teaLambda.queriedAt', Date.now());
     set(
       state,
       'teaLambda.errors',
@@ -114,7 +114,7 @@ export default createReducer(initialState, {
   [DIST_S3ACCESS]: (state, action) => {
     set(state, 's3Access.error', null);
     set(state, 's3Access.inflight', false);
-    set(state, 's3Access.queriedAt', new Date(Date.now()));
+    set(state, 's3Access.queriedAt', Date.now());
     set(
       state,
       's3Access.errors',

--- a/app/src/js/reducers/logs.js
+++ b/app/src/js/reducers/logs.js
@@ -28,7 +28,7 @@ export default createReducer(initialState, {
       set(state, 'items', items);
     }
     set(state, 'inflight', false);
-    set(state, 'queriedAt', new Date());
+    set(state, 'queriedAt', Date.now());
     set(state, 'error', false);
   },
   [LOGS_INFLIGHT]: (state, action) => {

--- a/app/src/js/reducers/workflows.js
+++ b/app/src/js/reducers/workflows.js
@@ -31,7 +31,7 @@ export default createReducer(initialState, {
     const { data } = action;
     set(state, 'map', createMap(data));
     set(state, ['list', 'data'], data);
-    set(state, ['list', 'meta'], { queriedAt: new Date() });
+    set(state, ['list', 'meta'], { queriedAt: Date.now() });
     set(state, ['list', 'inflight'], false);
     set(state, ['list', 'error'], false);
   },

--- a/app/src/js/utils/datepicker.js
+++ b/app/src/js/utils/datepicker.js
@@ -38,7 +38,7 @@ export const urlDateProps = matchObjects.map((o) => o.dateProp);
 export const dropdownValue = (values) => {
   let dropdownInfo = {value: 'Custom', label: 'Custom'};
   if (!!values.startDateTime && !!values.endDateTime) {
-    const durationDays = (values.endDateTime.valueOf() - values.startDateTime.valueOf()) / msPerDay;
+    const durationDays = (values.endDateTime - values.startDateTime) / msPerDay;
     dropdownInfo = allDateRanges.find((r) => r.value === durationDays) || dropdownInfo;
   }
   return dropdownInfo;
@@ -54,7 +54,7 @@ export const fetchCurrentTimeFilters = (datepicker) => {
   const filters = {};
   matchObjects.map((o) => {
     if (datepicker[o.dateProp] !== null) {
-      filters[`timestamp${o.filterProp}`] = datepicker[o.dateProp].valueOf();
+      filters[`timestamp${o.filterProp}`] = datepicker[o.dateProp];
     }
   });
   return filters;

--- a/app/src/js/utils/kibana.js
+++ b/app/src/js/utils/kibana.js
@@ -8,13 +8,13 @@ const formatKibanaDate = (datepicker = {}) => {
   let kibanaDate = '';
 
   if (startTime && endTime) {
-    kibanaDate = `from:'${startTime.toISOString()}',to:'${endTime.toISOString()}'`;
+    kibanaDate = `from:'${new Date(startTime).toISOString()}',to:'${new Date(endTime).toISOString()}'`;
   } else if (startTime && !endTime) {
-    kibanaDate = `from:'${startTime.toISOString()}',to:now`;
+    kibanaDate = `from:'${new Date(startTime).toISOString()}',to:now`;
   } else if (!startTime && endTime) {
     const calculatedStartTime = new Date(0);
 
-    kibanaDate = `from:'${calculatedStartTime.toISOString()}',to:'${endTime.toISOString()}'`;
+    kibanaDate = `from:'${calculatedStartTime.toISOString()}',to:'${new Date(endTime).toISOString()}'`;
   } else {
     kibanaDate = 'from:now-24h,mode:quick,to:now';
   }

--- a/test/actions/datefilters.js
+++ b/test/actions/datefilters.js
@@ -27,8 +27,8 @@ test('listGranules injects timestamps from datepicker state when calling the Cum
   const testState = { ...initialState };
   const startDateTime = new Date('2020-01-18T13:05:00.000Z');
   const endDateTime = new Date('2020-02-10T20:55:00.000Z');
-  testState.startDateTime = startDateTime;
-  testState.endDateTime = endDateTime;
+  testState.startDateTime = startDateTime.valueOf();
+  testState.endDateTime = endDateTime.valueOf();
 
   const store = mockStore({
     datepicker: testState

--- a/test/reducers/dist.js
+++ b/test/reducers/dist.js
@@ -2,9 +2,6 @@
 
 import test from 'ava';
 
-// import * as assignDateModule from '../../app/scripts/reducers/assign-date';
-// assignDateModule.default = (object) => Object.assign({}, object, {queriedAt: 'fakeTime'});
-
 import { apiGatewayFixture } from '../fixtures/apiGatewayMetrics';
 import { apiLambdaFixture } from '../fixtures/apiLambdaMetrics';
 import { teaLambdaFixture } from '../fixtures/teaLambdaMetrics';
@@ -52,7 +49,7 @@ test('reducers/dist/dist_apigateway', (t) => {
     apiGateway: {
       inflight: false,
       error: null,
-      queriedAt: new Date(Date.now()),
+      queriedAt: Date.now(),
       execution: {
         errors: 0,
         successes: 7
@@ -109,7 +106,7 @@ test('reducers/dist/dist_apilambda', (t) => {
     apiLambda: {
       inflight: false,
       error: null,
-      queriedAt: new Date(Date.now()),
+      queriedAt: Date.now(),
       errors: 10,
       successes: 4001
     }
@@ -169,7 +166,7 @@ test('reducers/dist/dist_tea_lambda', (t) => {
     teaLambda: {
       inflight: false,
       error: null,
-      queriedAt: new Date(Date.now()),
+      queriedAt: Date.now(),
       errors: 18,
       successes: 34301
     }
@@ -230,7 +227,7 @@ test('reducers/dist/dist_s3access', (t) => {
     s3Access: {
       inflight: false,
       error: null,
-      queriedAt: new Date(Date.now()),
+      queriedAt: Date.now(),
       errors: 1,
       successes: 200
     }

--- a/test/reducers/stats.js
+++ b/test/reducers/stats.js
@@ -32,7 +32,7 @@ test('stats', (t) => {
   const expected = {
     ...testState,
     stats: {
-      data: { ...data, queriedAt: new Date(testStart) },
+      data: { ...data, queriedAt: testStart },
       inflight: false,
       error: null
     }

--- a/test/utils/datepicker.js
+++ b/test/utils/datepicker.js
@@ -25,12 +25,11 @@ test('fetchCurrentTimeFilters returns empty object if no start and end times pro
 
 test('fetchCurrentTimeFilters creates object with "timestamp__to" if endDateTime time is provided.', (t) => {
   let state = { ...testState };
-  const valueOfDate = 1582307006281;
-  const endDateTime = valueOfDate;
-  state.endDateTime = endDateTime;
+  const valueOfEndDateTime = 1582307006281;
+  state.endDateTime = valueOfEndDateTime;
   state.startDateTime = null;
 
-  const expected = { timestamp__to: valueOfDate };
+  const expected = { timestamp__to: valueOfEndDateTime };
 
   const actual = fetchCurrentTimeFilters(state);
   t.deepEqual(expected, actual);
@@ -38,12 +37,11 @@ test('fetchCurrentTimeFilters creates object with "timestamp__to" if endDateTime
 
 test('fetchCurrentTimeFilters creates an object with "timestamp__from" if startDateTime time is provided.', (t) => {
   let state = { ...testState };
-  const valueOfDate = 1582307006281;
-  const startDateTime = valueOfDate;
+  const valueOfStartDateTime = 1582307006281;
   state.endDateTime = null;
-  state.startDateTime = startDateTime;
+  state.startDateTime = valueOfStartDateTime;
 
-  const expected = { timestamp__from: valueOfDate };
+  const expected = { timestamp__from: valueOfStartDateTime };
 
   const actual = fetchCurrentTimeFilters(state);
   t.deepEqual(expected, actual);
@@ -54,10 +52,8 @@ test('fetchCurrentTimeFilters creates an object with both timestamp__from and ti
   const valueOfStartDate = 1501907006251;
   const valueOfEndDate = 1582307006281;
 
-  const startDateTime = valueOfStartDate;
-  const endDateTime = valueOfEndDate;
-  state.startDateTime = startDateTime;
-  state.endDateTime = endDateTime;
+  state.startDateTime = valueOfStartDate;
+  state.endDateTime = valueOfEndDate;
 
   const expected = {
     timestamp__from: valueOfStartDate,

--- a/test/utils/datepicker.js
+++ b/test/utils/datepicker.js
@@ -26,7 +26,7 @@ test('fetchCurrentTimeFilters returns empty object if no start and end times pro
 test('fetchCurrentTimeFilters creates object with "timestamp__to" if endDateTime time is provided.', (t) => {
   let state = { ...testState };
   const valueOfDate = 1582307006281;
-  const endDateTime = new Date(valueOfDate);
+  const endDateTime = valueOfDate;
   state.endDateTime = endDateTime;
   state.startDateTime = null;
 
@@ -39,7 +39,7 @@ test('fetchCurrentTimeFilters creates object with "timestamp__to" if endDateTime
 test('fetchCurrentTimeFilters creates an object with "timestamp__from" if startDateTime time is provided.', (t) => {
   let state = { ...testState };
   const valueOfDate = 1582307006281;
-  const startDateTime = new Date(valueOfDate);
+  const startDateTime = valueOfDate;
   state.endDateTime = null;
   state.startDateTime = startDateTime;
 
@@ -54,8 +54,8 @@ test('fetchCurrentTimeFilters creates an object with both timestamp__from and ti
   const valueOfStartDate = 1501907006251;
   const valueOfEndDate = 1582307006281;
 
-  const startDateTime = new Date(valueOfStartDate);
-  const endDateTime = new Date(valueOfEndDate);
+  const startDateTime = valueOfStartDate;
+  const endDateTime = valueOfEndDate;
   state.startDateTime = startDateTime;
   state.endDateTime = endDateTime;
 
@@ -69,7 +69,7 @@ test('fetchCurrentTimeFilters creates an object with both timestamp__from and ti
 });
 
 test('dropdownValue returns the "Custom" value/label if object is missing a date.', (t) => {
-  const values = { startDateTime: new Date(Date.now()) };
+  const values = { startDateTime: Date.now() };
   const expected = allDateRanges.find((e) => e.value === 'Custom');
   const actual = dropdownValue(values);
   t.deepEqual(expected, actual);
@@ -77,8 +77,8 @@ test('dropdownValue returns the "Custom" value/label if object is missing a date
 
 test('dropdownValue returns the "Custom" value/label if datetimes do not match any dropdown values.', (t) => {
   const values = {
-    startDateTime: new Date(Date.now()),
-    endDateTime: new Date(Date.now())
+    startDateTime: Date.now(),
+    endDateTime: Date.now()
   };
   const expected = allDateRanges.find((e) => e.value === 'Custom');
   const actual = dropdownValue(values);
@@ -89,10 +89,9 @@ test('dropdownValue returns the correct value/label when datetimes match a dropd
   const testValues = [1 / 24, 1, 7, 30, 90, 180, 366];
 
   testValues.forEach((testValue) => {
-    const endDateTime = new Date(Date.now());
-    const startDateTime = new Date(
-      endDateTime.valueOf() - testValue * msPerDay
-    );
+    const endDateTime = Date.now();
+    const startDateTime = endDateTime - testValue * msPerDay;
+
     const values = {
       endDateTime,
       startDateTime

--- a/test/utils/kibana.js
+++ b/test/utils/kibana.js
@@ -36,8 +36,8 @@ test('Kibana links will return a range for the last 24 hours when no time is pro
 
 test('Kibana links will return a range with start date and end date when both are provided', function (t) {
   const datepicker = {
-    startDateTime: new Date(startDateString),
-    endDateTime: new Date(endDateString)
+    startDateTime: new Date(startDateString).valueOf(),
+    endDateTime: new Date(endDateString).valueOf()
   };
   const expectedRegEx = /from:'2020-02-20T17:43:26.281Z',to:'2020-02-21T17:43:26.281Z'/;
 
@@ -47,7 +47,7 @@ test('Kibana links will return a range with start date and end date when both ar
 
 test('Kibana links will return a range of start time to now when only start time is provided', function (t) {
   const datepicker = {
-    startDateTime: new Date(startDateString)
+    startDateTime: new Date(startDateString).valueOf()
   };
   const expectedRegEx = /from:'2020-02-20T17:43:26.281Z',to:now/;
 
@@ -57,7 +57,7 @@ test('Kibana links will return a range of start time to now when only start time
 
 test('Kibana links will return a range from Jan 1, 1970 until the end time when just end time is provided', function (t) {
   const datepicker = {
-    endDateTime: new Date(endDateString)
+    endDateTime: new Date(endDateString).valueOf()
   };
   const expectedRegEx = /from:'1970-01-01T00:00:00.000Z',to:'2020-02-21T17:43:26.281Z'/;
 


### PR DESCRIPTION
Changes application state from Date Objects to Numbers that represent milliseconds since the Unix Epoch. Jan 1 1970, the value that is given by Date.now().  Or (new Date()).valueOf().