### PR TITLE
CUMULUS-1906 Download report button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **CUMULUS-1904**
   - Adds a TableFilters component for dynamically showing/hiding table columns
 
+- **CUMULUS-1906**
+  - Adds a download button dropdown to reconciliation report inventory view.
+    Option to download full report as json or indivdual tables as csv files.
+
 - **CUMULUS-1917**
   - Adds a download button to reconciliation report list page
 

--- a/app/src/css/vendor/bootstrap/_components.scss
+++ b/app/src/css/vendor/bootstrap/_components.scss
@@ -12,6 +12,7 @@ and behaviors for our Cumulus Dashboard components
 @import "~bootstrap/scss/_breadcrumb";
 @import "~bootstrap/scss/_card";
 @import "~bootstrap/scss/_close";
+@import "~bootstrap/scss/_dropdown";
 @import "~bootstrap/scss/_modal";
 @import "~bootstrap/scss/_nav";
 @import "~bootstrap/scss/_popover";

--- a/app/src/js/components/Granules/overview.js
+++ b/app/src/js/components/Granules/overview.js
@@ -37,6 +37,7 @@ import { window } from '../../utils/browser';
 import ListFilters from '../ListActions/ListFilters';
 import Breadcrumbs from '../Breadcrumbs/Breadcrumbs';
 import pageSizeOptions from '../../utils/page-size';
+import { downloadFile } from '../../utils/download-file';
 
 const { updateInterval } = _config;
 
@@ -134,14 +135,8 @@ class GranulesOverview extends React.Component {
       const { granuleCSV } = this.props;
       const { data } = granuleCSV;
       const csvData = new Blob([data], { type: 'text/csv' });
-
-      const link = document.createElement('a');
-      link.setAttribute('download', 'granules.csv');
       const url = window.URL.createObjectURL(csvData);
-      link.href = url;
-      document.body.appendChild(link);
-      link.click();
-      link.parentNode.removeChild(link);
+      downloadFile(url, 'granules.csv');
     });
   }
 

--- a/app/src/js/components/Granules/overview.js
+++ b/app/src/js/components/Granules/overview.js
@@ -33,7 +33,7 @@ import statusOptions from '../../utils/status';
 import _config from '../../config';
 import { strings } from '../locale';
 import { workflowOptionNames } from '../../selectors';
-import { window, document } from '../../utils/browser';
+import { window } from '../../utils/browser';
 import ListFilters from '../ListActions/ListFilters';
 import Breadcrumbs from '../Breadcrumbs/Breadcrumbs';
 import pageSizeOptions from '../../utils/page-size';
@@ -232,7 +232,6 @@ GranulesOverview.propTypes = {
   stats: PropTypes.object,
   dispatch: PropTypes.func,
   workflowOptions: PropTypes.array,
-  location: PropTypes.object,
   config: PropTypes.object,
   granuleCSV: PropTypes.object
 };

--- a/app/src/js/components/ReconciliationReports/reconciliation-report.js
+++ b/app/src/js/components/ReconciliationReports/reconciliation-report.js
@@ -112,15 +112,15 @@ const ReconciliationReport = ({ reconciliationReports, dispatch, match }) => {
 
   function handleCardClick(e, id) {
     e.preventDefault();
-    setactiveId(id);
+    setActiveId(id);
   }
 
   function handleToggleClick(e, tableId) {
     e.preventDefault();
     const updatedState = {
       [activeId]: {
-        ...expandedState[activeIdx],
-        [tableId]: !expandedState[activeIdx][tableId],
+        ...expandedState[activeId],
+        [tableId]: !expandedState[activeId][tableId],
       },
     };
     setExpandedState({
@@ -142,8 +142,8 @@ const ReconciliationReport = ({ reconciliationReports, dispatch, match }) => {
   }
 
   function allCollapsed() {
-    return Object.keys(expandedState[activeIdx]).every(
-      (key) => expandedState[activeIdx][key] === true
+    return Object.keys(expandedState[activeId]).every(
+      (key) => expandedState[activeId][key] === true
     );
   }
 

--- a/app/src/js/utils/download-file.js
+++ b/app/src/js/utils/download-file.js
@@ -1,0 +1,15 @@
+/**
+ * downloadFile
+ * @description This causes the browser to download a given file in the browser with a given filename
+ * @param {string} file url to the file itself ex: csv Blob or data:text/json url
+ * @param {*} fileName the name of the downloaded file
+ */
+
+export const downloadFile = (file, fileName) => {
+  const link = document.createElement('a');
+  link.setAttribute('download', fileName);
+  link.href = file;
+  document.body.appendChild(link);
+  link.click();
+  link.parentNode.removeChild(link);
+};

--- a/cypress/integration/reconciliation_spec.js
+++ b/cypress/integration/reconciliation_spec.js
@@ -158,5 +158,17 @@ describe('Dashboard Reconciliation Reports Page', () => {
       cy.get('.link').should('contain', 'Expand All');
       cy.get('.multicard__header--expanded').should('not.exist');
     });
+
+    it('should have download option for full report and individual tables', () => {
+      cy.visit('/reconciliation-reports/report/inventoryReport-20200114T205238781');
+
+      cy.contains('.card-header', 'Cumulus').click();
+      cy.get('#download-report-dropdown').click();
+      cy.get('.dropdown-item').should('have.length', 4);
+      cy.get('.dropdown-item').eq(0).should('contain', 'JSON - Full Report');
+      cy.get('.dropdown-item').eq(1).should('contain', 'CSV - Collections only in Cumulus');
+      cy.get('.dropdown-item').eq(2).should('contain', 'CSV - Granules only in Cumulus');
+      cy.get('.dropdown-item').eq(3).should('contain', 'CSV - Files only in Cumulus');
+    });
   });
 });


### PR DESCRIPTION
**Summary:** Add download button to report inventory view

Addresses [CUMULUS-1906: Reports: Inventory View - Download Report Feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1906)

## Changes

* Adds dropdown to allow user to download full report as json, or csv of each individual table
* Adds downloadFile helper
* Changes `activeIdx` to `activeId` since we're using an actual id not an index

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests
