### PR TITLE
CUMULUS-1830:Fix redirect issue when logging out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,13 +43,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- **CUMULUS-1815**
+  - Refactor some PDR components. No user facing changes.
+
+- **CUMULUS-1830**
+  - Fix redirect issue when logging out from the page with URL path containing dot
+
 - **CUMULUS-1861**
   - Update Execution/Rule tables to handle undefined collectionIds
   - Update Rule add dialogue logic to allow Rule creation without a collection
     value.
-
-- **CUMULUS-1815**
-  - Refactor some PDR components. No user facing changes.
 
 - **CUMULUS-1905**
   - Updates Inventory Report view to clarify Cumulus's internal consistency differences and Cumulus's differences with CMR.

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -14,7 +14,7 @@ const DevConfig = merge.smartStrategy(
   devtool: 'inline-source-map',
   devServer: {
     hot: false,
-    historyApiFallback: true,
+    historyApiFallback: { disableDotRule: true },
     // host: '0.0.0.0', // Required for Docker -- someone will need to link this somehow
     publicPath: '/',
     watchContentBase: true,


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-1830: Logging out when viewing a reconciliation report doesn't redirect you to the auth page, but just drops an error](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1830)

## Changes

* Fix redirect issue when logging out from the page with URL path containing dot

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Adhoc testing
- [ ] Integration tests