### PR TITLE
Cumulus 1677 modal workflow updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,29 +9,32 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- **CUMULUS-1822**
-  - Added dynamic form validation as user types
+- **CUMULUS-1515**
+  - filter capability to workflow overview page.
+
+- **CUMULUS-1526**
+  - Add a copy rule button
 
 - **CUMULUS-1538**
   - Add ability to expand size of visual on execution details page
 
-- **CUMULUS-1515**
-  - filter capability to workflow overview page.
+- **CUMULUS-1677**
+  - Updates the user experience when re-ingesting granules. Adds Modal flow for better understanding.
+
+- **CUMULUS-1646**
+  - Add 'Results Per Page' dropdown for tables that use pagination
 
 - **CUMULUS-1798**
   - Add a refresh button
   - Add individual cancel buttons for date time range inputs
 
-- **CUMULUS-1526**
-  - Add a copy rule button
-
-- **CUMULUS-1646**
-  - Add 'Results Per Page' dropdown for tables that use pagination
+- **CUMULUS-1822**
+  - Added dynamic form validation as user types
 
 ### Changed
 
 - **CUMULUS-1538**
-  - Update executions details page styles 
+  - Update executions details page styles
 
 - **CUMULUS-1460**
   - Update dashboard headers overall

--- a/app/src/js/components/BatchAsyncCommands/BatchAsyncCommands.js
+++ b/app/src/js/components/BatchAsyncCommands/BatchAsyncCommands.js
@@ -72,7 +72,8 @@ export class BatchCommand extends React.Component {
         selected,
         history,
         isOnModalConfirm: true,
-        isOnModalComplete: false
+        isOnModalComplete: false,
+        setState: this.setState.bind(this)
       });
       this.setState({ modalOptions });
 
@@ -137,7 +138,8 @@ export class BatchCommand extends React.Component {
         selected,
         results,
         error,
-        isOnModalComplete: true
+        isOnModalComplete: true,
+        setState: this.setState.bind(this)
       });
       this.setState({ modalOptions });
     }
@@ -154,7 +156,8 @@ export class BatchCommand extends React.Component {
     if (typeof getModalOptions === 'function') {
       const modalOptions = getModalOptions({
         selected,
-        history
+        history,
+        setState: this.setState.bind(this)
       });
       this.setState({ modalOptions });
     }

--- a/app/src/js/components/BatchAsyncCommands/BatchAsyncCommands.js
+++ b/app/src/js/components/BatchAsyncCommands/BatchAsyncCommands.js
@@ -43,6 +43,11 @@ export class BatchCommand extends React.Component {
     this.cleanup = this.cleanup.bind(this);
     this.isInflight = this.isInflight.bind(this);
     this.handleClick = this.handleClick.bind(this);
+    this.closeModal = this.closeModal.bind(this);
+  }
+
+  closeModal () {
+    this.setState({ activeModal: false });
   }
 
   componentDidUpdate () {
@@ -73,7 +78,7 @@ export class BatchCommand extends React.Component {
         history,
         isOnModalConfirm: true,
         isOnModalComplete: false,
-        setState: this.setState.bind(this)
+        closeModal: this.closeModal
       });
       this.setState({ modalOptions });
 
@@ -139,7 +144,7 @@ export class BatchCommand extends React.Component {
         results,
         error,
         isOnModalComplete: true,
-        setState: this.setState.bind(this)
+        closeModal: this.closeModal
       });
       this.setState({ modalOptions });
     }
@@ -157,7 +162,7 @@ export class BatchCommand extends React.Component {
       const modalOptions = getModalOptions({
         selected,
         history,
-        setState: this.setState.bind(this)
+        closeModal: this.closeModal
       });
       this.setState({ modalOptions });
     }

--- a/app/src/js/components/Collections/overview.js
+++ b/app/src/js/components/Collections/overview.js
@@ -95,6 +95,7 @@ class CollectionOverview extends React.Component {
   generateBulkActions () {
     const { granules } = this.props;
     return [
+      reingestAction(granules),
       {
         Component:
         <Bulk
@@ -102,8 +103,7 @@ class CollectionOverview extends React.Component {
           className='button button__bulkgranules button--green button--small form-group__element link--no-underline'
           confirmAction={true}
         />
-      },
-      reingestAction(granules)
+      }
     ];
   }
 

--- a/app/src/js/components/Collections/overview.js
+++ b/app/src/js/components/Collections/overview.js
@@ -29,7 +29,7 @@ import pageSizeOptions from '../../utils/page-size';
 import List from '../Table/Table';
 import Bulk from '../Granules/bulk';
 import Overview from '../Overview/overview';
-import { tableColumns } from '../../utils/table-config/granules';
+import { tableColumns, reingestAction } from '../../utils/table-config/granules';
 import { strings } from '../locale';
 import DeleteCollection from '../DeleteCollection/DeleteCollection';
 import Breadcrumbs from '../Breadcrumbs/Breadcrumbs';
@@ -50,17 +50,6 @@ const breadcrumbConfig = [
   }
 ];
 
-const bulkActions = [
-  {
-    Component:
-      <Bulk
-        element='a'
-        className='button button__bulkgranules button--green button--small form-group__element link--no-underline'
-        confirmAction={true}
-      />
-  }
-];
-
 class CollectionOverview extends React.Component {
   constructor (props) {
     super(props);
@@ -72,6 +61,7 @@ class CollectionOverview extends React.Component {
       this.deleteMe,
       this.errors,
       this.generateQuery,
+      this.generateBulkActions,
       this.gotoGranules,
       this.load,
       this.navigateBack
@@ -100,6 +90,21 @@ class CollectionOverview extends React.Component {
   changeCollection (_, collectionId) {
     const { name, version } = collectionNameVersion(collectionId);
     this.props.history.push(`/collections/collection/${name}/${version}`);
+  }
+
+  generateBulkActions () {
+    const { granules } = this.props;
+    return [
+      {
+        Component:
+        <Bulk
+          element='a'
+          className='button button__bulkgranules button--green button--small form-group__element link--no-underline'
+          confirmAction={true}
+        />
+      },
+      reingestAction(granules)
+    ];
   }
 
   generateQuery () {
@@ -270,7 +275,7 @@ class CollectionOverview extends React.Component {
             action={listGranules}
             tableColumns={tableColumns}
             query={this.generateQuery()}
-            bulkActions={bulkActions}
+            bulkActions={this.generateBulkActions()}
             rowId='granuleId'
             sortIdx='timestamp'
           >

--- a/app/src/js/components/Executions/execution-status-graph.js
+++ b/app/src/js/components/Executions/execution-status-graph.js
@@ -93,7 +93,7 @@ class ExecutionStatusGraph extends React.Component {
           className='default-modal execution__modal--visual'>
           <Modal.Header>
             <div className='header' onClick={this.onHide}>
-              <div>Click <FontAwesomeIcon icon='compress'/> to return to execution view</div>
+              <div>Click to return to execution view</div>
               <div><FontAwesomeIcon icon='compress' className='button__icon--animation'/></div>
             </div>
           </Modal.Header>

--- a/app/src/js/components/ReingestGranules/BatchReingestCompleteContent.js
+++ b/app/src/js/components/ReingestGranules/BatchReingestCompleteContent.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
+export const maxDisplayed = 10;
+
 const BatchReingestCompleteContent = ({
   results,
   error
@@ -9,14 +11,18 @@ const BatchReingestCompleteContent = ({
   return (
     <>
       {(results && results.length > 0) &&
-        <>
-          <p>{confirmation}</p>
-          <ul>
-            {results.map((result, index) => {
-              return <li key={index}>{result}</li>;
-            })}
-          </ul>
-        </>
+       <>
+         <p>{confirmation}</p>
+         <ul>
+           {results.map((result, index) => {
+             if (index < maxDisplayed) {
+               return <li key={index}>{result}</li>;
+             } return <></>;
+           })}
+           {(results.length > maxDisplayed) &&
+            <li key={maxDisplayed}>and {results.length - maxDisplayed} more.</li>}
+         </ul>
+       </>
       }
       {error && <span className='error'>{error}</span>}
     </>

--- a/app/src/js/components/ReingestGranules/BatchReingestCompleteContent.js
+++ b/app/src/js/components/ReingestGranules/BatchReingestCompleteContent.js
@@ -7,20 +7,25 @@ const BatchReingestCompleteContent = ({
   results,
   error
 }) => {
-  const confirmation = `successfully reingested ${results.length > 1 ? 'these' : 'this'} granule${results.length > 1 ? 's' : ''}`;
+  const confirmation = () => `successfully reingested ${results.length > 1 ? 'these' : 'this'} granule${results.length > 1 ? 's' : ''}`;
+  const displayedItems = () => {
+    const items = [];
+    for (let i = 0; i < Math.min(results.length, maxDisplayed); i++) {
+      items.push(<li key={i}>{results[i]}</li>);
+    }
+    if (results.length > maxDisplayed) {
+      items.push(<li key={maxDisplayed}>and {results.length - maxDisplayed} more.</li>);
+    }
+    return items;
+  };
+
   return (
     <>
       {(results && results.length > 0) &&
        <>
-         <p>{confirmation}</p>
+         <p>{confirmation()}</p>
          <ul>
-           {results.map((result, index) => {
-             if (index < maxDisplayed) {
-               return <li key={index}>{result}</li>;
-             } return <></>;
-           })}
-           {(results.length > maxDisplayed) &&
-            <li key={maxDisplayed}>and {results.length - maxDisplayed} more.</li>}
+           {displayedItems()}
          </ul>
        </>
       }

--- a/app/src/js/components/ReingestGranules/BatchReingestCompleteContent.js
+++ b/app/src/js/components/ReingestGranules/BatchReingestCompleteContent.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const BatchReingestCompleteContent = ({
+  results,
+  error
+}) => {
+  const confirmation = `successfully reingested ${results.length > 1 ? 'these' : 'this'} granule${results.length > 1 ? 's' : ''}`;
+  return (
+    <>
+      {(results && results.length > 0) &&
+        <>
+          <p>{confirmation}</p>
+          <ul>
+            {results.map((result, index) => {
+              return <li key={index}>{result}</li>;
+            })}
+          </ul>
+        </>
+      }
+      {error && <span className='error'>{error}</span>}
+    </>
+  );
+};
+
+BatchReingestCompleteContent.propTypes = {
+  results: PropTypes.array,
+  error: PropTypes.string
+};
+
+export default BatchReingestCompleteContent;

--- a/app/src/js/components/ReingestGranules/BatchReingestConfirmContent.js
+++ b/app/src/js/components/ReingestGranules/BatchReingestConfirmContent.js
@@ -1,0 +1,37 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export const maxDisplayed = 10;
+const pluralRequest = 'You have submitted a request to reingest the following granules.';
+const singularRequest = 'You have submitted a request to reingest the following granule.';
+
+const pluralConfirm = 'Are you sure that you want to reingest these granules?\nNote: These granule files will be overwritten.';
+const singularConfirm = 'Are you sure that you want to reingest this granule?\nNote: The granule file will be overwritten.';
+
+const BatchReingestConfirmContent = ({ selected = [] }) => {
+  const isMultiple = (selected.length > 1);
+  const requestText = isMultiple ? pluralRequest : singularRequest;
+  const confirmText = isMultiple ? pluralConfirm : singularConfirm;
+
+  return (
+    <>
+      {requestText}
+      <ul>
+        {selected.map((selection, index) => {
+          if (index < maxDisplayed) {
+            return <li key={index}>{selection}</li>;
+          } return <></>;
+        })}
+        {(selected.length > maxDisplayed) &&
+         <li key={maxDisplayed}>and {selected.length - maxDisplayed} more.</li>}
+      </ul>
+      {confirmText.split('\n').map((line, index) => <p key={index}>{line}</p>)}
+    </>
+  );
+};
+
+BatchReingestConfirmContent.propTypes = {
+  selected: PropTypes.array
+};
+
+export default BatchReingestConfirmContent;

--- a/app/src/js/components/ReingestGranules/BatchReingestConfirmContent.js
+++ b/app/src/js/components/ReingestGranules/BatchReingestConfirmContent.js
@@ -2,16 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 export const maxDisplayed = 10;
-const pluralRequest = 'You have submitted a request to reingest the following granules.';
-const singularRequest = 'You have submitted a request to reingest the following granule.';
-
-const pluralConfirm = 'Are you sure that you want to reingest these granules?\nNote: These granule files will be overwritten.';
-const singularConfirm = 'Are you sure that you want to reingest this granule?\nNote: The granule file will be overwritten.';
 
 const BatchReingestConfirmContent = ({ selected = [] }) => {
-  const isMultiple = (selected.length > 1);
-  const requestText = isMultiple ? pluralRequest : singularRequest;
-  const confirmText = isMultiple ? pluralConfirm : singularConfirm;
+  const isMultiple = selected.length > 1;
+  const these = isMultiple ? 'These' : 'This';
+  const s = isMultiple ? 's' : '';
+  const requestText = `You have submitted a request to reingest the following granule${s}.`;
+  const confirmText = `Are you sure that you want to reingest ${these.toLowerCase()} granule${s}?\nNote: ${these} granule file${s} will be overwritten.`;
 
   return (
     <>
@@ -20,12 +17,16 @@ const BatchReingestConfirmContent = ({ selected = [] }) => {
         {selected.map((selection, index) => {
           if (index < maxDisplayed) {
             return <li key={index}>{selection}</li>;
-          } return <></>;
+          }
+          return <></>;
         })}
-        {(selected.length > maxDisplayed) &&
-         <li key={maxDisplayed}>and {selected.length - maxDisplayed} more.</li>}
+        {selected.length > maxDisplayed && (
+          <li key={maxDisplayed}>and {selected.length - maxDisplayed} more.</li>
+        )}
       </ul>
-      {confirmText.split('\n').map((line, index) => <p key={index}>{line}</p>)}
+      {confirmText.split('\n').map((line, index) => (
+        <p key={index}>{line}</p>
+      ))}
     </>
   );
 };

--- a/app/src/js/components/ReingestGranules/BatchReingestConfirmContent.js
+++ b/app/src/js/components/ReingestGranules/BatchReingestConfirmContent.js
@@ -10,19 +10,22 @@ const BatchReingestConfirmContent = ({ selected = [] }) => {
   const requestText = `You have submitted a request to reingest the following granule${s}.`;
   const confirmText = `Are you sure that you want to reingest ${these.toLowerCase()} granule${s}?\nNote: ${these} granule file${s} will be overwritten.`;
 
+  const displayedItems = () => {
+    const items = [];
+    for (let i = 0; i < Math.min(selected.length, maxDisplayed); i++) {
+      items.push(<li key={i}>{selected[i]}</li>);
+    }
+    if (selected.length > maxDisplayed) {
+      items.push(<li key={maxDisplayed}>and {selected.length - maxDisplayed} more.</li>);
+    }
+    return items;
+  };
+
   return (
     <>
       {requestText}
       <ul>
-        {selected.map((selection, index) => {
-          if (index < maxDisplayed) {
-            return <li key={index}>{selection}</li>;
-          }
-          return <></>;
-        })}
-        {selected.length > maxDisplayed && (
-          <li key={maxDisplayed}>and {selected.length - maxDisplayed} more.</li>
-        )}
+        {displayedItems()}
       </ul>
       {confirmText.split('\n').map((line, index) => (
         <p key={index}>{line}</p>

--- a/app/src/js/utils/table-config/granules.js
+++ b/app/src/js/utils/table-config/granules.js
@@ -128,6 +128,17 @@ const confirmRemove = (d) => `Remove ${d} granule(s) from ${strings.cmr}?`;
 const confirmDelete = (d) => `Delete ${d} granule(s)?`;
 
 /**
+ * Determine the base context of a collection view
+ * @param {Object} path - react router history object
+ */
+const determineCollectionsBase = (path) => {
+  if (path.includes('granules')) {
+    return path.replace(/\/granules.*/, '/granules');
+  }
+  return `${path}/granules`;
+};
+
+/**
  * Determines next location based on granule success/error and number of
  * successes.  If there's an error do nothing, if there is a single granule
  * visit that granule's detail page, if there are multiple granules reingested
@@ -143,7 +154,7 @@ const confirmDelete = (d) => `Delete ${d} granule(s)?`;
  * @returns {Function} function to call on confirm selection.
  */
 const setOnConfirm = ({ history, error, selected, redirectBase }) => {
-  const baseRedirect = redirectBase || '/granules';
+  const baseRedirect = determineCollectionsBase(history.location.pathname);
   if (error) { return () => {}; } else {
     if (selected.length > 1) {
       return () => history.push(`${baseRedirect}/processing`);
@@ -176,7 +187,7 @@ const granuleModalJourney = ({
       modalOptions.confirmButtonText = (selected.length > 1) ? 'View Running' : 'View Granule';
       modalOptions.cancelButtonClass = 'button--green';
       modalOptions.confirmButtonClass = 'button__goto';
-      modalOptions.onConfirm = setOnConfirm({ history, selected, error, redirectBase: determineCollectionsBase(history.location.pathname) });
+      modalOptions.onConfirm = setOnConfirm({ history, selected, error});
     }
   }
   return modalOptions;
@@ -224,16 +235,4 @@ export const bulkActions = function (granules, config) {
       confirm: confirmDelete,
       className: 'button--delete'
     }];
-};
-
-/**
- * Determine the base context of a collection view
- * @param {Object} path - react router history object
- */
-const determineCollectionsBase = (path) => {
-  console.log(`getbase: ${path}`);
-  if (path.includes('granules')) {
-    return path.replace(/\/granules.*/, '/granules');
-  }
-  return `${path}/granules`;
 };

--- a/app/src/js/utils/table-config/granules.js
+++ b/app/src/js/utils/table-config/granules.js
@@ -150,10 +150,9 @@ const determineCollectionsBase = (path) => {
  * @param {Object} anonymous.history - Connected router history object.
  * @param {Object} anonymous.error - error object.
  * @param {Object} anonymous.selected - array of selected values.
- * @param {Object} anonymous.redirectBase - string to use in computing redirect of multiple granules.
  * @returns {Function} function to call on confirm selection.
  */
-const setOnConfirm = ({ history, error, selected, redirectBase }) => {
+const setOnConfirm = ({ history, error, selected }) => {
   const baseRedirect = determineCollectionsBase(history.location.pathname);
   if (error) { return () => {}; } else {
     if (selected.length > 1) {
@@ -187,7 +186,7 @@ const granuleModalJourney = ({
       modalOptions.confirmButtonText = (selected.length > 1) ? 'View Running' : 'View Granule';
       modalOptions.cancelButtonClass = 'button--green';
       modalOptions.confirmButtonClass = 'button__goto';
-      modalOptions.onConfirm = setOnConfirm({ history, selected, error});
+      modalOptions.onConfirm = setOnConfirm({ history, selected, error });
     }
   }
   return modalOptions;

--- a/app/src/js/utils/table-config/granules.js
+++ b/app/src/js/utils/table-config/granules.js
@@ -126,43 +126,49 @@ const confirmReingest = (d) => `Reingest ${d} granule${d > 1 ? 's' : ''}?`;
 const confirmApply = (d) => `Run workflow on ${d} granules?`;
 const confirmRemove = (d) => `Remove ${d} granule(s) from ${strings.cmr}?`;
 const confirmDelete = (d) => `Delete ${d} granule(s)?`;
+
+export const reingestAction = (granules) => ({
+  text: 'Reingest',
+  action: reingestGranule,
+  state: granules.reingested,
+  confirm: confirmReingest,
+  className: 'button--reingest',
+  getModalOptions: granuleModalJourney
+});
+
 export const bulkActions = function (granules, config) {
-  return [{
-    text: 'Reingest',
-    action: reingestGranule,
-    state: granules.reingested,
-    confirm: confirmReingest,
-    className: 'button--reingest',
-    getModalOptions: granuleModalJourney
-  }, {
-    text: 'Execute',
-    action: config.execute.action,
-    state: granules.executed,
-    confirm: confirmApply,
-    confirmOptions: config.execute.options,
-    className: 'button--execute'
-  }, {
-    text: strings.remove_from_cmr,
-    action: removeGranule,
-    state: granules.removed,
-    confirm: confirmRemove,
-    className: 'button--remove'
-  },
-  {
-    Component:
-      <Bulk
-        element='button'
-        className='button button__bulkgranules button--green button--small form-group__element'
-        confirmAction={true}
-      />
-  },
-  {
-    text: 'Delete',
-    action: deleteGranule,
-    state: granules.deleted,
-    confirm: confirmDelete,
-    className: 'button--delete'
-  }];
+  return [
+    reingestAction(granules),
+    {
+      text: 'Execute',
+      action: config.execute.action,
+      state: granules.executed,
+      confirm: confirmApply,
+      confirmOptions: config.execute.options,
+      className: 'button--execute'
+    },
+    {
+      text: strings.remove_from_cmr,
+      action: removeGranule,
+      state: granules.removed,
+      confirm: confirmRemove,
+      className: 'button--remove'
+    },
+    {
+      Component:
+        <Bulk
+          element='button'
+          className='button button__bulkgranules button--green button--small form-group__element'
+          confirmAction={true}
+        />
+    },
+    {
+      text: 'Delete',
+      action: deleteGranule,
+      state: granules.deleted,
+      confirm: confirmDelete,
+      className: 'button--delete'
+    }];
 };
 
 /**

--- a/app/src/js/utils/table-config/granules.js
+++ b/app/src/js/utils/table-config/granules.js
@@ -140,16 +140,18 @@ const determineCollectionsBase = (path) => {
 
 /**
  * Determines next location based on granule success/error and number of
- * successes.  If there's an error do nothing, if there is a single granule
- * visit that granule's detail page, if there are multiple granules reingested
- * visit the running granules page.  Multiple granules will redirect to a base
- * if provided.  This is used by the collections overview to return the user to
- * the correct collections page view context.
+ * successes.
+ *   - If there's an error do nothing.
+ *   - If there is a single granule visit that granule's detail page
+ *   - If there are multiple granules reingested visit the running granules page.
+ * Multiple granules will redirect to a base location determined by the current
+ * location's pathname.
  *
  * @param {Object} anonymous
  * @param {Object} anonymous.history - Connected router history object.
  * @param {Object} anonymous.error - error object.
  * @param {Object} anonymous.selected - array of selected values.
+ * @param {Function} anonymous.setState - setState function for the Modal component.
  * @returns {Function} function to call on confirm selection.
  */
 const setOnConfirm = ({ history, error, selected, setState }) => {

--- a/app/src/js/utils/table-config/granules.js
+++ b/app/src/js/utils/table-config/granules.js
@@ -151,14 +151,14 @@ const determineCollectionsBase = (path) => {
  * @param {Object} anonymous.history - Connected router history object.
  * @param {Object} anonymous.error - error object.
  * @param {Object} anonymous.selected - array of selected values.
- * @param {Function} anonymous.setState - setState function for the Modal component.
+ * @param {Function} anonymous.closeModal - function to close the Modal component.
  * @returns {Function} function to call on confirm selection.
  */
-const setOnConfirm = ({ history, error, selected, setState }) => {
+const setOnConfirm = ({ history, error, selected, closeModal }) => {
   const redirectAndClose = (redirect) => {
     return () => {
       history.push(redirect);
-      if (typeof setState === 'function') setState({ activeModal: false });
+      if (typeof closeModal === 'function') closeModal();
     };
   };
   const baseRedirect = determineCollectionsBase(history.location.pathname);
@@ -178,7 +178,7 @@ const granuleModalJourney = ({
   isOnModalComplete,
   error,
   results,
-  setState
+  closeModal
 }) => {
   const initialEntry = !isOnModalConfirm && !isOnModalComplete;
   const modalOptions = {};
@@ -194,7 +194,7 @@ const granuleModalJourney = ({
       modalOptions.confirmButtonText = (selected.length > 1) ? 'View Running' : 'View Granule';
       modalOptions.cancelButtonClass = 'button--green';
       modalOptions.confirmButtonClass = 'button__goto';
-      modalOptions.onConfirm = setOnConfirm({ history, selected, error, setState });
+      modalOptions.onConfirm = setOnConfirm({ history, selected, error, closeModal });
     }
   }
   return modalOptions;

--- a/app/src/js/utils/table-config/granules.js
+++ b/app/src/js/utils/table-config/granules.js
@@ -172,10 +172,10 @@ export const bulkActions = function (granules, config) {
 };
 
 /**
- * Determines next location based on granule success/error and number If
- * there's an error do nothing, if there is a single granule visit that
- * granule's detail page, if there are multiple granules reingested visit the
- * running granules page.
+ * Determines next location based on granule success/error and number of
+ * successes.  If there's an error do nothing, if there is a single granule
+ * visit that granule's detail page, if there are multiple granules reingested
+ * visit the running granules page.
  *
  * @param {Object} anonymous
  * @param {Object} anonymous.history - Connected router history object.

--- a/cypress/integration/collections_spec.js
+++ b/cypress/integration/collections_spec.js
@@ -406,5 +406,56 @@ describe('Dashboard Collections Page', () => {
       cy.contains('.heading--xlarge', 'Collections');
       cy.contains('.table .tbody .tr a', name);
     });
+
+    it('Should fail to reingest granules on a collection detail page', () => {
+      cy.visit('/collections/collection/MOD09GQ/006');
+      const granuleIds = [
+        'MOD09GQ.A0142558.ee5lpE.006.5112577830916',
+        'MOD09GQ.A9344328.K9yI3O.006.4625818663028'
+      ];
+      cy.server();
+      cy.route({
+        method: 'PUT',
+        url: '/granules/*',
+        status: 500,
+        response: { message: 'Oopsie' }
+      });
+      cy.visit('/granules');
+      cy.get(`[data-value="${granuleIds[0]}"] > .td >input[type="checkbox"]`).click();
+      cy.get(`[data-value="${granuleIds[1]}"] > .td >input[type="checkbox"]`).click();
+      cy.get('.list-actions').contains('Reingest').click();
+      cy.get('.button--submit').click();
+      cy.get('.modal-content > .modal-title').should('contain.text', 'Error');
+      cy.get('.error').should('contain.text', 'Oopsie');
+      cy.get('.button--cancel').click();
+      cy.url().should('match', /\/granules$/);
+      cy.get('.heading--large').should('have.text', 'Granule Overview');
+    });
+
+    it('Should reingest multiple granules and redirect to the running page on a collection detail page', () => {
+      cy.visit('/collections/collection/MOD09GQ/006');
+      const granuleIds = [
+        'MOD09GQ.A0142558.ee5lpE.006.5112577830916',
+        'MOD09GQ.A9344328.K9yI3O.006.4625818663028'
+      ];
+      cy.server();
+      cy.route({
+        method: 'PUT',
+        url: '/granules/*',
+        status: 200,
+        response: { message: 'ingested' }
+      });
+
+      cy.get(`[data-value="${granuleIds[0]}"] > .td >input[type="checkbox"]`).click();
+      cy.get(`[data-value="${granuleIds[1]}"] > .td >input[type="checkbox"]`).click();
+      cy.get('.list-actions').contains('Reingest').click();
+      cy.get('.button--submit').click();
+      cy.get('.modal-content > .modal-title').should('contain.text', 'Complete');
+      cy.get('.modal-content').within(() => {
+        cy.get('.button__goto').click();
+      });
+      cy.url().should('include', '/collections/collection/MOD09GQ/006/granules/processing');
+      cy.get('.heading--medium').should('have.text', 'Running Granules 2');
+    });
   });
 });

--- a/cypress/integration/collections_spec.js
+++ b/cypress/integration/collections_spec.js
@@ -432,8 +432,8 @@ describe('Dashboard Collections Page', () => {
       cy.get('.heading--large').should('have.text', 'Granule Overview');
     });
 
-    it('Should reingest multiple granules and redirect to the running page on a collection detail page', () => {
-      cy.visit('/collections/collection/MOD09GQ/006');
+    it('Should reingest multiple granules and redirect to the running page on a collection\'s granule detail page and close the modal', () => {
+      cy.visit('/collections/collection/MOD09GQ/006/granules');
       const granuleIds = [
         'MOD09GQ.A0142558.ee5lpE.006.5112577830916',
         'MOD09GQ.A9344328.K9yI3O.006.4625818663028'
@@ -456,6 +456,9 @@ describe('Dashboard Collections Page', () => {
       });
       cy.url().should('include', '/collections/collection/MOD09GQ/006/granules/processing');
       cy.get('.heading--medium').should('have.text', 'Running Granules 2');
+
+      // Ensure we have closed the modal.
+      cy.get('.modal-content').should('not.be.visible');
     });
   });
 });

--- a/cypress/integration/granules_spec.js
+++ b/cypress/integration/granules_spec.js
@@ -179,5 +179,71 @@ describe('Dashboard Granules Page', () => {
         .next().contains('li', '1')
         .next().contains('li', '2');
     });
+
+    it('Should reingest a granule and redirect to the granules detail page.', () => {
+      const granuleId = 'MOD09GQ.A0142558.ee5lpE.006.5112577830916';
+      cy.server();
+      cy.route({
+        method: 'PUT',
+        url: '/granules/*',
+        status: 200,
+        response: { message: 'ingested' }
+      });
+      cy.visit('/granules');
+      cy.get(`[data-value="${granuleId}"] > .td >input[type="checkbox"]`).click();
+      cy.get('.list-actions').contains('Reingest').click();
+      cy.get('.button--submit').click();
+      cy.get('.modal-content > .modal-title').should('contain.text', 'Complete');
+      cy.get('.button__goto').click();
+      cy.url().should('include', `granules/granule/${granuleId}`);
+      cy.get('.heading--large').should('have.text', granuleId);
+    });
+
+    it('Should reingest multiple granules and redirect to the running page.', () => {
+      const granuleIds = [
+        'MOD09GQ.A0142558.ee5lpE.006.5112577830916',
+        'MOD09GQ.A9344328.K9yI3O.006.4625818663028'
+      ];
+      cy.server();
+      cy.route({
+        method: 'PUT',
+        url: '/granules/*',
+        status: 200,
+        response: { message: 'ingested' }
+      });
+      cy.visit('/granules');
+      cy.get(`[data-value="${granuleIds[0]}"] > .td >input[type="checkbox"]`).click();
+      cy.get(`[data-value="${granuleIds[1]}"] > .td >input[type="checkbox"]`).click();
+      cy.get('.list-actions').contains('Reingest').click();
+      cy.get('.button--submit').click();
+      cy.get('.modal-content > .modal-title').should('contain.text', 'Complete');
+      cy.get('.button__goto').click();
+      cy.url().should('include', 'granules/processing');
+      cy.get('.heading--large').should('have.text', 'Running Granules 2');
+    });
+
+    it('Should fail to reingest multiple granules and remain on the page.', () => {
+      const granuleIds = [
+        'MOD09GQ.A0142558.ee5lpE.006.5112577830916',
+        'MOD09GQ.A9344328.K9yI3O.006.4625818663028'
+      ];
+      cy.server();
+      cy.route({
+        method: 'PUT',
+        url: '/granules/*',
+        status: 500,
+        response: { message: 'Oopsie' }
+      });
+      cy.visit('/granules');
+      cy.get(`[data-value="${granuleIds[0]}"] > .td >input[type="checkbox"]`).click();
+      cy.get(`[data-value="${granuleIds[1]}"] > .td >input[type="checkbox"]`).click();
+      cy.get('.list-actions').contains('Reingest').click();
+      cy.get('.button--submit').click();
+      cy.get('.modal-content > .modal-title').should('contain.text', 'Error');
+      cy.get('.error').should('contain.text', 'Oopsie');
+      cy.get('.button--cancel').click();
+      cy.url().should('match', /\/granules$/);
+      cy.get('.heading--large').should('have.text', 'Granule Overview');
+    });
   });
 });

--- a/cypress/integration/main_page_spec.js
+++ b/cypress/integration/main_page_spec.js
@@ -177,13 +177,11 @@ describe('Dashboard Home Page', () => {
       cy.get('#Collections').contains('1');
       cy.get('#Granules').contains('11');
       cy.get('#Executions').contains('6');
+      cy.get('[id="Ingest Rules"]').contains('1');
 
       // Test there are values in Granule Error list
       cy.get('[data-value="0"]').contains('FileNotFound');
       cy.get('[data-value="1"]').contains('FileNotFound');
-
-      // This selector fails cy.get('#Ingest Rules').contains('1');
-      cy.get('.overview-num__wrapper-home > ul > :nth-child(5)').contains('1');
 
       cy.get('[data-cy=startDateTime]').within(() => {
         cy.get('input[name=month]').click().type(1);

--- a/package-lock.json
+++ b/package-lock.json
@@ -17017,6 +17017,15 @@
       "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
       "dev": true
     },
+    "rewire": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/rewire/-/rewire-5.0.0.tgz",
+      "integrity": "sha512-1zfitNyp9RH5UDyGGLe9/1N0bMlPQ0WrX0Tmg11kMHBpqwPJI4gfPpP7YngFyLbFmhXh19SToAG0sKKEFcOIJA==",
+      "dev": true,
+      "requires": {
+        "eslint": "^6.8.0"
+      }
+    },
     "rework": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/rework/-/rework-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -148,6 +148,7 @@
     "redux-mock-store": "^1.5.3",
     "redux-test-utils": "^0.2.2",
     "resolve-url-loader": "^3.1.1",
+    "rewire": "^5.0.0",
     "sass-loader": "^8.0.0",
     "sass-resources-loader": "^2.0.1",
     "sinon": "^8.1.1",

--- a/test/components/ReingestGranules/BatchReingestCompleteContent.js
+++ b/test/components/ReingestGranules/BatchReingestCompleteContent.js
@@ -1,0 +1,63 @@
+'use strict';
+
+import test from 'ava';
+import Adapter from 'enzyme-adapter-react-16';
+import React from 'react';
+import { shallow, configure } from 'enzyme';
+
+import BatchReingestComplete, {
+  maxDisplayed
+} from '../../../app/src/js/components/ReingestGranules/BatchReingestCompleteContent';
+
+configure({ adapter: new Adapter() });
+
+const anError = `1 error(s) occurred:
+Execution Does Not Exist: 'arn:aws:states:us-east-1:123456789012:execution:TestStateMachine-Rcei43QwgSP6:bab9c234-e492-40e6-a34c-a0f76a4c7968'; Function params: [
+  {
+    "executionArn": "arn:aws:states:us-east-1:123456789012:execution:TestStateMachine-Rcei43QwgSP6:bab9c234-e492-40e6-a34c-a0f76a4c7968"
+  }
+]`;
+
+test('Renders Error result', (t) => {
+  const wrapper = shallow(
+    <BatchReingestComplete results={[]} error={anError} />
+  );
+
+  t.true(wrapper.find('span').hasClass('error'));
+  t.true(wrapper.text().includes(anError));
+});
+
+test('Renders success results with multiple Granules', (t) => {
+  const results = ['granule-1', 'granule-2'];
+  const wrapper = shallow(
+    <BatchReingestComplete results={results} error={undefined} />
+  );
+
+  t.true(wrapper.html().includes('successfully reingested these granules'));
+  t.is(wrapper.find('ul').children().length, 2);
+});
+
+test('Renders success results with a single granule', (t) => {
+  const results = ['granule-1'];
+  const wrapper = shallow(
+    <BatchReingestComplete results={results} error={undefined} />
+  );
+
+  t.true(wrapper.html().includes('successfully reingested this granule'));
+  t.is(wrapper.find('ul').children().length, 1);
+  t.falsy(wrapper.html().match('and.* more'));
+});
+
+test('Limits success results with a many granules', (t) => {
+  const results = Array.from(Array(maxDisplayed + 5).keys()).map(
+    (t) => `granule-${t}`
+  );
+
+  const wrapper = shallow(
+    <BatchReingestComplete results={results} error={undefined} />
+  );
+
+  t.true(wrapper.html().includes('successfully reingested these granules'));
+  t.is(wrapper.find('ul').children().length, maxDisplayed + 1);
+  t.true(wrapper.html().includes('and 5 more'));
+});

--- a/test/components/ReingestGranules/BatchReingestConfirmContent.js
+++ b/test/components/ReingestGranules/BatchReingestConfirmContent.js
@@ -1,0 +1,65 @@
+'use strict';
+
+import test from 'ava';
+import Adapter from 'enzyme-adapter-react-16';
+import React from 'react';
+import { shallow, configure } from 'enzyme';
+
+import BatchReingestConfirmContent, {
+  maxDisplayed
+} from '../../../app/src/js/components/ReingestGranules/BatchReingestConfirmContent';
+
+configure({ adapter: new Adapter() });
+
+test('Renders successful results with multiple granules', (t) => {
+  const selected = ['granule-a', 'granule-b'];
+
+  const wrapper = shallow(<BatchReingestConfirmContent selected={selected} />);
+
+  t.true(
+    wrapper
+      .text()
+      .includes(
+        'You have submitted a request to reingest the following granules.'
+      )
+  );
+  t.true(wrapper.text().includes('you want to reingest these granules?'));
+  t.falsy(wrapper.text().match('and.*more.'));
+  t.is(wrapper.find('ul').children().length, 2);
+});
+
+test('Renders successful results with a single granule', (t) => {
+  const selected = ['granule-c'];
+
+  const wrapper = shallow(<BatchReingestConfirmContent selected={selected} />);
+
+  t.true(
+    wrapper
+      .text()
+      .includes(
+        'You have submitted a request to reingest the following granule.'
+      )
+  );
+  t.true(wrapper.text().includes('you want to reingest this granule?'));
+  t.falsy(wrapper.text().match('and.*more.'));
+  t.is(wrapper.find('ul').children().length, 1);
+});
+
+test('Abbreviates when number selected is greater than the maxDisplayed', (t) => {
+  const selected = Array.from(Array(maxDisplayed + 5).keys()).map(
+    (t) => `granule-${t}`
+  );
+
+  const wrapper = shallow(<BatchReingestConfirmContent selected={selected} />);
+
+  t.true(
+    wrapper
+      .text()
+      .includes(
+        'You have submitted a request to reingest the following granules.'
+      )
+  );
+  t.true(wrapper.text().includes('you want to reingest these granules?'));
+  t.true(wrapper.text().includes('and 5 more.'));
+  t.is(wrapper.find('ul').children().length, maxDisplayed + 1);
+});

--- a/test/utils/table-config/granules.js
+++ b/test/utils/table-config/granules.js
@@ -3,6 +3,7 @@
 import test from 'ava';
 import rewire from 'rewire';
 import sinon from 'sinon';
+import cloneDeep from 'lodash.clonedeep';
 
 const granules = rewire('../../../app/src/js/utils/table-config/granules');
 
@@ -11,6 +12,7 @@ const setOnConfirm = granules.__get__('setOnConfirm');
 test.beforeEach((t) => {
   t.context.history = {};
   t.context.history.push = sinon.fake();
+  t.context.history.location = { pathname: '/granules' };
 });
 
 test.afterEach((t) => {
@@ -45,4 +47,45 @@ test('setOnConfirm navigates to the processing page with multiple selected granu
   confirmCallback();
 
   t.true(t.context.history.push.calledWith('/granules/processing'));
+});
+
+test('setOnConfirm navigates to the correct processing page irrespective of the current location.', (t) => {
+  const input = {
+    history: t.context.history,
+    selected: ['one-granule', 'two-granule']
+  };
+
+  const locationExpects = [
+    {
+      pathname: 'collections/collection/MOD09GQ/006/granules/completed',
+      expected: 'collections/collection/MOD09GQ/006/granules/processing'
+    },
+    {
+      pathname: 'collections/collection/MOD09GQ/006/granules/processing',
+      expected: 'collections/collection/MOD09GQ/006/granules/processing'
+    },
+    {
+      pathname: 'collections/collection/MOD09GQ/006',
+      expected: 'collections/collection/MOD09GQ/006/granules/processing'
+    },
+    {
+      pathname: 'collections/collection/MOD09GQ/006/granules',
+      expected: 'collections/collection/MOD09GQ/006/granules/processing'
+    },
+    {
+      pathname: '/granules/completed',
+      expected: '/granules/processing'
+    }
+  ];
+
+  locationExpects.forEach((o) => {
+    const testInput = cloneDeep(input);
+    testInput.history.location.pathname = o.pathname;
+    const confirmCallback = setOnConfirm(testInput);
+    confirmCallback();
+    t.true(t.context.history.push.calledWith(o.expected));
+  });
+  const confirmCallback = setOnConfirm(input);
+
+  confirmCallback();
 });

--- a/test/utils/table-config/granules.js
+++ b/test/utils/table-config/granules.js
@@ -98,7 +98,4 @@ test('setOnConfirm navigates to the correct processing page irrespective of the 
     confirmCallback();
     t.true(t.context.history.push.calledWith(o.expected));
   });
-  const confirmCallback = setOnConfirm(input);
-
-  confirmCallback();
 });

--- a/test/utils/table-config/granules.js
+++ b/test/utils/table-config/granules.js
@@ -1,0 +1,48 @@
+'use strict';
+
+import test from 'ava';
+import rewire from 'rewire';
+import sinon from 'sinon';
+
+const granules = rewire('../../../app/src/js/utils/table-config/granules');
+
+const setOnConfirm = granules.__get__('setOnConfirm');
+
+test.beforeEach((t) => {
+  t.context.history = {};
+  t.context.history.push = sinon.fake();
+});
+
+test.afterEach((t) => {
+  sinon.restore();
+});
+
+test('setOnConfirm does nothing with an error', (t) => {
+  const input = { history: t.context.history, error: true };
+  const confirmCallback = setOnConfirm(input);
+
+  confirmCallback();
+
+  t.true(t.context.history.push.notCalled);
+});
+
+test('setOnConfirm navigates to the target granule with a single selected granule', (t) => {
+  const input = { history: t.context.history, selected: ['one-granule'] };
+  const confirmCallback = setOnConfirm(input);
+
+  confirmCallback();
+
+  t.true(t.context.history.push.calledWith('/granules/granule/one-granule'));
+});
+
+test('setOnConfirm navigates to the processing page with multiple selected granules', (t) => {
+  const input = {
+    history: t.context.history,
+    selected: ['one-granule', 'two-granule']
+  };
+  const confirmCallback = setOnConfirm(input);
+
+  confirmCallback();
+
+  t.true(t.context.history.push.calledWith('/granules/processing'));
+});

--- a/test/utils/table-config/granules.js
+++ b/test/utils/table-config/granules.js
@@ -49,6 +49,19 @@ test('setOnConfirm navigates to the processing page with multiple selected granu
   t.true(t.context.history.push.calledWith('/granules/processing'));
 });
 
+test('setOnConfirm calls setState to close the modal with multiple selected granules', (t) => {
+  const input = {
+    history: t.context.history,
+    selected: ['one-granule', 'two-granule'],
+    setState: sinon.fake()
+  };
+  const confirmCallback = setOnConfirm(input);
+
+  confirmCallback();
+  t.true(t.context.history.push.calledWith('/granules/processing'));
+  t.true(input.setState.calledWith({ activeModal: false }));
+});
+
 test('setOnConfirm navigates to the correct processing page irrespective of the current location.', (t) => {
   const input = {
     history: t.context.history,

--- a/test/utils/table-config/granules.js
+++ b/test/utils/table-config/granules.js
@@ -53,13 +53,13 @@ test('setOnConfirm calls setState to close the modal with multiple selected gran
   const input = {
     history: t.context.history,
     selected: ['one-granule', 'two-granule'],
-    setState: sinon.fake()
+    closeModal: sinon.fake()
   };
   const confirmCallback = setOnConfirm(input);
 
   confirmCallback();
   t.true(t.context.history.push.calledWith('/granules/processing'));
-  t.true(input.setState.calledWith({ activeModal: false }));
+  t.true(input.closeModal.called);
 });
 
 test('setOnConfirm navigates to the correct processing page irrespective of the current location.', (t) => {


### PR DESCRIPTION
# Track reingested granules on the dashboard.

- Updates the modal workflow for a reingest action on the granule page.
  + When there is a single granule reingested, on complete action the user is redirected to that granule's overview page.
  + When multiple granules are ingested the complete action redirects the user to the granule's running page `/granule/processing`
  
- Adds reingest bulk action to the collections overview page with same behavior as for the granules page.
  

