### PR TITLE
[CUMULUS-1767] Fix lack of error messaging when attempting to update collection name or version

### DIFF
--- a/app/src/js/actions/index.js
+++ b/app/src/js/actions/index.js
@@ -158,12 +158,13 @@ export const createCollection = (payload) => ({
   }
 });
 
-export const updateCollection = (payload) => ({
+// include the option to specify the name and version of the collection to update in case they differ in the payload
+export const updateCollection = (payload, name, version) => ({
   [CALL_API]: {
     type: types.UPDATE_COLLECTION,
     method: 'PUT',
-    id: getCollectionId(payload),
-    path: `collections/${payload.name}/${payload.version}`,
+    id: (name && version) ? getCollectionId({ name, version }) : getCollectionId(payload),
+    path: `collections/${name || payload.name}/${version || payload.version}`,
     body: payload
   }
 });

--- a/app/src/js/components/Collections/edit.js
+++ b/app/src/js/components/Collections/edit.js
@@ -24,7 +24,7 @@ const EditCollection = ({ match, collections }) => {
       primaryProperty='name'
       state={collections}
       getRecord={() => getCollection(name, version)}
-      updateRecord={updateCollection}
+      updateRecord={payload => updateCollection(payload, name, version)}
       backRoute={`/collections/collection/${name}/${version}`}
       clearRecordUpdate={clearUpdateCollection}
       hasModal={true}

--- a/cypress/integration/collections_spec.js
+++ b/cypress/integration/collections_spec.js
@@ -269,6 +269,32 @@ describe('Dashboard Collections Page', () => {
       cy.contains('.heading--large', `${name} / ${version}`);
     });
 
+    it('should display an error when attempting to edit a collection name or version', () => {
+      const name = 'MOD09GQ';
+      const version = '006';
+
+      cy.visit(`/collections/collection/${name}/${version}`);
+      cy.contains('a', 'Edit').as('editCollection');
+      cy.get('@editCollection')
+        .should('have.attr', 'href')
+        .and('include', `/collections/edit/${name}/${version}`);
+      cy.get('@editCollection').click();
+
+      cy.contains('.heading--large', `${name}___${version}`);
+
+      // change name and version
+      // Edit Collection should display proper error message
+      const newName = 'TEST';
+      const newVersion = '2';
+      const errorMessage = `Expected collection name and version to be '${name}' and '${version}', respectively, but found '${newName}' and '${newVersion}' in payload`;
+      cy.contains('.ace_variable', 'name');
+      cy.editJsonTextarea({ data: { name: newName, version: newVersion }, update: true });
+      cy.contains('form button', 'Submit').click();
+      cy.contains('.default-modal .edit-collection__title', 'Edit Collection');
+      cy.contains('.default-modal .modal-body', `Collection ${name}___${version} has encountered an error.`);
+      cy.get('.default-modal .modal-body .error').invoke('text').should('eq', errorMessage);
+    });
+
     it('should delete a collection', () => {
       cy.visit('/');
       const name = 'https_testcollection';


### PR DESCRIPTION
**Description of bug:** When editing the name or version of a collection, there is an error in the console, but it is not displayed in the modal or error message banner

**Solution:** This was happening because the request to `updateCollection` was using the name and version from the payload, regardless of the original collection the user is trying to edit. This causes the request to 404, since that new collection does not exist.

Additionally, in the redux state, that new collection id would be added to `collections.updated` instead of the id of the original collection.  `EditRaw` attempts to grab the error from `collections.updated[ORIGINAL COLLECTION ID]`, but it is undefined, since the request went to the new collection. Instead, `collections.updated[NEW COLLECTION ID]` is defined.

To get the correct error behavior, we need a way for `updateCollection` to know the original collection id. The solution is to make `name` and `version` optional params for that function. That way, if they are present, they will override the values from the payload. Therefore, `collections.updated[ORIGINAL COLLECTION ID]` is no longer undefined, the correct 400 error is returned from the API, and that error is displayed.

https://nasa.github.io/cumulus-api/#updatereplace-collection


Change ended up being relatively simple. Also added a test to verify the error is properly displayed.