### PR TITLE
CUMULUS-1913: Add datepicker to Reconciliation Reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     of the data based on the timer. This could take a long time, depending on the number of granules.
     This has been changed so that the data is only fetched when the user clicks the "Download CSV" button.
 
+- **CUMULUS-1913**
+  - Add datepicker to reconcilation-reports page
+
 - **CUMULUS-1916**
   - reconcilation-reports page now requires Cumulus API version >= v1.23.0
 

--- a/app/src/js/actions/index.js
+++ b/app/src/js/actions/index.js
@@ -923,14 +923,19 @@ export const clearRulesSearch = () => ({ type: types.CLEAR_RULES_SEARCH });
 export const filterRules = (param) => ({ type: types.FILTER_RULES, param: param });
 export const clearRulesFilter = (paramKey) => ({ type: types.CLEAR_RULES_FILTER, paramKey: paramKey });
 
-export const listReconciliationReports = (options) => ({
-  [CALL_API]: {
-    type: types.RECONCILIATIONS,
-    method: 'GET',
-    url: new URL('reconciliationReports', root).href,
-    qs: Object.assign({ limit: defaultPageLimit }, options)
-  }
-});
+export const listReconciliationReports = (options) => {
+  return (dispatch, getState) => {
+    const timeFilters = fetchCurrentTimeFilters(getState().datepicker);
+    return dispatch({
+      [CALL_API]: {
+        type: types.RECONCILIATIONS,
+        method: 'GET',
+        url: new URL('reconciliationReports', root).href,
+        qs: Object.assign({ limit: defaultPageLimit }, options, timeFilters)
+      }
+    });
+  };
+};
 
 export const getReconciliationReport = (reconciliationName) => ({
   [CALL_API]: {

--- a/app/src/js/components/ReconciliationReports/index.js
+++ b/app/src/js/components/ReconciliationReports/index.js
@@ -4,22 +4,15 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter, Route, Switch } from 'react-router-dom';
 import Sidebar from '../Sidebar/sidebar';
-import { getCount } from '../../actions';
+import { strings } from '../locale';
+import { getCount, listReconciliationReports } from '../../actions';
 import ReconciliationReportList from './list';
 import ReconciliationReport from './reconciliation-report';
-import withQueryParams from 'react-router-query-params';
+import DatePickerHeader from '../../components/DatePickerHeader/DatePickerHeader';
 
 class ReconciliationReports extends React.Component {
-  constructor () {
-    super();
-    this.queryParams = this.queryParams.bind(this);
-  }
-
-  componentDidMount () {
-    this.queryParams();
-  }
-
-  queryParams () {
+  query() {
+    this.props.dispatch(listReconciliationReports());
     this.props.dispatch(getCount({
       type: 'reconciliationReports',
       field: 'status'
@@ -29,11 +22,7 @@ class ReconciliationReports extends React.Component {
   render () {
     return (
       <div className='page__reconciliations'>
-        <div className='content__header'>
-          <div className='row'>
-            <h1 className='heading--xlarge heading--shared-content'>Reconciliation Reports</h1>
-          </div>
-        </div>
+        <DatePickerHeader onChange={this.query} heading={strings.reconciliation_reports} />
         <div className='page__content'>
           <div className='wrapper__sidebar'>
             <Sidebar
@@ -61,7 +50,4 @@ ReconciliationReports.propTypes = {
 
 ReconciliationReports.displayName = 'Reconciliation Reports';
 
-export default withRouter(withQueryParams()(connect(state => ({
-  stats: state.stats,
-  reconciliationReports: state.reconciliationReports
-}))(ReconciliationReports)));
+export default withRouter(connect()(ReconciliationReports));

--- a/app/src/js/components/locale.js
+++ b/app/src/js/components/locale.js
@@ -34,6 +34,7 @@ export const strings = new LocalizedStrings({
     logo: 'cumulus-logo.png',
     operations: 'Operations',
     pdrs: 'Pdrs',
+    reconciliation_reports: 'Reconciliation Reports',
     remove_from_cmr: 'Remove from CMR',
     running_granules: 'Running Granules',
     total_granules: 'Total Granules',
@@ -69,8 +70,10 @@ export const strings = new LocalizedStrings({
     logo: 'gitc-logo.png',
     operations: 'Operations',
     pdrs: 'Pdrs',
+    reconciliation_reports: 'Reconciliation Reports',
     remove_from_cmr: 'Remove from OnEarth',
     running_granules: 'Running Products',
+    total_granules: 'Total Products',
     view_all_granules: 'View All Products',
     view_granules_overview: 'View Product Overview'
   }

--- a/test/actions/datefilters.js
+++ b/test/actions/datefilters.js
@@ -68,6 +68,8 @@ test('Each of these list action creators will pull data from datepicker state wh
     { action: 'OPERATIONS_INFLIGHT', dispatcher: listOperations },
     { action: 'PDRS_INFLIGHT', dispatcher: listPdrs },
     { action: 'PROVIDERS_INFLIGHT', dispatcher: listProviders },
+    { action: 'PROVIDERS_INFLIGHT', dispatcher: listProviders },
+    { action: 'RECONCILIATIONS_INFLIGHT', dispatcher: listReconciliationReports },
     { action: 'RULES_INFLIGHT', dispatcher: listRules },
     { action: 'STATS_INFLIGHT', dispatcher: getStats }
   ];
@@ -95,7 +97,6 @@ test('Each of these list action creators will pull data from datepicker state wh
 test('Each of these list action creators will not use data from datepicker state when calling the Cumulus API.', (t) => {
   const endpoints = [
     { action: 'WORKFLOWS_INFLIGHT', dispatcher: listWorkflows },
-    { action: 'RECONCILIATIONS_INFLIGHT', dispatcher: listReconciliationReports },
     { action: 'EXECUTION_LOGS_INFLIGHT', dispatcher: getExecutionLogs }
   ];
 


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-1913: Add datepicker to Reconciliation Reports](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1913)

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Adhoc testing
- [ ] Integration tests