### PR TITLE
[CUMULUS-1904] Add TableFilters component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 ## [Unreleased]
 
+### Added
+
+- **CUMULUS-1904**
+  - Adds a TableFilters component for dynamically showing/hiding table columns
 
 ### Changed
 - **CUMULUS-1888**

--- a/app/src/css/_buttons.scss
+++ b/app/src/css/_buttons.scss
@@ -553,4 +553,23 @@
         
       } 
     }
+
+    &__filter {
+      background-color: $light-green;
+      position: relative;
+    
+      &:before {
+        color: $white;
+        position: absolute;
+        font-family: 'FontAwesome';
+        content: '\f0b0';
+        font-weight: 900;
+        left: 10px;
+        
+      }
+
+      &:hover {
+        background-color: $light-green;
+      }
+    }
 }

--- a/app/src/css/modules/_table.scss
+++ b/app/src/css/modules/_table.scss
@@ -1,10 +1,3 @@
-.table--wrapper {
-  overflow-x: scroll;
-  border-radius: 8px 8px 0px 0px;
-  /*border: 1px solid #ECEAEA;
-  box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.08);*/
-}
-
 .pre-style {
   white-space: pre-wrap;       /* Since CSS 2.1 */
   white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
@@ -16,6 +9,8 @@
 .table {
   width: 100%;
   line-height: 1.6em;
+  overflow-x: scroll;
+  border-radius: 8px 8px 0px 0px;
 
   .Collapsible {
     max-width: 500px;
@@ -50,6 +45,32 @@
       &:nth-child(odd) {
         background-color: darken($background-white, 2%);
       }
+    }
+  }
+}
+
+.table__filters {
+
+  .button__filter {
+    margin-bottom: 1em;
+  }
+
+  &--wrapper {
+    display: flex;
+    background: $white;
+    padding: 2em;
+    margin: 1em 0;
+    box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.08);
+    border-radius: 8px;
+  }
+
+  &--filter {
+    display: flex;
+    align-items: center;
+    width: 20%;
+
+    label {
+      margin: 0 .5em;
     }
   }
 }

--- a/app/src/js/components/ReconciliationReports/reconciliation-report.js
+++ b/app/src/js/components/ReconciliationReports/reconciliation-report.js
@@ -246,6 +246,7 @@ class ReconciliationReport extends React.Component {
             data={cardConfig[activeIdx].data}
             tableColumns={cardConfig[activeIdx].columns}
             shouldUsePagination={true}
+            initialHiddenColumns={['']}
           />
         </section>
       </div>

--- a/app/src/js/components/SortableTable/SortableTable.js
+++ b/app/src/js/components/SortableTable/SortableTable.js
@@ -3,14 +3,12 @@ import React, {
   useMemo,
   useEffect,
   forwardRef,
-  useRef,
-  useState
+  useRef
 } from 'react';
 import PropTypes from 'prop-types';
 import { useTable, useResizeColumns, useFlexLayout, useSortBy, useRowSelect, usePagination } from 'react-table';
 import SimplePagination from '../Pagination/simple-pagniation';
 import TableFilters from '../Table/TableFilters';
-import { Collapse } from 'react-bootstrap';
 
 /**
  * IndeterminateCheckbox
@@ -126,7 +124,6 @@ const SortableTable = ({
 
   const tableRows = page || rows;
   const includeFilters = initialHiddenColumns.length > 0;
-  const [filtersExpanded, setFiltersExpanded] = useState(true);
 
   useEffect(() => {
     if (clearSelected) {
@@ -163,22 +160,7 @@ const SortableTable = ({
   return (
     <div className='table--wrapper'>
       {includeFilters &&
-        <div className='table__filters'>
-          <button
-            aria-expanded={filtersExpanded}
-            aria-controls="table__filters--collapse"
-            className='button button--small button__filter'
-            onClick={() => setFiltersExpanded(!filtersExpanded)}
-          >
-            {`${filtersExpanded ? 'Hide' : 'Show'} Column Filters`}
-          </button>
-          <Collapse in={filtersExpanded}>
-            <div className='table__filters--collapse'>
-              <h3>Table Column Filters</h3>
-              <TableFilters columns={tableColumns} onChange={toggleHideColumn} hiddenColumns={hiddenColumns} />
-            </div>
-          </Collapse>
-        </div>
+        <TableFilters columns={tableColumns} onChange={toggleHideColumn} hiddenColumns={hiddenColumns} />
       }
       <form>
         <div className='table' {...getTableProps()}>

--- a/app/src/js/components/Table/TableFilters.js
+++ b/app/src/js/components/Table/TableFilters.js
@@ -7,7 +7,7 @@ import { Collapse } from 'react-bootstrap';
 const TableFilters = ({
   columns,
   onChange,
-  hiddenColumns
+  hiddenColumns = []
 }) => {
   const [filtersExpanded, setFiltersExpanded] = useState(true);
 
@@ -37,8 +37,8 @@ const TableFilters = ({
               const isChecked = !hiddenColumns.includes(columnId);
               return (
                 <div className='table__filters--filter' key={index}>
-                  <input type="checkbox" checked={isChecked} onChange={() => handleChange(columnId)} />
-                  <label>{Header}</label>
+                  <input id={columnId} type='checkbox' checked={isChecked} onChange={() => handleChange(columnId)} />
+                  <label htmlFor={columnId}>{Header}</label>
                 </div>
               );
             })}

--- a/app/src/js/components/Table/TableFilters.js
+++ b/app/src/js/components/Table/TableFilters.js
@@ -1,13 +1,16 @@
 'use strict';
 
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
+import { Collapse } from 'react-bootstrap';
 
 const TableFilters = ({
   columns,
   onChange,
   hiddenColumns
 }) => {
+  const [filtersExpanded, setFiltersExpanded] = useState(true);
+
   function handleChange (id) {
     if (typeof onChange === 'function') {
       onChange(id);
@@ -15,18 +18,33 @@ const TableFilters = ({
   }
 
   return (
-    <div className='table__filters--wrapper'>
-      {columns.map((column, index) => {
-        const { Header, id, accessor } = column;
-        const columnId = id || accessor;
-        const isChecked = !hiddenColumns.includes(columnId);
-        return (
-          <div className='table__filters--filter' key={index}>
-            <input type="checkbox" checked={isChecked} onChange={() => handleChange(columnId)} />
-            <label>{Header}</label>
+    <div className='table__filters'>
+      <button
+        aria-expanded={filtersExpanded}
+        aria-controls="table__filters--collapse"
+        className='button button--small button__filter'
+        onClick={() => setFiltersExpanded(!filtersExpanded)}
+      >
+        {`${filtersExpanded ? 'Hide' : 'Show'} Column Filters`}
+      </button>
+      <Collapse in={filtersExpanded}>
+        <div className='table__filters--collapse'>
+          <h3>Table Column Filters</h3>
+          <div className='table__filters--wrapper'>
+            {columns.map((column, index) => {
+              const { Header, id, accessor } = column;
+              const columnId = id || accessor;
+              const isChecked = !hiddenColumns.includes(columnId);
+              return (
+                <div className='table__filters--filter' key={index}>
+                  <input type="checkbox" checked={isChecked} onChange={() => handleChange(columnId)} />
+                  <label>{Header}</label>
+                </div>
+              );
+            })}
           </div>
-        );
-      })}
+        </div>
+      </Collapse>
     </div>
   );
 };

--- a/app/src/js/components/Table/TableFilters.js
+++ b/app/src/js/components/Table/TableFilters.js
@@ -1,0 +1,40 @@
+'use strict';
+
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const TableFilters = ({
+  columns,
+  onChange,
+  hiddenColumns
+}) => {
+  function handleChange (id) {
+    if (typeof onChange === 'function') {
+      onChange(id);
+    }
+  }
+
+  return (
+    <div className='table__filters--wrapper'>
+      {columns.map((column, index) => {
+        const { Header, id, accessor } = column;
+        const columnId = id || accessor;
+        const isChecked = !hiddenColumns.includes(columnId);
+        return (
+          <div className='table__filters--filter' key={index}>
+            <input type="checkbox" checked={isChecked} onChange={() => handleChange(columnId)} />
+            <label>{Header}</label>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+TableFilters.propTypes = {
+  columns: PropTypes.array,
+  onChange: PropTypes.func,
+  hiddenColumns: PropTypes.array
+};
+
+export default TableFilters;

--- a/cypress/integration/reconciliation_spec.js
+++ b/cypress/integration/reconciliation_spec.js
@@ -106,6 +106,21 @@ describe('Dashboard Reconciliation Reports Page', () => {
         // verify correct table is displayed on click
         cy.get('.table .th').first().contains(cards[index].firstColumn);
       });
+
+      /** Table Filters **/
+      cy.get('.table__filters');
+      cy.contains('.table__filters .button__filter', 'Hide Column Filters');
+      cy.get('.table__filters--collapse').should('be.visible');
+
+      const filterLabel = 'GranuleId';
+
+      cy.contains('.table .th', filterLabel).should('be.visible');
+      cy.contains('.table__filters--filter label', filterLabel).prev().click();
+      cy.contains('.table .th', filterLabel).should('not.be.visible');
+
+      cy.get('.table__filters .button__filter').click();
+      cy.contains('.table__filters .button__filter', 'Show Column Filters');
+      cy.get('.table__filters--collapse').should('not.be.visible');
     });
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1909,6 +1909,11 @@
         "any-observable": "^0.3.0"
       }
     },
+    "@scarf/scarf": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@scarf/scarf/-/scarf-1.0.5.tgz",
+      "integrity": "sha512-9WKaGVpQH905Aqkk+BczFEeLQxS07rl04afFRPUG9IcSlOwmo5EVVuuNu0d4M9LMYucObvK0LoAe+5HfMW2QhQ=="
+    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -15983,9 +15988,12 @@
       }
     },
     "react-table": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.0.0.tgz",
-      "integrity": "sha512-/RKUYLuqrupUs0qHdjdQLmgwdQ9mgXPnpshqv2T+OQUGhTu0XuLXVc6GOIywemXNf6qjL3dj81O6zALLK74Emw=="
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.1.0.tgz",
+      "integrity": "sha512-AZpgW0Xpo6Z7jxXZIBovzCGoYVkuBwATsJh7X4+JXwq9JtDaorOmxWC9gKx5Hui4d+n+I99enyyJS+LRtKydxA==",
+      "requires": {
+        "@scarf/scarf": "^1.0.4"
+      }
     },
     "react-test-renderer": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -225,7 +225,7 @@
     "react-router-bootstrap": "^0.25.0",
     "react-router-dom": "^5.1.2",
     "react-router-query-params": "^1.0.3",
-    "react-table": "^7.0.0-rc.16",
+    "react-table": "^7.1.0",
     "recompose": "^0.30.0",
     "redux": "^3.6.0",
     "redux-devtools-extension": "^2.13.8",

--- a/test/components/table/TableFilters.js
+++ b/test/components/table/TableFilters.js
@@ -1,0 +1,62 @@
+'use strict';
+
+import test from 'ava';
+import Adapter from 'enzyme-adapter-react-16';
+import React from 'react';
+import { shallow, configure } from 'enzyme';
+
+import TableFilters from '../../../app/src/js/components/Table/TableFilters';
+
+configure({ adapter: new Adapter() });
+
+const columns = [
+  {
+    Header: 'Name',
+    accessor: 'name'
+  },
+  {
+    Header: 'Title',
+    accessor: 'title'
+  },
+  {
+    Header: 'Company',
+    accessor: 'company',
+  },
+  {
+    Header: 'Start Date',
+    id: 'startDate',
+    accessor: row => row.timestamp
+  }
+];
+
+test('Renders table filters', t => {
+  const wrapper = shallow(
+    <TableFilters columns={columns} />
+  );
+
+  const filters = wrapper.find('.table__filters--filter');
+
+  t.is(filters.length, 4);
+
+  filters.forEach(node => {
+    t.is(node.find('input').props().checked, true);
+  });
+});
+
+test('Renders table filters with hidden columns unchecked', t => {
+  const wrapper = shallow(
+    <TableFilters
+      columns={columns}
+      hiddenColumns={['title', 'startDate']}
+    />
+  );
+
+  const filters = wrapper.find('.table__filters--filter');
+
+  t.is(filters.length, 4);
+
+  t.is(filters.find('input#name').props().checked, true);
+  t.is(filters.find('input#title').props().checked, false);
+  t.is(filters.find('input#company').props().checked, true);
+  t.is(filters.find('input#startDate').props().checked, false);
+});


### PR DESCRIPTION
**Summary:** Adds TableFilters component for dynamically hiding/showing columns in reconciliation reports view

Addresses [CUMULUS-1904: Reports: Inventory View - Table Advanced Column Filters](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1904)

## Changes

* Updates react-table
* Uses `toggleHideColumn` function from the table instance to toggle the columns that are checked
* Various styles to match mock up

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Adhoc testing
- [x] Integration tests