### PR TITLE
CUMULUS-1787 collections header

### DIFF
--- a/app/src/js/actions/index.js
+++ b/app/src/js/actions/index.js
@@ -128,9 +128,9 @@ export const checkApiVersion = () => {
 };
 
 export const listCollections = (options = {}) => {
-  const { listAll, ...queryOptions } = options;
+  const { listAll = false, getMMT = true, ...queryOptions } = options;
   return (dispatch, getState) => {
-    const timeFilters = fetchCurrentTimeFilters(getState().datepicker);
+    const timeFilters = !listAll ? fetchCurrentTimeFilters(getState().datepicker) : {};
     const urlPath = `collections${isEmpty(timeFilters) || listAll ? '' : '/active'}`;
     return dispatch({
       [CALL_API]: {
@@ -140,7 +140,11 @@ export const listCollections = (options = {}) => {
         url: new URL(urlPath, root).href,
         qs: Object.assign({ limit: defaultPageLimit }, queryOptions, timeFilters)
       }
-    }).then(() => dispatch(getMMTLinks()));
+    }).then(() => {
+      if (getMMT) {
+        dispatch(getMMTLinks());
+      }
+    });
   };
 };
 
@@ -582,15 +586,16 @@ export const clearPdrsSearch = () => ({ type: types.CLEAR_PDRS_SEARCH });
 export const filterPdrs = (param) => ({ type: types.FILTER_PDRS, param: param });
 export const clearPdrsFilter = (paramKey) => ({ type: types.CLEAR_PDRS_FILTER, paramKey: paramKey });
 
-export const listProviders = (options) => {
+export const listProviders = (options = {}) => {
+  const { listAll = false, queryOptions } = options;
   return (dispatch, getState) => {
-    const timeFilters = fetchCurrentTimeFilters(getState().datepicker);
+    const timeFilters = !listAll ? fetchCurrentTimeFilters(getState().datepicker) : {};
     return dispatch({
       [CALL_API]: {
         type: types.PROVIDERS,
         method: 'GET',
         url: new URL('providers', root).href,
-        qs: Object.assign({ limit: defaultPageLimit }, options, timeFilters)
+        qs: Object.assign({ limit: defaultPageLimit }, queryOptions, timeFilters)
       }
     });
   };

--- a/app/src/js/actions/index.js
+++ b/app/src/js/actions/index.js
@@ -130,7 +130,7 @@ export const checkApiVersion = () => {
 export const listCollections = (options = {}) => {
   const { listAll = false, getMMT = true, ...queryOptions } = options;
   return (dispatch, getState) => {
-    const timeFilters = !listAll ? fetchCurrentTimeFilters(getState().datepicker) : {};
+    const timeFilters = listAll ? {} : fetchCurrentTimeFilters(getState().datepicker);
     const urlPath = `collections${isEmpty(timeFilters) || listAll ? '' : '/active'}`;
     return dispatch({
       [CALL_API]: {
@@ -589,7 +589,7 @@ export const clearPdrsFilter = (paramKey) => ({ type: types.CLEAR_PDRS_FILTER, p
 export const listProviders = (options = {}) => {
   const { listAll = false, ...queryOptions } = options;
   return (dispatch, getState) => {
-    const timeFilters = !listAll ? fetchCurrentTimeFilters(getState().datepicker) : {};
+    const timeFilters = listAll ? {} : fetchCurrentTimeFilters(getState().datepicker);
     return dispatch({
       [CALL_API]: {
         type: types.PROVIDERS,

--- a/app/src/js/actions/index.js
+++ b/app/src/js/actions/index.js
@@ -587,7 +587,7 @@ export const filterPdrs = (param) => ({ type: types.FILTER_PDRS, param: param })
 export const clearPdrsFilter = (paramKey) => ({ type: types.CLEAR_PDRS_FILTER, paramKey: paramKey });
 
 export const listProviders = (options = {}) => {
-  const { listAll = false, queryOptions } = options;
+  const { listAll = false, ...queryOptions } = options;
   return (dispatch, getState) => {
     const timeFilters = !listAll ? fetchCurrentTimeFilters(getState().datepicker) : {};
     return dispatch({

--- a/app/src/js/components/Collections/list.js
+++ b/app/src/js/components/Collections/list.js
@@ -100,7 +100,7 @@ class CollectionList extends React.Component {
           <div className='heading__wrapper--border'>
             <h2 className='heading--medium heading--shared-content with-description'>
               {hasTimeFilter ? strings.active_collections : strings.all_collections}
-              <span className='num--title'>{count ? `${tally(count)}` : 0}</span>
+              <span className='num--title'>{count ? tally(count) : 0}</span>
             </h2>
           </div>
 

--- a/app/src/js/components/Collections/list.js
+++ b/app/src/js/components/Collections/list.js
@@ -99,8 +99,8 @@ class CollectionList extends React.Component {
         <section className='page__section'>
           <div className='heading__wrapper--border'>
             <h2 className='heading--medium heading--shared-content with-description'>
-              {hasTimeFilter ? 'Active Collections' : strings.all_collections}
-              <span className='num--title'>{count ? ` ${tally(count)}` : 0}</span>
+              {hasTimeFilter ? strings.active_collections : strings.all_collections}
+              <span className='num--title'>{count ? `${tally(count)}` : 0}</span>
             </h2>
           </div>
 

--- a/app/src/js/components/Collections/list.js
+++ b/app/src/js/components/Collections/list.js
@@ -4,7 +4,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import moment from 'moment';
 import {
   applyRecoveryWorkflowToCollection,
   clearCollectionsSearch,
@@ -47,13 +46,6 @@ const breadcrumbConfig = [
 class CollectionList extends React.Component {
   constructor () {
     super();
-    this.displayName = 'CollectionList';
-    this.timeOptions = {
-      '': '',
-      '1 Week Ago': moment().subtract(1, 'weeks').format(),
-      '1 Month Ago': moment().subtract(1, 'months').format(),
-      '1 Year Ago': moment().subtract(1, 'years').format()
-    };
     this.generateQuery = this.generateQuery.bind(this);
     this.generateBulkActions = this.generateBulkActions.bind(this);
   }
@@ -80,9 +72,12 @@ class CollectionList extends React.Component {
   }
 
   render () {
-    const { list } = this.props.collections;
+    const { collections, mmtLinks, datepicker } = this.props;
+    const { list } = collections;
+    const { startDateTime, endDateTime } = datepicker;
+    const hasTimeFilter = startDateTime || endDateTime;
+
     // merge mmtLinks with the collection data;
-    const mmtLinks = this.props.mmtLinks;
     const data = list.data.map((collection) => {
       return {
         ...collection,
@@ -103,7 +98,10 @@ class CollectionList extends React.Component {
         </section>
         <section className='page__section'>
           <div className='heading__wrapper--border'>
-            <h2 className='heading--medium heading--shared-content with-description'>{strings.all_collections} <span className='num--title'>{count ? ` ${tally(count)}` : 0}</span></h2>
+            <h2 className='heading--medium heading--shared-content with-description'>
+              {hasTimeFilter ? 'Active Collections' : strings.all_collections}
+              <span className='num--title'>{count ? ` ${tally(count)}` : 0}</span>
+            </h2>
           </div>
 
           <List
@@ -149,10 +147,14 @@ CollectionList.propTypes = {
   collections: PropTypes.object,
   mmtLinks: PropTypes.object,
   dispatch: PropTypes.func,
-  logs: PropTypes.object,
   config: PropTypes.object,
-  location: PropTypes.object
+  datepicker: PropTypes.shape({
+    startDateTime: PropTypes.number,
+    endDateTime: PropTypes.number
+  })
 };
+
+CollectionList.displayName = 'CollectionList';
 
 export { CollectionList };
 export default withRouter(connect(state => state)(CollectionList));

--- a/app/src/js/components/Collections/list.js
+++ b/app/src/js/components/Collections/list.js
@@ -74,7 +74,7 @@ class CollectionList extends React.Component {
   render () {
     const { collections, mmtLinks, datepicker } = this.props;
     const { list } = collections;
-    const { startDateTime, endDateTime } = datepicker;
+    const { startDateTime, endDateTime } = datepicker || {};
     const hasTimeFilter = startDateTime || endDateTime;
 
     // merge mmtLinks with the collection data;
@@ -148,10 +148,7 @@ CollectionList.propTypes = {
   mmtLinks: PropTypes.object,
   dispatch: PropTypes.func,
   config: PropTypes.object,
-  datepicker: PropTypes.shape({
-    startDateTime: PropTypes.number,
-    endDateTime: PropTypes.number
-  })
+  datepicker: PropTypes.object
 };
 
 CollectionList.displayName = 'CollectionList';

--- a/app/src/js/components/Rules/add.js
+++ b/app/src/js/components/Rules/add.js
@@ -115,8 +115,8 @@ const AddRule = ({
   };
 
   useEffect(() => {
-    if (!dispatched(collections)) dispatch(listCollections({ listAll: true }));
-    if (!dispatched(providers)) dispatch(listProviders());
+    if (!dispatched(collections)) dispatch(listCollections({ listAll: true, getMMT: false }));
+    if (!dispatched(providers)) dispatch(listProviders({ listAll: true }));
     if (!dispatched(workflows)) dispatch(listWorkflows());
   });
 

--- a/app/src/js/components/locale.js
+++ b/app/src/js/components/locale.js
@@ -6,6 +6,7 @@ function getCustomInterfaceLanguage () {
 
 export const strings = new LocalizedStrings({
   daac: {
+    active_collections: 'Active Collections',
     add_collection: 'Add Collection',
     all_collections: 'All Collections',
     all_granules: 'All Granules',


### PR DESCRIPTION
1. When time filter is applied, header on collections page says "Active Collections". Otherwise, it says "All Collections". Also cleaned up some extraneous code on that page.

2. Removes time filter from the `listCollections` and `listProviders` actions on the Add Rule page by passing in `listAll` option

Can test by setting date to a time after data was seeded/ingested. When adding a rule, all collections and providers should still be populated. Did not change the workflows action since it does not take in a timefilter.