### PR TITLE
Fix bug in dropdowns on granules page

### DIFF
--- a/app/src/js/reducers/granules.js
+++ b/app/src/js/reducers/granules.js
@@ -84,9 +84,9 @@ export default createReducer(initialState, {
   },
   [GRANULES]: (state, action) => {
     state.list = {
+      ...state.list,
       data: removeDeleted('granuleId', action.data.results, state.deleted),
       meta: assignDate(action.data.meta),
-      params: {},
       inflight: false,
       error: false
     };


### PR DESCRIPTION
Since the reducer was directly setting `state.list`, any changes to the state were overridden. Also, any changes to `state.list.params` were overridden because it was set to an empty object. Updated the reducer to use the spread operator so that it can maintain the full `state.list` object.