### PR TITLE
Workaround to resolve intermittent failure in collection_spec

### DIFF
--- a/app/src/js/components/Form/_form.scss
+++ b/app/src/js/components/Form/_form.scss
@@ -227,7 +227,7 @@ select option{
     display: block;
   }
   .metadata__updated {
-    padding-top: 18px;
+    margin-top: 18px;
     padding-right: 4px;
     &:hover {
       text-decoration: underline;

--- a/cypress/integration/collections_spec.js
+++ b/cypress/integration/collections_spec.js
@@ -159,6 +159,10 @@ describe('Dashboard Collections Page', () => {
       // collections with which to populate the dropdown on the collection
       // details page.
       cy.visit('/collections');
+      // TODO [DOP, 2020-05-14] Workaround until CUMULUS-1996 is resolved
+      // Stop timer so that it does not dispatch listCollections and change
+      // the order of items in the list after date is cleared
+      cy.get('.form__element__updateToggle .form__element__clickable').click();
       cy.clearStartDateTime();
       cy.wait('@getCollections');
       cy.get('.table .tbody .tr').should('have.length', 5);


### PR DESCRIPTION
The test is failing because once the date picker is clear, `listCollections` is called with no options. Then, before Cypress can actually click the correct item in the table, the timer dispatches `listCollections` with the correct options and changes the order. It then clicks the wrong item and the rest of the test fails.

This workaround simply stops the timer before clearing the date so that the order will remain the same when the click occurs.