### PR TITLE
Mhs/cumulus 1869/fix granule metrics tiles

### DIFF
--- a/app/src/js/actions/index.js
+++ b/app/src/js/actions/index.js
@@ -74,19 +74,27 @@ export const refreshAccessToken = (token) => {
 export const setTokenState = (token) => ({ type: types.SET_TOKEN, token });
 
 export const interval = function (action, wait, immediate) {
-  if (immediate) { action(); }
+  if (immediate) {
+    action();
+  }
   const intervalId = setInterval(action, wait);
   return () => clearInterval(intervalId);
 };
 
-export const getCollection = (name, version) => ({
-  [CALL_API]: {
-    type: types.COLLECTION,
-    method: 'GET',
-    id: getCollectionId({ name, version }),
-    path: `collections?name=${name}&version=${version}`
-  }
-});
+export const getCollection = (name, version) => {
+  return (dispatch, getState) => {
+    const timeFilters = fetchCurrentTimeFilters(getState().datepicker);
+    return dispatch({
+      [CALL_API]: {
+        type: types.COLLECTION,
+        method: 'GET',
+        id: getCollectionId({ name, version }),
+        path: `collections?name=${name}&version=${version}`,
+        qs: timeFilters,
+      },
+    });
+  };
+};
 
 export const getApiVersion = () => {
   return (dispatch) => {

--- a/app/src/js/components/Collections/overview.js
+++ b/app/src/js/components/Collections/overview.js
@@ -1,8 +1,9 @@
 'use strict';
+import { get } from 'object-path';
+import PropTypes from 'prop-types';
 import React from 'react';
 import { connect } from 'react-redux';
-import { withRouter, Link } from 'react-router-dom';
-import PropTypes from 'prop-types';
+import { Link, withRouter } from 'react-router-dom';
 import {
   clearGranulesFilter,
   clearGranulesSearch,
@@ -13,30 +14,30 @@ import {
   listGranules,
   searchGranules,
 } from '../../actions';
-import { get } from 'object-path';
 import {
   collectionName as collectionLabelForId,
-  tally,
-  lastUpdated,
-  getCollectionId,
   collectionNameVersion,
+  getCollectionId,
+  lastUpdated,
+  tally,
 } from '../../utils/format';
+import pageSizeOptions from '../../utils/page-size';
+import statusOptions from '../../utils/status';
+import isEqual from 'lodash.isequal';
+import {
+  reingestAction,
+  tableColumns,
+} from '../../utils/table-config/granules';
+import Breadcrumbs from '../Breadcrumbs/Breadcrumbs';
+import DeleteCollection from '../DeleteCollection/DeleteCollection';
 import Dropdown from '../DropDown/dropdown';
 import SimpleDropdown from '../DropDown/simple-dropdown';
-import Search from '../Search/search';
-import statusOptions from '../../utils/status';
-import pageSizeOptions from '../../utils/page-size';
-import List from '../Table/Table';
 import Bulk from '../Granules/bulk';
-import Overview from '../Overview/overview';
-import {
-  tableColumns,
-  reingestAction,
-} from '../../utils/table-config/granules';
-import { strings } from '../locale';
-import DeleteCollection from '../DeleteCollection/DeleteCollection';
-import Breadcrumbs from '../Breadcrumbs/Breadcrumbs';
 import ListFilters from '../ListActions/ListFilters';
+import { strings } from '../locale';
+import Overview from '../Overview/overview';
+import Search from '../Search/search';
+import List from '../Table/Table';
 
 const breadcrumbConfig = [
   {
@@ -76,7 +77,11 @@ class CollectionOverview extends React.Component {
     const { name, version } = this.props.match.params;
     const { name: prevName, version: prevVersion } = prevProps.match.params;
 
-    if (name !== prevName || version !== prevVersion) {
+    if (
+      name !== prevName ||
+      version !== prevVersion ||
+      !isEqual(this.props.datepicker, prevProps.datepicker)
+    ) {
       this.load();
     }
   }
@@ -322,17 +327,19 @@ class CollectionOverview extends React.Component {
 CollectionOverview.displayName = 'CollectionOverview';
 
 CollectionOverview.propTypes = {
-  match: PropTypes.object,
-  history: PropTypes.object,
+  collections: PropTypes.object,
+  datepicker: PropTypes.object,
   dispatch: PropTypes.func,
   granules: PropTypes.object,
-  collections: PropTypes.object,
+  history: PropTypes.object,
+  match: PropTypes.object,
   router: PropTypes.object,
 };
 
 export default withRouter(
   connect((state) => ({
     collections: state.collections,
+    datepicker: state.datepicker,
     granules: state.granules,
   }))(CollectionOverview)
 );

--- a/app/src/js/components/Overview/overview.js
+++ b/app/src/js/components/Overview/overview.js
@@ -4,21 +4,22 @@ import PropTypes from 'prop-types';
 import Loading from '../LoadingIndicator/loading-indicator';
 
 class Overview extends React.Component {
-  constructor () {
+  constructor() {
     super();
     this.displayName = 'Overview';
   }
 
-  render () {
+  render() {
     const { inflight, items } = this.props;
     return (
-      <div className='overview-num__wrapper'>
+      <div className="overview-num__wrapper" data-cy="overview-num">
         {inflight ? <Loading /> : null}
         <ul>
-          {items.map(d => (
+          {items.map((d) => (
             <li key={d[1]}>
-              <span className='overview-num overview-num--small' to='/'>
-                <span className='num--large num--large--color'>{d[0]}</span><span className='num-status'>{d[1]}</span>
+              <span className="overview-num overview-num--small" to="/">
+                <span className="num--large num--large--color">{d[0]}</span>
+                <span className="num-status">{d[1]}</span>
               </span>
             </li>
           ))}
@@ -30,7 +31,7 @@ class Overview extends React.Component {
 
 Overview.propTypes = {
   items: PropTypes.array,
-  inflight: PropTypes.bool
+  inflight: PropTypes.bool,
 };
 
 export default Overview;

--- a/app/src/js/components/Timer/timer.js
+++ b/app/src/js/components/Timer/timer.js
@@ -8,6 +8,7 @@ import {
   TIMER_STOP,
   TIMER_SET_COUNTDOWN,
 } from '../../actions/types';
+import isEqual from 'lodash.isequal';
 
 const { updateInterval } = _config;
 
@@ -32,7 +33,8 @@ class Timer extends React.Component {
   componentDidUpdate(prevProps) {
     if (
       JSON.stringify(prevProps.config) !== JSON.stringify(this.props.config) ||
-      (this.props.reload && prevProps.reload !== this.props.reload)
+      (this.props.reload && prevProps.reload !== this.props.reload) ||
+      !isEqual(prevProps.datepicker, this.props.datepicker)
     ) {
       this.refreshTimer(this.props.config);
     }
@@ -124,6 +126,7 @@ class Timer extends React.Component {
 Timer.propTypes = {
   action: PropTypes.func,
   config: PropTypes.object,
+  datepicker: PropTypes.object,
   dispatch: PropTypes.func,
   noheader: PropTypes.bool,
   reload: PropTypes.any,
@@ -131,5 +134,6 @@ Timer.propTypes = {
 };
 
 export default connect((state) => ({
+  datepicker: state.datepicker,
   timer: state.timer,
 }))(Timer);

--- a/cypress/integration/collections_spec.js
+++ b/cypress/integration/collections_spec.js
@@ -490,5 +490,34 @@ describe('Dashboard Collections Page', () => {
       // Ensure we have closed the modal.
       cy.get('.modal-content').should('not.be.visible');
     });
+
+    it('Should display Granule Metrics that match the datepicker selection', () => {
+      cy.visit('/collections/collection/MOD09GQ/006');
+
+      cy.get('[data-cy=endDateTime]').within(() => {
+        cy.get('input[name=month]').click().type(3);
+        cy.get('input[name=day]').click().type(17);
+        cy.get('input[name=year]').click().type(2009);
+        cy.get('input[name=hour12]').click().type(3);
+        cy.get('input[name=minute]').click().type(37);
+        cy.get('input[name=minute]').should('have.value', '37');
+        cy.get('select[name=amPm]').select('PM');
+      });
+      cy.get('[data-cy=overview-num]').within(() => {
+        cy.get('li')
+          .first().should('contain', '--').and('contain', 'Completed')
+          .next().should('contain', '--').and('contain', 'Failed')
+          .next().should('contain', '--').and('contain', 'Running');
+      });
+
+      cy.get('[data-cy=endDateTime] > .react-datetime-picker > .react-datetime-picker__wrapper > .react-datetime-picker__clear-button > .react-datetime-picker__clear-button__icon').click();
+
+      cy.get('[data-cy=overview-num]').within(() => {
+        cy.get('li')
+          .first().should('contain', 7).and('contain', 'Completed')
+          .next().should('contain', 2).and('contain', 'Failed')
+          .next().should('contain', 2).and('contain', 'Running');
+      });
+    });
   });
 });

--- a/test/actions/recover.js
+++ b/test/actions/recover.js
@@ -28,6 +28,10 @@ const store = mockStore({
     recovered: {},
     executed: {},
     meta: {}
+  },
+  datepicker: {
+    startDateTime: null,
+    endDateTime: null,
   }
 });
 const getActionType = (action) => action.type;


### PR DESCRIPTION
Connects datepicker state to the timer the timer and now will the timer will refresh on datepicker changes.

Adds datepicker params to the getCollection call to Cumulus API so that the correct statistics show up when a page is filtered by the datepicker.

Adds cypress `data-cy` selector to overview for testing.


after this PR all of these items will have been addressed.
Fixes: https://bugs.earthdata.nasa.gov/browse/CUMULUS-1869

