### PR TITLE
[CUMULUS-1537] View and download execution output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- **CUMULUS-1537**
+  - Update execution details page format
+  - Move execution input and output json to modal
+
 - **CUMULUS-1798**
   - Change the 12HR/24HR Format selector from radio to dropdown
   - Hide clock component in react-datetime-picker

--- a/app/src/css/modules/_modals.scss
+++ b/app/src/css/modules/_modals.scss
@@ -94,25 +94,6 @@
 }
 
 .default-modal {
-  &.bulk_granules {
-    &.modal-dialog {
-      overflow-y: initial !important;
-      max-height:85%;  
-      margin-top: 50px; 
-      margin-bottom:50px;
-      max-width: 750px;
-    }
-
-    .modal-body {
-      height: 425px;
-      overflow-y: auto;
-    }
-
-    .button__arrow--md:hover:after {
-      left: 85%;
-    }
-  }
-
   .modal-body {
     text-align: center;
 
@@ -132,6 +113,38 @@
 
     .dropdown__wrapper {
       float: none;
+    }
+  }
+
+  &.bulk_granules {
+    &.modal-dialog {
+      overflow-y: initial !important;
+      max-height:85%;  
+      margin-top: 50px; 
+      margin-bottom:50px;
+      max-width: 750px;
+    }
+
+    .modal-body {
+      height: 425px;
+      overflow-y: auto;
+    }
+
+    .button__arrow--md:hover:after {
+      left: 85%;
+    }
+  }
+
+  &.execution--modal {
+    max-width: 80%;
+
+    .modal-body {
+      text-align: left;
+
+      pre {
+        /* placeholder border to define pre region */
+        border: 1px solid gray;
+      }
     }
   }
 }

--- a/app/src/js/components/Executions/execution-status.js
+++ b/app/src/js/components/Executions/execution-status.js
@@ -17,11 +17,11 @@ import ErrorReport from '../Errors/report';
 import ExecutionStatusGraph from './execution-status-graph';
 import { getEventDetails } from './execution-graph-utils';
 import SortableTable from '../SortableTable/SortableTable';
+import Metadata from '../Table/Metadata';
 
 class ExecutionStatus extends React.Component {
   constructor () {
     super();
-    this.displayName = 'Execution';
     this.navigateBack = this.navigateBack.bind(this);
     this.errors = this.errors.bind(this);
     this.renderEvents = this.renderEvents.bind(this);
@@ -66,51 +66,110 @@ class ExecutionStatus extends React.Component {
 
   render () {
     const { executionStatus, cumulusInstance } = this.props;
-    if (!executionStatus.execution) return null;
-
-    const input = (executionStatus.execution.input)
-      ? <dd>
-        <Collapse trigger={'Show Input'} triggerWhenOpen={'Hide Input'}>
-          <pre>{parseJson(executionStatus.execution.input)}</pre>
-        </Collapse>
-      </dd>
-      : <dd>N/A</dd>;
-
-    let output, outputJson, asyncOperationId;
-    if (executionStatus.execution.output) {
-      outputJson = JSON.parse(executionStatus.execution.output, null, 2);
-      output = (executionStatus.execution.output)
-        ? <dd>
-          <Collapse trigger={'Show Output'} triggerWhenOpen={'Hide Output'}>
-            <pre>{parseJson(executionStatus.execution.output)}</pre>
-          </Collapse>
-        </dd>
-        : <dd>N/A</dd>;
-      asyncOperationId = get(outputJson.cumulus_meta, 'asyncOperationId');
-    }
-    let parentARN;
-    if (executionStatus.execution.input) {
-      const input = JSON.parse(executionStatus.execution.input);
-      const parent = get(input.cumulus_meta, 'parentExecutionArn');
-      if (parent) {
-        parentARN = <dd><Link to={'/executions/execution/' + parent} title={parent}>{parent}</Link></dd>;
-      } else {
-        parentARN = <dd>N/A</dd>;
-      }
-    } else {
-      parentARN = <dd>N/A</dd>;
-    }
+    const { execution } = executionStatus;
+    if (!execution) return null;
 
     const errors = this.errors();
 
-    const kibanaLink = kibanaExecutionLink(cumulusInstance, executionStatus.execution.name);
-
-    let logsLink;
-    if (kibanaLink && kibanaLink.length) {
-      logsLink = <dd><a href={kibanaLink} target="_blank">View Logs in Kibana</a></dd>;
-    } else {
-      logsLink = <dd><Link to={'/executions/execution/' + executionStatus.execution.name + '/logs'} title={executionStatus.execution.name + '/logs'}>View Execution Logs</Link></dd>;
-    }
+    const metaAccessors = [
+      {
+        label: 'Execution Status',
+        property: 'status',
+        accessor: displayCase
+      },
+      {
+        label: 'Execution Arn',
+        property: 'executionArn'
+      },
+      {
+        label: 'State Machine Arn',
+        property: 'stateMachineArn'
+      },
+      {
+        label: 'Async Operation ID',
+        property: 'output',
+        accessor: d => {
+          const outputJson = JSON.parse(d);
+          return get(outputJson.cumulus_meta, 'asyncOperationId');
+        }
+      },
+      {
+        label: 'Started',
+        property: 'startDate',
+        accessor: fullDate
+      },
+      {
+        label: 'Ended',
+        property: 'endDate',
+        accessor: fullDate
+      },
+      {
+        label: 'Parent Workflow Exectuion',
+        property: 'input',
+        accessor: d => {
+          if (!d) return 'N/A';
+          const input = JSON.parse(d);
+          const parent = get(input.cumulus_meta, 'parentExecutionArn');
+          if (parent) {
+            return <Link to={'/executions/execution/' + parent} title={parent}>{parent}</Link>;
+          } else {
+            return 'N/A';
+          }
+        }
+      },
+      {
+        label: 'Input',
+        property: 'input',
+        accessor: d => {
+          if (d) {
+            const trigger = <a href='#'>Show Input</a>;
+            const triggerWhenOpen = <a href='#'>Hide Input</a>;
+            return (
+              <Collapse trigger={trigger} triggerWhenOpen={triggerWhenOpen}>
+                <pre>{parseJson(d)}</pre>
+              </Collapse>
+            );
+          } else {
+            return 'N/A';
+          }
+        }
+      },
+      {
+        label: 'Output',
+        property: 'output',
+        accessor: d => {
+          if (d) {
+            const trigger = <a href='#'>Show Output</a>;
+            const triggerWhenOpen = <a href='#'>Hide Output</a>;
+            const jsonData = new Blob([d], { type: 'text/json' });
+            return (
+              <Collapse trigger={trigger} triggerWhenOpen={triggerWhenOpen}>
+                <a className='button button--small button--download button--green form-group__element--right'
+                  id='download_link'
+                  download='output.json'
+                  href={window.URL.createObjectURL(jsonData)}
+                >Download Output</a>
+                <pre>{parseJson(d)}</pre>
+              </Collapse>
+            );
+          } else {
+            return 'N/A';
+          }
+        }
+      },
+      {
+        label: 'Logs',
+        property: 'name',
+        accessor: d => {
+          const kibanaLink = kibanaExecutionLink(cumulusInstance, d);
+          if (kibanaLink && kibanaLink.length) {
+            return <a href={kibanaLink} target="_blank">View Logs in Kibana</a>;
+          } else {
+            return <Link to={'/executions/execution/' + d + '/logs'} title={d + '/logs'}>View Execution Logs</Link>;
+          }
+        }
+      }
+    ];
 
     return (
       <div className='page__component'>
@@ -125,7 +184,7 @@ class ExecutionStatus extends React.Component {
         {/* stateMachine's definition and executionHistory's event statuses are needed to draw the graph */}
         {
           (executionStatus.stateMachine && executionStatus.executionHistory)
-            ? <section className='page__section width--half' style={{ display: 'inline-block', marginRight: '5%' }}>
+            ? <section className='page__section'>
               <div className='heading__wrapper--border'>
                 <h2 className='heading--medium with-description'>Visual workflow</h2>
               </div>
@@ -135,48 +194,13 @@ class ExecutionStatus extends React.Component {
             : null
         }
 
-        <section className='page__section width--half' style={{ display: 'inline-block', verticalAlign: 'top' }}>
+        <section className='page__section'>
           <div className='heading__wrapper--border'>
             <h2 className='heading--medium with-description'>Execution Details</h2>
           </div>
-
-          <dl className='status--process'>
-            <dt>Execution Status:</dt>
-            <dd>{displayCase(executionStatus.execution.status)}</dd><br />
-
-            <dt>Execution Arn:</dt>
-            <dd>{executionStatus.execution.executionArn}</dd><br />
-
-            <dt>State Machine Arn:</dt>
-            <dd>{executionStatus.execution.stateMachineArn}</dd><br />
-
-            { asyncOperationId ? (<div>
-              <dt>Async Operation ID</dt>
-              <dd>{asyncOperationId}</dd>
-            </div>) : null }
-
-            <dt>Started:</dt>
-            <dd>{fullDate(executionStatus.execution.startDate)}</dd><br />
-
-            <dt>Ended:</dt>
-            <dd>{fullDate(executionStatus.execution.stopDate)}</dd><br />
-
-            <dt>Parent Workflow Execution</dt>
-            {parentARN}
-            <br />
-
-            <dt>Input:</dt>
-            {input}
-            <br />
-
-            <dt>Output:</dt>
-            {output}
-            <br />
-
-            <dt>Logs:</dt>
-            {logsLink}
-            <br />
-          </dl>
+          <div className='execution__content'>
+            <Metadata data={executionStatus.execution} accessors={metaAccessors} />
+          </div>
         </section>
 
         {(executionStatus.executionHistory)
@@ -204,6 +228,8 @@ ExecutionStatus.propTypes = {
   cumulusInstance: PropTypes.object,
   history: PropTypes.object
 };
+
+ExecutionStatus.displayName = 'Execution';
 
 export { ExecutionStatus };
 

--- a/app/src/js/components/Executions/execution-status.js
+++ b/app/src/js/components/Executions/execution-status.js
@@ -1,6 +1,5 @@
 'use strict';
 import React from 'react';
-import Collapse from 'react-collapsible';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import get from 'lodash.get';
@@ -18,6 +17,7 @@ import ExecutionStatusGraph from './execution-status-graph';
 import { getEventDetails } from './execution-graph-utils';
 import SortableTable from '../SortableTable/SortableTable';
 import Metadata from '../Table/Metadata';
+import DefaultModal from '../Modal/modal';
 
 class ExecutionStatus extends React.Component {
   constructor () {
@@ -25,6 +25,12 @@ class ExecutionStatus extends React.Component {
     this.navigateBack = this.navigateBack.bind(this);
     this.errors = this.errors.bind(this);
     this.renderEvents = this.renderEvents.bind(this);
+    this.openModal = this.openModal.bind(this);
+    this.closeModal = this.closeModal.bind(this);
+    this.state = {
+      showInputModal: false,
+      showOutputModal: false
+    };
   }
 
   componentDidMount () {
@@ -41,6 +47,26 @@ class ExecutionStatus extends React.Component {
 
   errors () {
     return [].filter(Boolean);
+  }
+
+  openModal (type) {
+    switch (type) {
+      case 'input':
+        this.setState({ showInputModal: true });
+        break;
+      case 'output':
+        this.setState({ showOutputModal: true });
+    }
+  }
+
+  closeModal (type) {
+    switch (type) {
+      case 'input':
+        this.setState({ showInputModal: false });
+        break;
+      case 'output':
+        this.setState({ showOutputModal: false });
+    }
   }
 
   renderEvents () {
@@ -65,6 +91,7 @@ class ExecutionStatus extends React.Component {
   }
 
   render () {
+    const { showInputModal, showOutputModal } = this.state;
     const { executionStatus, cumulusInstance } = this.props;
     const { execution } = executionStatus;
     if (!execution) return null;
@@ -122,12 +149,24 @@ class ExecutionStatus extends React.Component {
         property: 'input',
         accessor: d => {
           if (d) {
-            const trigger = <a href='#'>Show Input</a>;
-            const triggerWhenOpen = <a href='#'>Hide Input</a>;
             return (
-              <Collapse trigger={trigger} triggerWhenOpen={triggerWhenOpen}>
-                <pre>{parseJson(d)}</pre>
-              </Collapse>
+              <>
+                <button
+                  onClick={() => this.openModal('input')}
+                  className='button button--small'
+                >Show Input</button>
+                <DefaultModal
+                  showModal={showInputModal}
+                  title='Execution Input'
+                  onCloseModal={() => this.closeModal('input')}
+                  hasConfirmButton={false}
+                  cancelButtonClass='button--close'
+                  cancelButtonText='Close'
+                  className='execution--modal'
+                >
+                  <pre>{parseJson(d)}</pre>
+                </DefaultModal>
+              </>
             );
           } else {
             return 'N/A';
@@ -139,18 +178,30 @@ class ExecutionStatus extends React.Component {
         property: 'output',
         accessor: d => {
           if (d) {
-            const trigger = <a href='#'>Show Output</a>;
-            const triggerWhenOpen = <a href='#'>Hide Output</a>;
             const jsonData = new Blob([d], { type: 'text/json' });
             return (
-              <Collapse trigger={trigger} triggerWhenOpen={triggerWhenOpen}>
-                <a className='button button--small button--download button--green form-group__element--right'
-                  id='download_link'
-                  download='output.json'
-                  href={window.URL.createObjectURL(jsonData)}
-                >Download Output</a>
-                <pre>{parseJson(d)}</pre>
-              </Collapse>
+              <>
+                <button
+                  onClick={() => this.openModal('output')}
+                  className='button button--small'
+                >Show Output</button>
+                <DefaultModal
+                  showModal={showOutputModal}
+                  title='Execution Output'
+                  onCloseModal={() => this.closeModal('output')}
+                  hasConfirmButton={false}
+                  cancelButtonClass='button--close'
+                  cancelButtonText='Close'
+                  className='execution--modal'
+                >
+                  <a className='button button--small button--download button--green'
+                    id='download_link'
+                    download='output.json'
+                    href={window.URL.createObjectURL(jsonData)}
+                  >Download File</a>
+                  <pre>{parseJson(d)}</pre>
+                </DefaultModal>
+              </>
             );
           } else {
             return 'N/A';

--- a/app/src/js/components/Executions/execution-status.js
+++ b/app/src/js/components/Executions/execution-status.js
@@ -127,7 +127,7 @@ class ExecutionStatus extends React.Component {
       },
       {
         label: 'Ended',
-        property: 'endDate',
+        property: 'stopDate',
         accessor: fullDate
       },
       {
@@ -249,7 +249,7 @@ class ExecutionStatus extends React.Component {
           <div className='heading__wrapper--border'>
             <h2 className='heading--medium with-description'>Execution Details</h2>
           </div>
-          <div className='execution__content'>
+          <div className='execution__content status--process'>
             <Metadata data={executionStatus.execution} accessors={metaAccessors} />
           </div>
         </section>

--- a/app/src/js/components/Form/_form.scss
+++ b/app/src/js/components/Form/_form.scss
@@ -516,24 +516,39 @@ select option{
     flex: 12;
 }
 
-.rule__content {
+.rule__content,
+.execution__content {
   border: 1px solid #eceaea;
   box-shadow: $shadow__default;
   border-radius: 10px;
   padding: 25px 40px;
   margin-top: 15px;
+
+  .metadata__details {
+    font-size: $base-font-size;
+    display: flex;
+    flex-direction: column;
+
+    .meta__row {
+      flex-direction: row;
+      dt{
+        width: 10%;
+      }
+    }
+  }
 }
 
-.rule__content .metadata__details {
-  font-size: $base-font-size;
-  display: flex;
-  flex-direction: column;
-}
+.execution__content {
 
-.rule__content .metadata__details .meta__row {
-  flex-direction: row;
-}
+  .metadata__details .meta__row {
+    dd {
+      width: 80%;
+      margin: 0;
+    }
 
-.rule__content .metadata__details dt{
-  width: 10%;
+    dt {
+      width: 20%;
+      padding: 0;
+    }
+  }
 }

--- a/app/src/js/components/Granules/granule.js
+++ b/app/src/js/components/Granules/granule.js
@@ -63,14 +63,46 @@ const tableColumns = [
 ];
 
 const metaAccessors = [
-  ['PDR Name', 'pdrName', pdrLink],
-  ['Collection', 'collectionId', collectionLink],
-  ['Provider', 'provider', providerLink],
-  [`${strings.cmr} Link`, 'cmrLink', (d) => d ? <a href={d} target='_blank'>Link</a> : nullValue],
-  ['Execution', 'execution', (d) => d ? <Link to={`/executions/execution/${path.basename(d)}`}>link</Link> : nullValue],
-  ['Published', 'published', bool],
-  ['Duplicate', 'hasDuplicate', bool],
-  ['Total duration', 'duration', seconds]
+  {
+    label: 'PDR Name',
+    property: 'pdrName',
+    accessor: pdrLink
+  },
+  {
+    label: 'Collection',
+    property: 'collectionId',
+    accessor: collectionLink
+  },
+  {
+    label: 'Provider',
+    property: 'provider',
+    accessor: providerLink
+  },
+  {
+    label: `${strings.cmr} Link`,
+    property: 'cmrLink',
+    accesssor: (d) => d ? <a href={d} target='_blank'>Link</a> : nullValue
+  },
+  {
+    label: 'Execution',
+    property: 'execution',
+    accessor: (d) => d ? <Link to={`/executions/execution/${path.basename(d)}`}>link</Link> : nullValue
+  },
+  {
+    label: 'Published',
+    property: 'published',
+    accessor: bool
+  },
+  {
+    label: 'Duplicate',
+    property: 'hasDuplicate',
+    accessor: bool
+  },
+  {
+    label: 'Total duration',
+    property: 'duration',
+    accessor: seconds
+  }
 ];
 
 class GranuleOverview extends React.Component {

--- a/app/src/js/components/Pdr/pdr.js
+++ b/app/src/js/components/Pdr/pdr.js
@@ -46,15 +46,50 @@ import ListFilters from '../ListActions/ListFilters';
 const { updateInterval } = _config;
 
 const metaAccessors = [
-  ['Provider', 'provider', (d) => <Link to={`providers/provider/${d}`}>{d}</Link>],
-  [strings.collection, 'collectionId', collectionLink],
-  ['Execution', 'execution', (d) => d ? <Link to={`/executions/execution/${path.basename(d)}`}>link</Link> : nullValue],
-  ['Status', 'status', displayCase],
-  ['Timestamp', 'timestamp', fullDate],
-  ['Created at', 'createdAt', fullDate],
-  ['Duration', 'duration', seconds],
-  ['PAN Sent', 'PANSent', bool],
-  ['PAN Message', 'PANmessage']
+  {
+    label: 'Provider',
+    property: 'provider',
+    accessor: (d) => <Link to={`providers/provider/${d}`}>{d}</Link>
+  },
+  {
+    label: strings.collection,
+    property: 'collectionId',
+    accessor: collectionLink
+  },
+  {
+    label: 'Execution',
+    property: 'execution',
+    accessor: (d) => d ? <Link to={`/executions/execution/${path.basename(d)}`}>link</Link> : nullValue
+  },
+  {
+    label: 'Status',
+    property: 'status',
+    accessor: displayCase
+  },
+  {
+    label: 'Timestamp',
+    property: 'timestamp',
+    accessor: fullDate
+  },
+  {
+    label: 'Created at',
+    property: 'createdAt',
+    accessor: fullDate
+  },
+  {
+    label: 'Duration',
+    property: 'duration',
+    accessor: seconds
+  },
+  {
+    label: 'PAN Sent',
+    property: 'PANSent',
+    accessor: bool
+  },
+  {
+    label: 'PAN Message',
+    property: 'PANmessage'
+  }
 ];
 
 class PDR extends React.Component {

--- a/app/src/js/components/Providers/provider.js
+++ b/app/src/js/components/Providers/provider.js
@@ -27,11 +27,30 @@ import _config from '../../config';
 const { updateInterval } = _config;
 
 const metaAccessors = [
-  ['Created', 'createdAt', fromNow],
-  ['Updated', 'updatedAt', fromNow],
-  ['Protocol', 'protocol'],
-  ['Host', 'host', link],
-  ['Global Connection Limit', 'globalConnectionLimit', tally]
+  {
+    label: 'Created',
+    property: 'createdAt',
+    accessor: fromNow
+  },
+  {
+    label: 'Updated',
+    property: 'updatedAt',
+    accessor: fromNow
+  },
+  {
+    label: 'Protocol',
+    property: 'protocol'
+  },
+  {
+    label: 'Host',
+    property: 'host',
+    accessor: link
+  },
+  {
+    label: 'Global Connection Limit',
+    property: 'globalConnectionLimit',
+    accessor: tally
+  }
 ];
 
 class ProviderOverview extends React.Component {

--- a/app/src/js/components/ReconciliationReports/reconciliation-report.js
+++ b/app/src/js/components/ReconciliationReports/reconciliation-report.js
@@ -28,12 +28,12 @@ import ReportTable from './report-table';
 const { updateInterval } = _config;
 
 const reportMetaAccessors = [
-  ['Created', 'reportStartTime'],
-  ['Status', 'status'],
-  ['Files in DynamoDB and S3', 'filesInCumulus.okCount'],
-  ['Collections in Cumulus and CMR', 'collectionsInCumulusCmr.okCount'],
-  ['Granules in Cumulus and CMR', 'granulesInCumulusCmr.okCount'],
-  ['Granule files in Cumulus and CMR', 'filesInCumulusCmr.okCount']
+  { label: 'Created', property: 'reportStartTime' },
+  { label: 'Status', property: 'status' },
+  { label: 'Files in DynamoDB and S3', property: 'filesInCumulus.okCount' },
+  { label: 'Collections in Cumulus and CMR', property: 'collectionsInCumulusCmr.okCount' },
+  { label: 'Granules in Cumulus and CMR', property: 'granulesInCumulusCmr.okCount' },
+  { label: 'Granule files in Cumulus and CMR', property: 'filesInCumulusCmr.okCount' }
 ];
 
 const parseFileObject = (d) => {

--- a/app/src/js/components/Rules/rule.js
+++ b/app/src/js/components/Rules/rule.js
@@ -45,13 +45,13 @@ const breadcrumbConfig = [
 ];
 
 const metaAccessors = [
-  ['Rule Name', 'name'],
-  ['Timestamp', 'timestamp', fullDate],
-  ['Workflow', 'workflow'],
-  ['Provider', 'provider', providerLink],
-  ['Provider Path', 'provider_path'],
-  ['Rule Type', 'rule.type'],
-  // PGC ['Collection', 'collection', d => collectionLink(getCollectionId(d))],  /* Why was this commented out? */
+  { label: 'Rule Name', property: 'name' },
+  { label: 'Timestamp', property: 'timestamp', accessor: fullDate },
+  { label: 'Workflow', property: 'workflow' },
+  { label: 'Provider', property: 'provider', accessor: providerLink },
+  { label: 'Provider Path', property: 'provider_path' },
+  { label: 'Rule Type', property: 'rule.type' },
+  // PGC { label: 'Collection', property: 'collection', accessor: d => collectionLink(getCollectionId(d)) },  /* Why was this commented out? */
 ];
 
 class Rule extends React.Component {

--- a/app/src/js/components/Table/Metadata.js
+++ b/app/src/js/components/Table/Metadata.js
@@ -4,27 +4,30 @@ import PropTypes from 'prop-types';
 import { get } from 'object-path';
 import { nullValue } from '../../utils/format';
 
-class Metadata extends React.Component {
-  render () {
-    const { data, accessors } = this.props;
-    return (
-      <dl className='metadata__details'>
-        {accessors.reduce((acc, meta) => {
-          let value = get(data, meta[1]);
-          if (value !== nullValue && typeof meta[2] === 'function') {
-            value = meta[2](value);
-          }
-          return acc.concat([
-            <div className="meta__row">
-              <dt key={`meta-${meta[1]}--dt`}>{meta[0]}</dt>
-              <dd key={`meta-${meta[1]}--dd`}>{value}</dd>
-            </div>
-          ]);
-        }, [])}
-      </dl>
-    );
-  }
-}
+const Metadata = ({
+  data,
+  accessors
+}) => {
+  return (
+    <dl className='metadata__details'>
+      {accessors.map((item, index) => {
+        const { label, property, accessor } = item;
+        let value = get(data, property);
+        if (value !== nullValue && typeof accessor === 'function') {
+          value = accessor(value, data);
+        }
+        return (
+          <React.Fragment key={index}>
+            {value && <div className="meta__row">
+              <dt key={`meta-${property}--dt`}>{label}</dt>
+              <dd key={`meta-${property}--dd`}>{value}</dd>
+            </div>}
+          </React.Fragment>
+        );
+      })}
+    </dl>
+  );
+};
 
 Metadata.propTypes = {
   data: PropTypes.object,

--- a/cypress/integration/executions_spec.js
+++ b/cypress/integration/executions_spec.js
@@ -41,9 +41,9 @@ describe('Dashboard Executions Page', () => {
       cy.getFakeApiFixture('executions').as('executionsFixture');
       cy.get('@executionsFixture').its('results')
         .each((execution) => {
-          const visiblePart = execution['name'].split('-').slice(0, 3).join('-');
+          const visiblePart = execution.name.split('-').slice(0, 3).join('-');
           cy.contains(visiblePart);
-          cy.get(`[data-value="${execution['name']}"]`).children().as('columns');
+          cy.get(`[data-value="${execution.name}"]`).children().as('columns');
           cy.get('@columns').should('have.length', 6);
 
           cy.get('@columns').eq(0).children('a')
@@ -89,7 +89,7 @@ describe('Dashboard Executions Page', () => {
       cy.url().should('include', 'executions');
       cy.contains('.heading--xlarge', 'Executions');
       cy.get('.table .tbody .tr .td.table__main-asset').within(() => {
-        cy.get(`a[title=${executionName}]`).click({force: true});
+        cy.get(`a[title=${executionName}]`).click({ force: true });
       });
 
       cy.contains('.heading--large', 'Execution');
@@ -97,11 +97,11 @@ describe('Dashboard Executions Page', () => {
 
       cy.get('.status--process')
         .within(() => {
-          cy.contains('Execution Status:').next().should('have.text', 'Succeeded');
-          cy.contains('Execution Arn:').next().should('have.text', executionArn);
-          cy.contains('State Machine Arn:').next().should('have.text', stateMachine);
-          cy.contains('Started:').next().should('have.text', fullDate('2019-12-13T15:16:46.753Z'));
-          cy.contains('Ended:').next().should('have.text', fullDate('2019-12-13T15:16:52.582Z'));
+          cy.contains('Execution Status').next().should('have.text', 'Succeeded');
+          cy.contains('Execution Arn').next().should('have.text', executionArn);
+          cy.contains('State Machine Arn').next().should('have.text', stateMachine);
+          cy.contains('Started').next().should('have.text', fullDate('2019-12-13T15:16:46.753Z'));
+          cy.contains('Ended').next().should('have.text', fullDate('2019-12-13T15:16:52.582Z'));
         });
 
       cy.get('.table .tbody .tr').as('events');
@@ -110,11 +110,11 @@ describe('Dashboard Executions Page', () => {
       cy.getFixture('valid-execution').as('executionStatus');
       cy.get('@executionStatus').its('executionHistory').its('events').then((events) => {
         cy.get('@events').each(($el, index, $list) => {
-          let timestamp = fullDate(events[index].timestamp);
+          const timestamp = fullDate(events[index].timestamp);
           cy.wrap($el).children('.td').as('columns');
           cy.get('@columns').should('have.length', 4);
-          let idMatch = `"id": ${index + 1},`;
-          let previousIdMatch = `"previousEventId": ${index}`;
+          const idMatch = `"id": ${index + 1},`;
+          const previousIdMatch = `"previousEventId": ${index}`;
 
           cy.get('@columns').eq(0).should('have.text', (index + 1).toString());
           cy.get('@columns').eq(2).should('have.text', timestamp);
@@ -151,7 +151,7 @@ describe('Dashboard Executions Page', () => {
 
       cy.get('.status--process')
         .within(() => {
-          cy.contains('Logs:').next()
+          cy.contains('Logs').next()
             .within(() => {
               cy.get('a').should('have.attr', 'href', `/executions/execution/${executionName}/logs`).click();
             });
@@ -200,35 +200,32 @@ describe('Dashboard Executions Page', () => {
 
       cy.get('.status--process')
         .within(() => {
-          cy.contains('Execution Status:').next().should('have.text', 'Succeeded');
-          cy.contains('Execution Arn:').next().should('have.text', executionArn);
-          cy.contains('State Machine Arn:').next().should('have.text', stateMachine);
-          cy.contains('Started:').next().should('have.text', startMatch);
-          cy.contains('Ended:').next().should('have.text', endMatch);
+          cy.contains('Execution Status').next().should('have.text', 'Succeeded');
+          cy.contains('Execution Arn').next().should('have.text', executionArn);
+          cy.contains('State Machine Arn').next().should('have.text', stateMachine);
+          cy.contains('Started').next().should('have.text', startMatch);
+          cy.contains('Ended').next().should('have.text', endMatch);
+        });
 
-          cy.getFakeApiFixture('executions').as('executionsFixture');
-          cy.get('@executionsFixture').its('results')
-            .each((execution) => {
-              if (execution.name === executionName) {
-                cy.contains('Input:').next().find('pre')
-                  .then(($content) =>
-                    expect(JSON.parse($content.text())).to.deep.equal(execution.originalPayload));
-                cy.contains('Input:').next().contains('.Collapsible', 'Show Input').click('topLeft');
-                cy.contains('Input:').next().contains('.Collapsible', 'Hide Input');
+      cy.getFakeApiFixture('executions').as('executionsFixture');
+      cy.get('@executionsFixture').its('results')
+        .each((execution) => {
+          if (execution.name === executionName) {
+            cy.contains('Input').next().contains('button', 'Show Input').click();
+            cy.get('.execution--modal').find('pre').then(($content) =>
+              expect(JSON.parse($content.text())).to.deep.equal(execution.originalPayload));
+            cy.get('.button--close').click();
 
-                cy.contains('Output:').next().find('pre')
-                  .then(($content) =>
-                    expect(JSON.parse($content.text())).to.deep.equal(execution.finalPayload));
+            cy.contains('Output').next().contains('button', 'Show Output').click();
+            cy.get('.execution--modal').find('pre').then(($content) =>
+              expect(JSON.parse($content.text())).to.deep.equal(execution.finalPayload));
+            cy.get('.button--close').click();
+          }
+        });
 
-                cy.contains('Output:').next().contains('.Collapsible', 'Show Output').click('topLeft');
-                cy.contains('Output:').next().contains('.Collapsible', 'Hide Output');
-              }
-            });
-
-          cy.contains('Logs:').next()
-            .within(() => {
-              cy.get('a').should('have.attr', 'href', `/executions/execution/${executionName}/logs`);
-            });
+      cy.contains('Logs').next()
+        .within(() => {
+          cy.get('a').should('have.attr', 'href', `/executions/execution/${executionName}/logs`);
         });
 
       cy.contains('.heading--medium', 'Events').should('not.exist');

--- a/test/components/reconciliation-reports/reconciliation-report.js
+++ b/test/components/reconciliation-reports/reconciliation-report.js
@@ -14,7 +14,7 @@ const reconciliationReports = {
     exampleReport: {
       data: {
         reportStartTime: '2018-06-11T18:52:37.710Z',
-        'reportEndTime': '2018-06-11T18:52:39.893Z',
+        reportEndTime: '2018-06-11T18:52:39.893Z',
         status: 'SUCCESS',
         error: null,
         okFileCount: 21,
@@ -31,7 +31,19 @@ const reconciliationReports = {
             uri: 's3://some-bucket/path/to/key-456.hdf',
             granuleId: 'g-456'
           }
-        ]
+        ],
+        filesInCumulus: {
+          okCount: 129
+        },
+        collectionsInCumulusCmr: {
+          okCount: 1
+        },
+        granulesInCumulusCmr: {
+          okCount: 7
+        },
+        filesInCumulusCmr: {
+          okCount: 4
+        }
       }
     },
     exampleReportWithError: {
@@ -57,7 +69,7 @@ test('show individual report', function (t) {
   const MetadataWrapper = Metadata.dive();
   const MetadataWrapperChildren = MetadataWrapper.children();
   // ReconciliationReport is configured to use 6 metaAccessors,
-  // so there will be 6 groups of dt, dd elements for a total of 12
+  // so there will be 6 groups of dt, dd elements
   t.is(MetadataWrapperChildren.length, 6);
 });
 


### PR DESCRIPTION
This updates the execution status page to allow the user to view and download the full execution output.

Also, reworked the Metadata component so that it takes in an array of objects rather than an array of arrays so that it is easier to understand. Updated all instances where that component is being used. Pulled it into the executions page for use there as well.

There's limited styling, the rest should be applied in [CUMULUS-1538](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1538)