### PR TITLE
Fix selector in spec to remove wait().

### DIFF
--- a/cypress/integration/granules_spec.js
+++ b/cypress/integration/granules_spec.js
@@ -173,8 +173,7 @@ describe('Dashboard Granules Page', () => {
       cy.get('.filter__item').eq(3).as('page-size-input');
       cy.get('@page-size-input').should('be.visible').click().type('10{enter}');
       cy.url().should('include', 'limit=10');
-      cy.wait(500);
-      cy.get('.table .tbody .tr').its('length').should('be.eq', 10);
+      cy.get('.table .tbody .tr').should('have.length', 10);
       cy.get('.pagination ol li')
         .first().contains('li', 'Previous')
         .next().contains('li', '1')


### PR DESCRIPTION
I'm pretty certain, this link below is describing a bunch of problems we're
having.  I have been unable to recreate the failed test since switching the get
selector.

Everyone should read this whole thing, but the TL;DR:

"For a variety of implementation reasons, Cypress commands only retry the last
command before the assertion."

https://docs.cypress.io/guides/core-concepts/retry-ability.html#Only-the-last-command-is-retried