### PR TITLE
Quick work around for rules input bug.

### DIFF
--- a/cypress/integration/rules_spec.js
+++ b/cypress/integration/rules_spec.js
@@ -106,44 +106,47 @@ describe('Rules page', () => {
       const collection = getCollectionId({ name: 'MOD09GQ', version: '006' });
 
       // Fill the form and submit
+      // mhs: I think we're seeing https://www.cypress.io/blog/2018/02/05/when-can-the-test-start/
+      // Typing into a form that's not ready. (https://github.com/cypress-io/cypress/issues/3817)
       cy.get('form div ul').as('ruleInput');
       cy.get('@ruleInput')
         .contains('name', { matchCase: false })
         .siblings('input')
+        .wait(500)
         .type(ruleName);
       cy.get('@ruleInput')
         .contains('.dropdown__label', 'workflow', { matchCase: false })
         .siblings()
         .find('select')
-        .select(workflow, { force: true })
+        .select(workflow)
         .should('have.value', workflow);
       cy.get('@ruleInput')
         .contains('.dropdown__label', 'provider', { matchCase: false })
         .siblings()
         .find('select')
-        .select(provider, { force: true })
+        .select(provider)
         .should('have.value', provider);
       cy.get('@ruleInput')
         .contains('.dropdown__label', 'collection', { matchCase: false })
         .siblings()
         .find('select')
-        .select(collection, { force: true })
+        .select(collection)
         .should('have.value', collection);
       cy.get('@ruleInput')
         .contains('.dropdown__label', 'type', { matchCase: false })
         .siblings()
         .find('select')
-        .select('onetime', { force: true })
+        .select('onetime')
         .should('have.value', 'onetime');
       cy.get('@ruleInput')
         .contains('.dropdown__label', 'state', { matchCase: false })
         .siblings()
         .find('select')
-        .select('ENABLED', { force: true })
+        .select('ENABLED')
         .should('have.value', 'ENABLED');
 
       cy.contains('form button', 'Submit').click();
-
+      cy.url().should('include', 'rule/newRule');
       cy.contains('.heading--xlarge', 'Rules');
       cy.contains('.heading--large', ruleName);
       cy.contains('.heading--medium', 'Rule Overview');


### PR DESCRIPTION
So I'm pretty convinced we are typing in the input field before it's ready to type.  

I found this looking for the bug and 
https://www.cypress.io/blog/2018/02/05/when-can-the-test-start/

I'd like to eventually try to implement spying on the dom as suggested in the article, but this seems to stop the bleeding.  I left comments in the spec pointing to the bug and the above article so we can come back to this sometime.

You can see in the image on the failed test. the rule name is `ewRule` 
![Screen Shot 2020-04-05 at 11 35 37 AM](https://user-images.githubusercontent.com/479480/78505600-bf037880-7731-11ea-8b1c-663d63f341cf.png)
