### PR TITLE
Quick fix to keep from mutating state outside of a reducer.

### DIFF
--- a/app/src/js/components/Operations/overview.js
+++ b/app/src/js/components/Operations/overview.js
@@ -3,6 +3,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
+import cloneDeep from 'lodash.clonedeep';
 import {
   clearOperationsFilter,
   filterOperations,
@@ -88,11 +89,13 @@ class OperationOverview extends React.Component {
     const { operations } = this.props;
     const { list } = operations;
     const { count } = list.meta;
-    if (list.internal.prefix) {
-      if (list.internal.prefix.queryValue) {
-        list.data = this.searchOperations(list.data, list.internal.prefix.queryValue);
-      } else if (typeof list.internal.prefix === 'string') {
-        list.data = this.searchOperations(list.data, list.internal.prefix);
+    const mutableList = cloneDeep(list);
+    //  This data munging should probably be handled in the reducer, but this is a workaround.
+    if (mutableList.internal.prefix) {
+      if (mutableList.internal.prefix.queryValue) {
+        mutableList.data = this.searchOperations(mutableList.data, mutableList.internal.prefix.queryValue);
+      } else if (typeof mutableList.internal.prefix === 'string') {
+        mutableList.data = this.searchOperations(mutableList.data, mutableList.internal.prefix);
       }
     }
 
@@ -108,7 +111,7 @@ class OperationOverview extends React.Component {
             <h2 className='heading--medium heading--shared-content with-description'>All Operations <span className='num--title'>{tally(count)}</span></h2>
           </div>
           <List
-            list={list}
+            list={mutableList}
             dispatch={this.props.dispatch}
             action={listOperations}
             tableColumns={tableColumns}

--- a/app/src/js/reducers/workflows.js
+++ b/app/src/js/reducers/workflows.js
@@ -37,7 +37,7 @@ function createMap (data) {
  */
 export const filterData = (rawData, filterString) => {
   if (filterString !== null) {
-    return rawData.filter(d => d.name.toLowerCase().includes(filterString.toLowerCase()));
+    return rawData.filter(d => d.name && d.name.toLowerCase().includes(filterString.toLowerCase()));
   }
   return rawData;
 };


### PR DESCRIPTION
This probably wasn't caught because we don't have tests for this page, that should probably get fixed.


Error:

Uncaught TypeError: Cannot assign to read only property 'data' of object '#<Object>'
    at OperationOverview.render (VM452 bundle.js:274695)
    at finishClassComponent (VM452 bundle.js:212676)
    at updateClassComponent (VM452 bundle.js:212626)
    at beginWork (VM452 bundle.js:214136)
    at HTMLUnknownElement.callCallback (VM452 bundle.js:195704)
    at Object.invokeGuardedCallbackDev (VM452 bundle.js:195753)
    at invokeGuardedCallback (VM452 bundle.js:195808)
    at beginWork$1 (VM452 bundle.js:218719)
    at performUnitOfWork (VM452 bundle.js:217670)
    at workLoopSync (VM452 bundle.js:217646)
    at performSyncWorkOnRoot (VM452 bundle.js:217272)
    at VM452 bundle.js:206605
    at unstable_runWithPriority (VM452 bundle.js:138315)
    at runWithPriority$1 (VM452 bundle.js:206555)
    at flushSyncCallbackQueueImpl (VM452 bundle.js:206600)
    at flushSyncCallbackQueue (VM452 bundle.js:206588)