### PR TITLE
CUMULUS-2024 Dispatch providers and collections on AddRule initial render

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Fix ES query for TEA Lambda metrics
   - Update Kibana links on homepage for TEA metrics
 
+- **CUMULUS-2024**
+  - Fix bug where new providers and collections were not being pulled in as options on the Add Rule page
+
 ## [v1.9.0]
 
 ### BREAKING CHANGES

--- a/app/src/js/components/Rules/add.js
+++ b/app/src/js/components/Rules/add.js
@@ -108,17 +108,17 @@ const AddRule = ({
     }
   }, [name, rulesMap, isCopy]);
 
-  const dispatched = ({ list }) => {
-    const { inflight, meta, error } = list || {};
-    const { queriedAt } = meta || {};
-    return error || inflight || queriedAt !== undefined;
-  };
+  useEffect(() => {
+    dispatch(listCollections({ listAll: true, getMMT: false }));
+  }, [dispatch]);
 
   useEffect(() => {
-    if (!dispatched(collections)) dispatch(listCollections({ listAll: true, getMMT: false }));
-    if (!dispatched(providers)) dispatch(listProviders());
-    if (!dispatched(workflows)) dispatch(listWorkflows());
-  });
+    dispatch(listProviders());
+  }, [dispatch]);
+
+  useEffect(() => {
+    dispatch(listWorkflows());
+  }, [dispatch]);
 
   useEffect(() => {
     setEnums({


### PR DESCRIPTION
**Summary:**

Addresses [CUMULUS-2024: Adding new provider or collection does not show in drop-down list when creating new rule](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2024)

## Changes

The issue was caused by dispatching listCollections, listProviders, and listWorkflows in a single useEffect. The original workaround was to just check if they had already been dispatched, but this prevents a dispatch on initial render if they have already been dispatched on other pages, so we're not getting the freshest data. Removing the `if` statements causes issues because each dispatch causes the component to rerender, so there would be an infinite loop. Instead, we should put them each in their own useEffect. Since `dispatch` is the only dependency and it doesn't change between renders, it will only dispatch those actions on the initial render, which means we'll get fresh results whenever we return to that page.

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests