### PR TITLE
Prevents accidental overwrite of this.cancelInterval

### DIFF
--- a/app/src/js/components/home.js
+++ b/app/src/js/components/home.js
@@ -55,7 +55,7 @@ class Home extends React.Component {
 
   componentDidMount () {
     const { dispatch } = this.props;
-    this.cancelInterval = interval(this.query, updateInterval, true);
+    this.refreshQuery();
     dispatch(getCumulusInstanceMetadata())
       .then(() => {
         dispatch(getDistApiGatewayMetrics(this.props.cumulusInstance));


### PR DESCRIPTION
This fixes ~a number~ of timer bugs. (update: fixes CUMULUS-1811)
I will add the tickets as I verify them.

What was happening is that the componentWillMount was setting the cancelInterval function on this.cancelInterval without checking to see if one already existed and canceling that one.  The datepicker uses refreshQuery to do the same thing.  So sometimes this.cancelInterval was overwritten leaving an interval in place, when the user navigated to other pages, this interval would kick off unexpectedly causing update of granule data and causing the table to get rerended with unexpected data.

