### PR TITLE
CUMULUS-1873 Executions page timers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **CUMULUS-1872**
   - Fix/remove unecessary timers on granules page
 
+- **CUMULUS-1873**
+  - Fix/remove unecessary timers on executions page
+
 - **CUMULUS-1882**
   - Fix ES query for TEA Lambda metrics
   - Update Kibana links on homepage for TEA metrics

--- a/app/src/js/components/Executions/execution-events.js
+++ b/app/src/js/components/Executions/execution-events.js
@@ -30,16 +30,16 @@ class ExecutionEvents extends React.Component {
   }
 
   componentDidMount () {
-    const { dispatch } = this.props;
-    const { executionArn } = this.props.match.params;
+    const { dispatch, match } = this.props;
+    const { executionArn } = match.params;
     dispatch(getExecutionStatus(executionArn));
     dispatch(getCumulusInstanceMetadata());
   }
 
   componentDidUpdate (prevProps) {
-    const { dispatch } = this.props;
-    const { executionArn } = this.props.match.params;
-    const { search } = this.props.location;
+    const { dispatch, match, location } = this.props;
+    const { executionArn } = match.params;
+    const { search } = location;
     const { search: prevSearch } = prevProps.location;
     if (search !== prevSearch) {
       dispatch(getExecutionStatus(executionArn));

--- a/app/src/js/components/Executions/execution-status.js
+++ b/app/src/js/components/Executions/execution-status.js
@@ -30,8 +30,8 @@ class ExecutionStatus extends React.Component {
   }
 
   componentDidMount () {
-    const { dispatch } = this.props;
-    const { executionArn } = this.props.match.params;
+    const { dispatch, match } = this.props;
+    const { executionArn } = match.params;
     dispatch(getExecutionStatus(executionArn));
     dispatch(getCumulusInstanceMetadata());
   }

--- a/app/src/js/components/Executions/index.js
+++ b/app/src/js/components/Executions/index.js
@@ -14,38 +14,30 @@ import { strings } from '../locale';
 
 class Executions extends React.Component {
   query () {
-    this.props.dispatch(getCount({
+    const { dispatch } = this.props;
+    dispatch(getCount({
       type: 'executions',
       field: 'status'
     }));
-    this.props.dispatch(listExecutions());
-    this.displayName = strings.executions;
-  }
-
-  renderHeader () {
-    const { pathname } = this.props.location;
-    const showDatePicker = pathname === '/executions';
-
-    if (showDatePicker) {
-      return <DatePickerHeader onChange={this.query} heading={strings.executions}/>;
-    } else {
-      return (
-        <div className='content__header'>
-          <div className='row'>
-            <h1 className='heading--xlarge'>{strings.executions}</h1>
-          </div>
-        </div>
-      );
-    }
+    dispatch(listExecutions());
   }
 
   render () {
+    const { pathname } = this.props.location;
+    const showDatePicker = pathname === '/executions';
     return (
       <div className='page__workflows'>
         <Helmet>
           <title> Cumulus Executions </title>
         </Helmet>
-        {this.renderHeader()}
+        {showDatePicker
+          ? <DatePickerHeader onChange={this.query} heading={strings.executions}/>
+          : <div className='content__header'>
+            <div className='row'>
+              <h1 className='heading--xlarge'>{strings.executions}</h1>
+            </div>
+          </div>
+        }
         <div className='page__content'>
           <div className='wrapper__sidebar'>
             <Route path='/executions/execution/:executionArn' component={Sidebar} />

--- a/app/src/js/components/Executions/overview.js
+++ b/app/src/js/components/Executions/overview.js
@@ -13,7 +13,8 @@ import {
   getCumulusInstanceMetadata,
   listCollections,
   listExecutions,
-  listWorkflows
+  listWorkflows,
+  getOptionsCollectionName
 } from '../../actions';
 import {
   tally,
@@ -21,8 +22,7 @@ import {
   displayCase
 } from '../../utils/format';
 import {
-  workflowOptions,
-  collectionOptions
+  workflowOptions
 } from '../../selectors';
 import statusOptions from '../../utils/status';
 import pageSizeOptions from '../../utils/page-size';
@@ -72,7 +72,8 @@ class ExecutionOverview extends React.Component {
   }
 
   render () {
-    const { dispatch, stats, executions, collectionOptions, workflowOptions } = this.props;
+    const { dispatch, stats, executions, collections, workflowOptions } = this.props;
+    const { dropdowns } = collections;
     const { list } = executions;
     const { count, queriedAt } = list.meta;
     if (list.infix && list.infix.value) {
@@ -107,14 +108,21 @@ class ExecutionOverview extends React.Component {
                 clear={clearExecutionsFilter}
                 paramKey={'status'}
                 label={'Status'}
+                inputProps={{
+                  placeholder: 'All'
+                }}
               />
 
               <Dropdown
-                options={collectionOptions}
+                getOptions={getOptionsCollectionName}
+                options={get(dropdowns, ['collectionName', 'options'])}
                 action={filterExecutions}
                 clear={clearExecutionsFilter}
                 paramKey={'collectionId'}
                 label={strings.collection_id}
+                inputProps={{
+                  placeholder: 'All'
+                }}
               />
 
               <Dropdown
@@ -123,6 +131,9 @@ class ExecutionOverview extends React.Component {
                 clear={clearExecutionsFilter}
                 paramKey={'type'}
                 label={'Workflow'}
+                inputProps={{
+                  placeholder: 'All'
+                }}
               />
 
               <Search dispatch={dispatch}
@@ -130,6 +141,7 @@ class ExecutionOverview extends React.Component {
                 clear={clearExecutionsSearch}
                 paramKey={'asyncOperationId'}
                 label={'Async Operation ID'}
+                placeholder='Search'
               />
 
               <Dropdown
@@ -138,6 +150,9 @@ class ExecutionOverview extends React.Component {
                 clear={clearExecutionsFilter}
                 paramKey={'limit'}
                 label={'Results Per Page'}
+                inputProps={{
+                  placeholder: 'Results Per Page'
+                }}
               />
             </ListFilters>
           </List>
@@ -151,7 +166,7 @@ ExecutionOverview.propTypes = {
   dispatch: PropTypes.func,
   stats: PropTypes.object,
   executions: PropTypes.object,
-  collectionOptions: PropTypes.object,
+  collections: PropTypes.object,
   workflowOptions: PropTypes.object
 };
 
@@ -159,5 +174,5 @@ export default withRouter(connect(state => ({
   stats: state.stats,
   executions: state.executions,
   workflowOptions: workflowOptions(state),
-  collectionOptions: collectionOptions(state)
+  collections: state.collections,
 }))(ExecutionOverview));

--- a/app/src/js/components/Executions/overview.js
+++ b/app/src/js/components/Executions/overview.js
@@ -11,7 +11,6 @@ import {
   clearExecutionsSearch,
   getCount,
   getCumulusInstanceMetadata,
-  listCollections,
   listExecutions,
   listWorkflows,
   getOptionsCollectionName
@@ -48,11 +47,6 @@ class ExecutionOverview extends React.Component {
   }
 
   queryMeta () {
-    this.props.dispatch(listCollections({
-      limit: 100,
-      fields: 'name,version',
-      getMMT: false
-    }));
     this.props.dispatch(listWorkflows());
     this.props.dispatch(getCount({
       type: 'executions',

--- a/app/src/js/components/Executions/overview.js
+++ b/app/src/js/components/Executions/overview.js
@@ -11,7 +11,6 @@ import {
   clearExecutionsSearch,
   getCount,
   getCumulusInstanceMetadata,
-  interval,
   listCollections,
   listExecutions,
   listWorkflows
@@ -31,12 +30,9 @@ import List from '../Table/Table';
 import Dropdown from '../DropDown/dropdown';
 import Search from '../Search/search';
 import Overview from '../Overview/overview';
-import _config from '../../config';
 import { strings } from '../locale';
 import { tableColumns } from '../../utils/table-config/executions';
 import ListFilters from '../ListActions/ListFilters';
-
-const { updateInterval } = _config;
 
 class ExecutionOverview extends React.Component {
   constructor (props) {
@@ -47,20 +43,15 @@ class ExecutionOverview extends React.Component {
   }
 
   componentDidMount () {
-    // use a slightly slower update interval, since the dropdown fields
-    // will change less frequently.
-    this.cancelInterval = interval(this.queryMeta, updateInterval, true);
+    this.queryMeta();
     this.props.dispatch(getCumulusInstanceMetadata());
-  }
-
-  componentWillUnmount () {
-    if (this.cancelInterval) { this.cancelInterval(); }
   }
 
   queryMeta () {
     this.props.dispatch(listCollections({
       limit: 100,
-      fields: 'name,version'
+      fields: 'name,version',
+      getMMT: false
     }));
     this.props.dispatch(listWorkflows());
     this.props.dispatch(getCount({
@@ -81,7 +72,7 @@ class ExecutionOverview extends React.Component {
   }
 
   render () {
-    const { stats, executions } = this.props;
+    const { dispatch, stats, executions, collectionOptions, workflowOptions } = this.props;
     const { list } = executions;
     const { count, queriedAt } = list.meta;
     if (list.infix && list.infix.value) {
@@ -119,22 +110,22 @@ class ExecutionOverview extends React.Component {
               />
 
               <Dropdown
-                options={this.props.collectionOptions}
+                options={collectionOptions}
                 action={filterExecutions}
                 clear={clearExecutionsFilter}
                 paramKey={'collectionId'}
-                label={strings.collection}
+                label={strings.collection_id}
               />
 
               <Dropdown
-                options={this.props.workflowOptions}
+                options={workflowOptions}
                 action={filterExecutions}
                 clear={clearExecutionsFilter}
                 paramKey={'type'}
                 label={'Workflow'}
               />
 
-              <Search dispatch={this.props.dispatch}
+              <Search dispatch={dispatch}
                 action={searchExecutions}
                 clear={clearExecutionsSearch}
                 paramKey={'asyncOperationId'}

--- a/app/src/js/components/Granules/list.js
+++ b/app/src/js/components/Granules/list.js
@@ -33,6 +33,7 @@ import ListFilters from '../ListActions/ListFilters';
 import pageSizeOptions from '../../utils/page-size';
 
 const AllGranules = ({
+  collections,
   dispatch,
   granules,
   location,
@@ -41,7 +42,8 @@ const AllGranules = ({
   workflowOptions
 }) => {
   const [workflow, setWorkflow] = useState(workflowOptions[0]);
-  const { list, dropdowns } = granules;
+  const { dropdowns } = collections;
+  const { list } = granules;
   const { count, queriedAt } = list.meta;
   const logsQuery = { granuleId__exists: 'true' };
   const query = generateQuery();
@@ -201,6 +203,7 @@ const AllGranules = ({
 };
 
 AllGranules.propTypes = {
+  collections: PropTypes.object,
   granules: PropTypes.object,
   logs: PropTypes.object,
   dispatch: PropTypes.func,
@@ -214,6 +217,7 @@ AllGranules.displayName = strings.all_granules;
 export { AllGranules };
 
 export default withRouter(connect(state => ({
+  collections: state.collections,
   logs: state.logs,
   granules: state.granules,
   workflowOptions: workflowOptionNames(state)

--- a/app/src/js/components/Granules/list.js
+++ b/app/src/js/components/Granules/list.js
@@ -19,7 +19,7 @@ import {
   tableColumns,
   errorTableColumns,
   bulkActions,
-  simpleDropdownOption
+  simpleDropdownOption,
 } from '../../utils/table-config/granules';
 import List from '../Table/Table';
 import LogViewer from '../Logs/viewer';
@@ -39,7 +39,7 @@ const AllGranules = ({
   location,
   logs,
   onQueryChange,
-  workflowOptions
+  workflowOptions,
 }) => {
   const [workflow, setWorkflow] = useState(workflowOptions[0]);
   const { dropdowns } = collections;
@@ -49,21 +49,21 @@ const AllGranules = ({
   const query = generateQuery();
   const view = getView();
   const displayCaseView = displayCase(view);
-  const statusOpts = (view === 'all') ? statusOptions : null;
+  const statusOpts = view === 'all' ? statusOptions : null;
   const tablesortId = view === 'failed' ? 'granuleId' : 'timestamp';
   const breadcrumbConfig = [
     {
       label: 'Dashboard Home',
-      href: '/'
+      href: '/',
     },
     {
       label: 'Granules',
-      href: '/granules'
+      href: '/granules',
     },
     {
       label: displayCaseView,
-      active: true
-    }
+      active: true,
+    },
   ];
 
   useEffect(() => {
@@ -80,7 +80,7 @@ const AllGranules = ({
     setWorkflow(workflowOptions[0]);
   }, [workflowOptions]);
 
-  function getView () {
+  function getView() {
     const { pathname } = location;
     if (pathname === '/granules/completed') return 'completed';
     else if (pathname === '/granules/processing') return 'running';
@@ -88,7 +88,7 @@ const AllGranules = ({
     else return 'all';
   }
 
-  function generateQuery () {
+  function generateQuery() {
     const options = {};
     const view = getView();
     if (view !== 'all') options.status = view;
@@ -96,56 +96,59 @@ const AllGranules = ({
     return options;
   }
 
-  function generateBulkActions () {
+  function generateBulkActions() {
     const config = {
       execute: {
         options: getExecuteOptions(),
-        action: applyWorkflow
-      }
+        action: applyWorkflow,
+      },
     };
     return bulkActions(granules, config);
   }
 
-  function selectWorkflow (selector, selectedWorkflow) {
+  function selectWorkflow(selector, selectedWorkflow) {
     setWorkflow(selectedWorkflow);
   }
 
-  function applyWorkflow (granuleId) {
+  function applyWorkflow(granuleId) {
     return applyWorkflowToGranule(granuleId, workflow);
   }
 
-  function getExecuteOptions () {
+  function getExecuteOptions() {
     return [
       simpleDropdownOption({
         handler: selectWorkflow,
         label: 'workflow',
         value: workflow,
-        options: workflowOptions
-      })
+        options: workflowOptions,
+      }),
     ];
   }
 
   return (
-    <div className='page__component'>
-      <section className='page__section'>
-        <section className='page__section page__section__controls'>
+    <div className="page__component">
+      <section className="page__section">
+        <section className="page__section page__section__controls">
           <Breadcrumbs config={breadcrumbConfig} />
         </section>
-        <div className='page__section__header page__section__header-wrapper'>
-          <h1 className='heading--large heading--shared-content with-description '>
-            {displayCaseView} {strings.granules} <span className='num-title'>{ !isNaN(count) ? `${tally(count)}` : 0 }</span>
+        <div className="page__section__header page__section__header-wrapper">
+          <h1 className="heading--large heading--shared-content with-description ">
+            {displayCaseView} {strings.granules}{' '}
+            <span className="num-title">
+              {!isNaN(count) ? `${tally(count)}` : 0}
+            </span>
           </h1>
           {lastUpdated(queriedAt)}
         </div>
       </section>
-      <section className='page__section'>
+      <section className="page__section">
         <List
           list={list}
           action={listGranules}
           tableColumns={view === 'failed' ? errorTableColumns : tableColumns}
           query={query}
           bulkActions={generateBulkActions()}
-          rowId='granuleId'
+          rowId="granuleId"
           sortId={tablesortId}
         >
           <ListFilters>
@@ -154,39 +157,39 @@ const AllGranules = ({
               options={get(dropdowns, ['collectionName', 'options'])}
               action={filterGranules}
               clear={clearGranulesFilter}
-              paramKey='collectionId'
-              label='Collection'
+              paramKey="collectionId"
+              label="Collection"
               inputProps={{
-                placeholder: 'All'
+                placeholder: 'All',
               }}
             />
-            {statusOpts &&
-                <Dropdown
-                  options={statusOpts}
-                  action={filterGranules}
-                  clear={clearGranulesFilter}
-                  paramKey='status'
-                  label='Status'
-                  inputProps={{
-                    placeholder: 'All'
-                  }}
-                />
-            }
+            {statusOpts && (
+              <Dropdown
+                options={statusOpts}
+                action={filterGranules}
+                clear={clearGranulesFilter}
+                paramKey="status"
+                label="Status"
+                inputProps={{
+                  placeholder: 'All',
+                }}
+              />
+            )}
             <Search
               dispatch={dispatch}
               action={searchGranules}
               clear={clearGranulesSearch}
-              label='Search'
-              placeholder='Granule ID'
+              label="Search"
+              placeholder="Granule ID"
             />
             <Dropdown
               options={pageSizeOptions}
               action={filterGranules}
               clear={clearGranulesFilter}
-              paramKey='limit'
-              label='Results Per Page'
+              paramKey="limit"
+              label="Results Per Page"
               inputProps={{
-                placeholder: 'Results Per Page'
+                placeholder: 'Results Per Page',
               }}
             />
           </ListFilters>
@@ -196,7 +199,7 @@ const AllGranules = ({
         query={logsQuery}
         dispatch={dispatch}
         logs={logs}
-        notFound='No recent logs for granules'
+        notFound="No recent logs for granules"
       />
     </div>
   );
@@ -209,16 +212,18 @@ AllGranules.propTypes = {
   dispatch: PropTypes.func,
   location: PropTypes.object,
   workflowOptions: PropTypes.array,
-  onQueryChange: PropTypes.func
+  onQueryChange: PropTypes.func,
 };
 
 AllGranules.displayName = strings.all_granules;
 
 export { AllGranules };
 
-export default withRouter(connect(state => ({
-  collections: state.collections,
-  logs: state.logs,
-  granules: state.granules,
-  workflowOptions: workflowOptionNames(state)
-}))(AllGranules));
+export default withRouter(
+  connect((state) => ({
+    collections: state.collections,
+    logs: state.logs,
+    granules: state.granules,
+    workflowOptions: workflowOptionNames(state),
+  }))(AllGranules)
+);

--- a/app/src/js/components/Granules/overview.js
+++ b/app/src/js/components/Granules/overview.js
@@ -138,8 +138,9 @@ class GranulesOverview extends React.Component {
   }
 
   render () {
-    const { stats, granules, dispatch } = this.props;
-    const { list, dropdowns } = granules;
+    const { collections, stats, granules, dispatch } = this.props;
+    const { list } = granules;
+    const { dropdowns } = collections;
     const { count, queriedAt } = list.meta;
     const statsCount = get(stats, 'count.data.granules.count', []);
     const overviewItems = statsCount.map(d => [tally(d.count), displayCase(d.key)]);
@@ -223,6 +224,7 @@ class GranulesOverview extends React.Component {
 }
 
 GranulesOverview.propTypes = {
+  collections: PropTypes.object,
   granules: PropTypes.object,
   stats: PropTypes.object,
   dispatch: PropTypes.func,
@@ -234,9 +236,10 @@ GranulesOverview.propTypes = {
 export { GranulesOverview };
 
 export default withRouter(connect(state => ({
+  collections: state.collections,
   stats: state.stats,
   workflowOptions: workflowOptionNames(state),
   granules: state.granules,
   config: state.config,
-  granuleCSV: state.granuleCSV
+  granuleCSV: state.granuleCSV,
 }))(GranulesOverview));

--- a/app/src/js/components/Operations/overview.js
+++ b/app/src/js/components/Operations/overview.js
@@ -18,7 +18,6 @@ import {
   listWorkflows
 } from '../../actions';
 import { tally } from '../../utils/format';
-import { workflowOptions } from '../../selectors';
 import List from '../Table/Table';
 import Dropdown from '../DropDown/dropdown';
 import Search from '../Search/search';
@@ -165,7 +164,5 @@ OperationOverview.propTypes = {
 };
 
 export default withRouter(connect(state => ({
-  stats: state.stats,
   operations: state.operations,
-  workflowOptions: workflowOptions(state)
 }))(OperationOverview));

--- a/app/src/js/components/Operations/overview.js
+++ b/app/src/js/components/Operations/overview.js
@@ -18,10 +18,7 @@ import {
   listWorkflows
 } from '../../actions';
 import { tally } from '../../utils/format';
-import {
-  workflowOptions,
-  collectionOptions
-} from '../../selectors';
+import { workflowOptions } from '../../selectors';
 import List from '../Table/Table';
 import Dropdown from '../DropDown/dropdown';
 import Search from '../Search/search';
@@ -164,15 +161,11 @@ class OperationOverview extends React.Component {
 
 OperationOverview.propTypes = {
   dispatch: PropTypes.func,
-  stats: PropTypes.object,
   operations: PropTypes.object,
-  collectionOptions: PropTypes.object,
-  workflowOptions: PropTypes.object
 };
 
 export default withRouter(connect(state => ({
   stats: state.stats,
   operations: state.operations,
-  workflowOptions: workflowOptions(state),
-  collectionOptions: collectionOptions(state)
+  workflowOptions: workflowOptions(state)
 }))(OperationOverview));

--- a/app/src/js/components/Pdr/pdr.js
+++ b/app/src/js/components/Pdr/pdr.js
@@ -108,7 +108,6 @@ class PDR extends React.Component {
     const { match, pdrs } = this.props;
     const { pdrName } = match.params;
     const immediate = !pdrs.map[pdrName];
-    console.log(immediate);
     this.reload(immediate);
   }
 

--- a/app/src/js/components/Pdr/pdr.js
+++ b/app/src/js/components/Pdr/pdr.js
@@ -105,8 +105,10 @@ class PDR extends React.Component {
   }
 
   componentDidMount () {
-    const { pdrName } = this.props.params;
-    const immediate = !this.props.pdrs.map[pdrName];
+    const { match, pdrs } = this.props;
+    const { pdrName } = match.params;
+    const immediate = !pdrs.map[pdrName];
+    console.log(immediate);
     this.reload(immediate);
   }
 
@@ -115,14 +117,14 @@ class PDR extends React.Component {
   }
 
   reload (immediate) {
-    const { pdrName } = this.props.params;
-    const { dispatch } = this.props;
+    const { dispatch, match } = this.props;
+    const { pdrName } = match.params;
     if (this.cancelInterval) { this.cancelInterval(); }
     this.cancelInterval = interval(() => dispatch(getPdr(pdrName)), updateInterval, immediate);
   }
 
   deletePdr () {
-    const { pdrName } = this.props.params;
+    const { pdrName } = this.props.match.params;
     this.props.dispatch(deletePdr(pdrName));
   }
 
@@ -149,12 +151,15 @@ class PDR extends React.Component {
   }
 
   render () {
-    const { pdrName } = this.props.params;
-    const { list, dropdowns } = this.props.granules;
+    const { match, granules, collections, pdrs } = this.props;
+    const { pdrName } = match.params;
+    const record = pdrs.map[pdrName];
+    if (!record || (record.inflight && !record.data)) return <Loading />;
+    const { dropdowns } = collections;
+    const { list } = granules;
     const { count, queriedAt } = list.meta;
-    const record = this.props.pdrs.map[pdrName];
     const logsQuery = { 'meta.pdrName': pdrName };
-    const deleteStatus = get(this.props.pdrs.deleted, [pdrName, 'status']);
+    const deleteStatus = get(pdrs.deleted, [pdrName, 'status']);
     const error = record.error;
 
     const granulesCount = get(record, 'data.granulesStatus', []);
@@ -179,7 +184,7 @@ class PDR extends React.Component {
               text={deleteStatus === 'success' ? 'Deleted!' : 'Delete'} />
             {lastUpdated(queriedAt)}
             {this.renderProgress(record)}
-            {error ? <ErrorReport report={error} /> : null}
+            {error && <ErrorReport report={error} />}
           </div>
         </section>
 
@@ -187,7 +192,7 @@ class PDR extends React.Component {
           <div className='heading__wrapper--border'>
             <h2 className='heading--medium with-description'>PDR Overview</h2>
           </div>
-          {!record || (record.inflight && !record.data) ? <Loading /> : <Metadata data={record.data} accessors={metaAccessors} />}
+          <Metadata data={record.data} accessors={metaAccessors} />
         </section>
 
         <section className='page__section'>
@@ -243,11 +248,12 @@ class PDR extends React.Component {
 }
 
 PDR.propTypes = {
+  collections: PropTypes.object,
   granules: PropTypes.object,
   logs: PropTypes.object,
   pdrs: PropTypes.object,
   dispatch: PropTypes.func,
-  params: PropTypes.object,
+  match: PropTypes.object,
   history: PropTypes.object
 };
 

--- a/app/src/js/reducers/collections.js
+++ b/app/src/js/reducers/collections.js
@@ -1,8 +1,9 @@
 'use strict';
 
 import { createReducer } from '@reduxjs/toolkit';
-import { deconstructCollectionId } from '../utils/format';
+import { deconstructCollectionId, getCollectionId } from '../utils/format';
 import assignDate from './utils/assign-date';
+import { set } from 'object-path';
 import {
   createClearItemReducer,
   createErrorReducer,
@@ -33,6 +34,9 @@ import {
   UPDATE_COLLECTION_ERROR,
   UPDATE_COLLECTION_INFLIGHT,
   UPDATE_COLLECTION,
+  OPTIONS_COLLECTIONNAME,
+  OPTIONS_COLLECTIONNAME_INFLIGHT,
+  OPTIONS_COLLECTIONNAME_ERROR,
 } from '../actions/types';
 
 export const initialState = {
@@ -41,6 +45,7 @@ export const initialState = {
     meta: {},
     params: {},
   },
+  dropdowns: {},
   created: {},
   deleted: {},
   executed: {},
@@ -122,5 +127,22 @@ export default createReducer(initialState, {
   },
   [CLEAR_COLLECTIONS_FILTER]: (state, action) => {
     state.list.params[action.paramKey] = null;
+  },
+  [OPTIONS_COLLECTIONNAME]: (state, action) => {
+    const options = action.data.results.reduce(
+      (obj, { name, version }) => {
+        const collectionId = getCollectionId({ name, version });
+        return Object.assign(obj, {
+          [collectionId]: collectionId,
+        });
+      },
+      {}
+    );
+    set(state.dropdowns, 'collectionName.options', options);
+  },
+  [OPTIONS_COLLECTIONNAME_INFLIGHT]: () => {},
+  [OPTIONS_COLLECTIONNAME_ERROR]: (state, action) => {
+    set(state.dropdowns, 'collectionName.options', []);
+    state.list.error = action.error;
   },
 });

--- a/app/src/js/reducers/granules.js
+++ b/app/src/js/reducers/granules.js
@@ -1,10 +1,9 @@
 'use strict';
 
-import { set, del } from 'object-path';
+import { del } from 'object-path';
 import assignDate from './utils/assign-date';
 import removeDeleted from './utils/remove-deleted';
 import { createReducer } from '@reduxjs/toolkit';
-import { getCollectionId } from '../utils/format';
 import {
   createErrorReducer,
   createInflightReducer,
@@ -45,9 +44,6 @@ import {
   CLEAR_GRANULES_SEARCH,
   FILTER_GRANULES,
   CLEAR_GRANULES_FILTER,
-  OPTIONS_COLLECTIONNAME,
-  OPTIONS_COLLECTIONNAME_INFLIGHT,
-  OPTIONS_COLLECTIONNAME_ERROR,
 } from '../actions/types';
 
 export const initialState = {
@@ -56,7 +52,6 @@ export const initialState = {
     meta: {},
     params: {},
   },
-  dropdowns: {},
   map: {},
   meta: {},
   reprocessed: {},
@@ -146,21 +141,5 @@ export default createReducer(initialState, {
   },
   [CLEAR_GRANULES_FILTER]: (state, action) => {
     state.list.params[action.paramKey] = null;
-  },
-  [OPTIONS_COLLECTIONNAME]: (state, action) => {
-    const options = action.data.results.reduce(
-      (obj, { name, version }) =>
-        Object.assign(obj, {
-          [`${name} ${version}`]: getCollectionId({ name, version }),
-        }),
-      {}
-    );
-
-    set(state.dropdowns, 'collectionName.options', options);
-  },
-  [OPTIONS_COLLECTIONNAME_INFLIGHT]: () => {},
-  [OPTIONS_COLLECTIONNAME_ERROR]: (state, action) => {
-    set(state.dropdowns, 'collectionName.options', []);
-    state.list.error = action.error;
-  },
+  }
 });

--- a/app/src/js/selectors/index.js
+++ b/app/src/js/selectors/index.js
@@ -1,6 +1,5 @@
 'use strict';
 import { get } from 'object-path';
-import { getCollectionId } from '../utils/format';
 
 // functions all expect the full state as arguments
 
@@ -14,13 +13,4 @@ export const workflowOptions = ({ workflows }) => {
 
 export const workflowOptionNames = ({ workflows }) => {
   return get(workflows, 'list.data', []).map(workflow => workflow.name);
-};
-
-export const collectionOptions = ({ collections }) => {
-  const options = {};
-  get(collections, 'list.data', []).forEach(collection => {
-    const collectionId = getCollectionId(collection);
-    options[collectionId] = collectionId;
-  });
-  return options;
 };

--- a/app/src/js/selectors/index.js
+++ b/app/src/js/selectors/index.js
@@ -1,12 +1,13 @@
 'use strict';
 import { get } from 'object-path';
+import { getCollectionId } from '../utils/format';
 
 // functions all expect the full state as arguments
 
 export const workflowOptions = ({ workflows }) => {
-  const options = { '': '' };
-  get(workflows, 'list.data', []).forEach(d => {
-    options[d.name] = d.name;
+  const options = {};
+  get(workflows, 'list.data', []).forEach(workflow => {
+    options[workflow.name] = workflow.name;
   });
   return options;
 };
@@ -16,9 +17,10 @@ export const workflowOptionNames = ({ workflows }) => {
 };
 
 export const collectionOptions = ({ collections }) => {
-  const options = { '': '' };
-  get(collections, 'list.data', []).forEach(d => {
-    options[d.name] = d.name;
+  const options = {};
+  get(collections, 'list.data', []).forEach(collection => {
+    const collectionId = getCollectionId(collection);
+    options[collectionId] = collectionId;
   });
   return options;
 };

--- a/app/src/js/utils/table-config/executions.js
+++ b/app/src/js/utils/table-config/executions.js
@@ -35,7 +35,7 @@ export const tableColumns = [
     id: 'duration'
   },
   {
-    Header: strings.collection_name,
+    Header: strings.collection_id,
     accessor: 'collectionId'
   }
 ];

--- a/app/src/js/utils/table-config/pdr-progress.js
+++ b/app/src/js/utils/table-config/pdr-progress.js
@@ -58,7 +58,7 @@ export const tableColumns = [
   {
     Header: 'Name',
     accessor: 'pdrName',
-    Cell: ({ cell: { value } }) => <Link to={`pdrs/pdr/${value}`}>{value}</Link> // eslint-disable-line react/prop-types
+    Cell: ({ cell: { value } }) => <Link to={`/pdrs/pdr/${value}`}>{value}</Link> // eslint-disable-line react/prop-types
   },
   {
     Header: 'Status',

--- a/app/src/js/utils/table-config/pdrs.js
+++ b/app/src/js/utils/table-config/pdrs.js
@@ -15,7 +15,7 @@ export const tableColumns = [
   {
     Header: 'Name',
     accessor: 'pdrName',
-    Cell: ({ cell: { value } }) => <Link to={`pdrs/pdr/${value}`}>{value}</Link> // eslint-disable-line react/prop-types
+    Cell: ({ cell: { value } }) => <Link to={`/pdrs/pdr/${value}`}>{value}</Link> // eslint-disable-line react/prop-types
   },
   {
     Header: 'Status',
@@ -28,8 +28,7 @@ export const tableColumns = [
   },
   {
     Header: strings.granules,
-    accessor: row => Object.keys(row.stats).filter(k => k !== 'total')
-      .reduce((a, b) => a + get(row.stats, b, 0), 0),
+    accessor: row => get(row, ['stats', 'total'], 0),
     id: 'granules'
   },
   {

--- a/test/components/granules/overview.js
+++ b/test/components/granules/overview.js
@@ -42,18 +42,20 @@ const data = {
   error: null
 };
 
-test('GranulesOverview generates bulkAction for recovery button', function (t) {
-  const dispatch = () => {};
-  const workflowOptions = [];
-  const stats = { count: 0, stats: {} };
-  const location = { pathname: 'granules' };
-  const config = { enableRecovery: true };
-  const store = {
-    subscribe: () => {},
-    dispatch: dispatch,
-    getState: () => {}
-  };
+const dispatch = () => {};
+const workflowOptions = [];
+const collections = {};
+const stats = { count: 0, stats: {} };
+const location = { pathname: 'granules' };
+const config = { enableRecovery: false };
+const store = {
+  subscribe: () => {},
+  dispatch: dispatch,
+  getState: () => {}
+};
 
+test('GranulesOverview generates bulkAction for recovery button', function (t) {
+  const configWithRecovery = { enableRecovery: true };
   const providerWrapper = shallow(
     <Provider store={store}>
       <GranulesOverview
@@ -62,8 +64,9 @@ test('GranulesOverview generates bulkAction for recovery button', function (t) {
         stats = {stats}
         dispatch = {dispatch}
         workflowOptions = {workflowOptions}
+        collections = {collections}
         location = {location}
-        config={config}/>
+        config={configWithRecovery}/>
     </Provider>);
 
   const overviewWrapper = providerWrapper.find('GranulesOverview').dive();
@@ -76,17 +79,7 @@ test('GranulesOverview generates bulkAction for recovery button', function (t) {
 });
 
 test('GranulesOverview does not generate bulkAction for recovery button', function (t) {
-  const dispatch = () => {};
-  const workflowOptions = [];
-  const stats = { count: 0, stats: {} };
-  const location = { pathname: 'granules' };
   const config = { enableRecovery: false };
-  const store = {
-    subscribe: () => {},
-    dispatch: dispatch,
-    getState: () => {}
-  };
-
   const providerWrapper = shallow(
     <Provider store={store}>
       <GranulesOverview
@@ -95,6 +88,7 @@ test('GranulesOverview does not generate bulkAction for recovery button', functi
         granuleCSV = {data}
         dispatch = {dispatch}
         workflowOptions = {workflowOptions}
+        collections = {collections}
         location = {location}
         config={config}/>
     </Provider>);
@@ -110,23 +104,17 @@ test('GranulesOverview does not generate bulkAction for recovery button', functi
 
 test('GranulesOverview will download CSV data when the Download Granule List button is clicked and not leave extra link on the page', function (t) {
   window.URL.createObjectURL = sinon.fake.returns('www.example.com');
-  const dispatch = () => Promise.resolve();
-  const workflowOptions = [];
-  const config = { enableRecovery: false };
-  const store = {
-    subscribe: () => {},
-    dispatch: dispatch,
-    getState: () => {}
-  };
+  const dispatchPromise = () => Promise.resolve();
 
   const providerWrapper = shallow(
     <Provider store={store}>
       <GranulesOverview
         granules = {granules}
         granuleCSV = {data}
-        dispatch = {dispatch}
+        dispatch = {dispatchPromise}
         location = {location}
         workflowOptions = {workflowOptions}
+        collections = {collections}
         config={config}/>
     </Provider>);
 


### PR DESCRIPTION
**Summary:** Fixes timers on the executions page. Also updates the collections dropdown on that page

Addresses [CUMULUS-1873: Fix Timers - Executions Page](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1873)

## Changes

* Normalized props destructuring on executions pages
* Removed queryMeta interval from overview page. Also stopped it from dispatching `getMMTLinks`
* Updated collections dropdown on executions page
	* This involved nixing the `collectionOptions` function and instead grabbing the options from the state as is happening on other pages. Moved this from the granules to collections reducer so that it made more sense when used on various pages, i.e. options are now in `state.collections.dropdown`
	* When doing this, noticed pdr.js wasn't rendering, so had to swap `params` for `match.params` and update how it handled `record` being undefined to get it working

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests