### PR TITLE
[CUMULUS-1888] Granule Pagination improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
+### Changed
+- **CUMULUS-1888**
+  - On the Granules page, CSV data was being refreshed in the background alog with the rest
+    of the data based on the timer. This could take a long time, depending on the number of granules.
+    This has been changed so that the data is only fetched when the user clicks the "Download CSV" button.
+
 ## [v1.8.1]
 
 ### Changed

--- a/app/src/js/components/Granules/overview.js
+++ b/app/src/js/components/Granules/overview.js
@@ -33,7 +33,7 @@ import statusOptions from '../../utils/status';
 import _config from '../../config';
 import { strings } from '../locale';
 import { workflowOptionNames } from '../../selectors';
-import { window } from '../../utils/browser';
+import { window, document } from '../../utils/browser';
 import ListFilters from '../ListActions/ListFilters';
 import Breadcrumbs from '../Breadcrumbs/Breadcrumbs';
 import pageSizeOptions from '../../utils/page-size';
@@ -61,6 +61,7 @@ class GranulesOverview extends React.Component {
     this.applyWorkflow = this.applyWorkflow.bind(this);
     this.getExecuteOptions = this.getExecuteOptions.bind(this);
     this.applyRecoveryWorkflow = this.applyRecoveryWorkflow.bind(this);
+    this.downloadGranuleCSV = this.downloadGranuleCSV.bind(this);
     this.state = {};
   }
 
@@ -79,7 +80,6 @@ class GranulesOverview extends React.Component {
       type: 'granules',
       field: 'status'
     }));
-    dispatch(getGranuleCSV());
   }
 
   generateQuery () {
@@ -128,12 +128,27 @@ class GranulesOverview extends React.Component {
     ];
   }
 
+  downloadGranuleCSV () {
+    const { dispatch } = this.props;
+    dispatch(getGranuleCSV()).then(() => {
+      const { granuleCSV } = this.props;
+      const { data } = granuleCSV;
+      const csvData = new Blob([data], { type: 'text/csv' });
+
+      const link = document.createElement('a');
+      link.setAttribute('download', 'granules.csv');
+      const url = window.URL.createObjectURL(csvData);
+      link.href = url;
+      document.body.appendChild(link);
+      link.click();
+      link.parentNode.removeChild(link);
+    });
+  }
+
   render () {
-    const { stats, granules, granuleCSV, dispatch } = this.props;
+    const { stats, granules, dispatch } = this.props;
     const { list, dropdowns } = granules;
     const { count, queriedAt } = list.meta;
-    const { data } = granuleCSV;
-    const csvData = data ? new Blob([data], { type: 'text/csv' }) : null;
     const statsCount = get(stats, 'count.data.granules.count', []);
     const overviewItems = statsCount.map(d => [tally(d.count), displayCase(d.key)]);
     return (
@@ -151,12 +166,10 @@ class GranulesOverview extends React.Component {
         <section className='page__section'>
           <div className='heading__wrapper--border'>
             <h2 className='heading--medium heading--shared-content with-description'>{strings.granules} <span className='num--title'>{count ? ` ${tally(count)}` : 0}</span></h2>
-            {csvData &&
-              <a className='csv__download button button--small button--download button--green form-group__element--right'
-                id='download_link'
-                download='granules.csv'
-                href={window.URL.createObjectURL(csvData)}
-              >Download Granule List</a>}
+            <a className='csv__download button button--small button--download button--green form-group__element--right'
+              id='download_link'
+              onClick={this.downloadGranuleCSV}
+            >Download Granule List</a>
           </div>
           <List
             list={list}

--- a/cypress/integration/granules_spec.js
+++ b/cypress/integration/granules_spec.js
@@ -109,8 +109,7 @@ describe('Dashboard Granules Page', () => {
 
       cy.contains('.heading--xlarge', 'Granules');
 
-      cy.contains('a', 'Download Granule List')
-        .should('have.attr', 'href').should('include', 'blob:http://');
+      cy.contains('a', 'Download Granule List');
     });
 
     it('Should update dropdown with label when visiting bookmarkable URL', () => {

--- a/test/components/granules/overview.js
+++ b/test/components/granules/overview.js
@@ -6,6 +6,7 @@ import React from 'react';
 import 'jsdom-global/register';
 import { Provider } from 'react-redux';
 import { shallow, configure } from 'enzyme';
+import sinon from 'sinon';
 import { GranulesOverview } from '../../../app/src/js/components/Granules/overview';
 
 configure({ adapter: new Adapter() });
@@ -35,7 +36,11 @@ const granules = {
     }
   }
 };
-const data = '';
+const data = {
+  data: 'granuleUr","collectionId","createdAt","startDateTime","endDateTime" "MOD09GQ.A1657416.CbyoRi.006.9697917818587","MOD09GQ___006","2018-09-24T23:28:43.341Z","2017-10-24T00:00:00.000Z","2017-11-08T23:59:59.000Z" "MOD09GQ.A0142558.ee5lpE.006.5112577830916","MOD09GQ___006","2018-09-24T17:53:10.359Z","2017-10-24T00:00:00.000Z","2017-11-08T23:59:59.000Z" "MOD09GQ.A2417309.YZ9tCV.006.4640974889044","MOD09GQ___006","2018-09-24T23:09:52.105Z","","" "MOD09GQ.A8022119.sk3Sph.006.0494433853533","MOD09GQ___006","2018-09-24T17:38:15.121Z","2017-10-24T00:00:00.000Z","2017-11-08T23:59:59.000Z" "MOD09GQ.A9344328.K9yI3O.006.4625818663028","MOD09GQ___006","2018-09-24T17:29:51.858Z","","" "MOD09GQ.A4622742.B7A8Ma.006.7857260550036","MOD09GQ___006","2019-12-11T23:19:23.823Z","2017-10-24T00:00:00Z","2017-11-08T23:59:59Z" "MOD09GQ.A5456658.rso6Y4.006.4979096122140","MOD09GQ___006","2018-09-24T23:11:06.647Z","2017-10-24T00:00:00.000Z","2017-11-08T23:59:59.000Z" "MOD09GQ.A1530852.CljGDp.006.2163412421938","MOD09GQ___006","2018-09-24T23:29:16.154Z","2017-10-24T00:00:00.000Z","2017-11-08T23:59:59.000Z" "MOD09GQ.A2016358.h13v04.006.2016360104606.hdf","MOD09GQ___006","2018-09-24T23:27:50.335Z","","" "MOD09GQ.A2016358.h13v04.006.2016360104606","MOD09GQ___006","2018-11-12T20:05:10.348Z","","" "MOD09GQ.A0501579.PZB_CG.006.8580266395214","MOD09GQ___006","2018-09-24T17:52:32.232Z","2017-10-24T00:00:00.000Z","2017-11-08T23:59:59.000Z"',
+  inflight: false,
+  error: null
+};
 
 test('GranulesOverview generates bulkAction for recovery button', function (t) {
   const dispatch = () => {};
@@ -101,4 +106,34 @@ test('GranulesOverview does not generate bulkAction for recovery button', functi
   const recoverFilter = (object) => object.text === 'Recover Granule';
   const recoverActionList = listBulkActions.filter(recoverFilter);
   t.is(recoverActionList.length, 0);
+});
+
+test('GranulesOverview will download CSV data when the Download Granule List button is clicked and not leave extra link on the page', function (t) {
+  window.URL.createObjectURL = sinon.fake.returns('www.example.com');
+  const dispatch = () => Promise.resolve();
+  const config = { enableRecovery: false };
+  const store = {
+    subscribe: () => {},
+    dispatch: dispatch,
+    getState: () => {}
+  };
+
+  const providerWrapper = shallow(
+    <Provider store={store}>
+      <GranulesOverview
+        granules = {granules}
+        granuleCSV = {data}
+        dispatch = {dispatch}
+        location = {location}
+        config={config}/>
+    </Provider>);
+
+  const overviewWrapper = providerWrapper.find('GranulesOverview').dive();
+
+  const granuleCSVButton = overviewWrapper.find('a.csv__download');
+  granuleCSVButton.simulate('click');
+
+  // should not leave extra link on the page
+  const downloadLink = overviewWrapper.find('a[href="www.example.com"]');
+  t.is(downloadLink.length, 0);
 });


### PR DESCRIPTION
So Far:

* Change the Granule CSV Download. Before it would constantly refresh the CSV data in the background, which could take 1.5s with ~5000 granules. Now the data isn't updated until the user clicks the button.