### PR TITLE
CUMULUS-2029 Update overview tiles to match what is displayed in table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **CUMULUS-2019**
   - Support partial search
 
+- **CUMULUS-2029**
+  - Overview tiles are updated to represent what is shown in the table
+
 ### Fixed
 
 - **CUMULUS-1815**

--- a/app/src/css/modules/_table.scss
+++ b/app/src/css/modules/_table.scss
@@ -179,20 +179,34 @@
       border-bottom: 0;
     }
   }
-}
 
-.overview-num__wrapper ul li, .overview-num__wrapper-home ul li{
-  display: inline-block
-}
+  ul li {
+    display: inline-block;
 
-.overview-num__wrapper ul li:first-child .num-status{
-  background-color: $light-green;
-}
-.overview-num__wrapper ul li:nth-child(2) .num-status{
-  background-color: $error-red;
-}
-.overview-num__wrapper ul li:nth-child(3) .num-status{
-  background-color: $orange;
+    .num-status {
+      padding: 5px 0px 5px 0px;
+      color: $white;
+      width: 100%;
+      display: inline-block;
+      text-align: center;
+      position: absolute;
+      top: 0px;
+      left: 0px;
+
+      &--completed {
+        background-color: $light-green;
+      }
+
+      &--failed {
+        background-color: $error-red;
+      }
+
+      &--running {
+        background-color: $orange;
+      }
+    }
+  }
+
 }
 
 .overview-num, .overview-num:visited {
@@ -219,17 +233,6 @@
     margin: .1em 1.5em 1.5em 0;
     box-shadow: $shadow__hover;
   }
-}
-
-.num-status{
-  padding: 5px 0px 5px 0px;
-  color: $white;
-  width: 100%;
-  display: inline-block;
-  text-align: center;
-  position: absolute;
-  top: 0px;
-  left: 0px;
 }
 
 .timeline--processing--overall {

--- a/app/src/js/actions/index.js
+++ b/app/src/js/actions/index.js
@@ -579,8 +579,6 @@ export const getCount = (options = {}) => {
     field,
     ...sidebarCount ? {} : restOptions
   };
-  console.log(options);
-  console.log(params);
   const actionType = sidebarCount ? types.COUNT_SIDEBAR : types.COUNT;
   return (dispatch, getState) => {
     const timeFilters = fetchCurrentTimeFilters(getState().datepicker);

--- a/app/src/js/actions/index.js
+++ b/app/src/js/actions/index.js
@@ -572,16 +572,25 @@ export const getDistS3AccessMetrics = (cumulusInstanceMeta) => {
 };
 
 // count queries *must* include type and field properties.
-export const getCount = (options) => {
+export const getCount = (options = {}) => {
+  const { sidebarCount, type, field, ...restOptions } = options;
+  const params = {
+    type,
+    field,
+    ...sidebarCount ? {} : restOptions
+  };
+  console.log(options);
+  console.log(params);
+  const actionType = sidebarCount ? types.COUNT_SIDEBAR : types.COUNT;
   return (dispatch, getState) => {
     const timeFilters = fetchCurrentTimeFilters(getState().datepicker);
     return dispatch({
       [CALL_API]: {
-        type: types.COUNT,
+        type: actionType,
         method: 'GET',
         id: null,
         url: new URL('stats/aggregate', root).href,
-        qs: Object.assign({ type: 'must-include-type', field: 'status' }, options, timeFilters)
+        qs: Object.assign({ type: 'must-include-type', field: 'status' }, params, timeFilters)
       }
     });
   };

--- a/app/src/js/actions/types.js
+++ b/app/src/js/actions/types.js
@@ -91,6 +91,7 @@ export const DIST_S3ACCESS_INFLIGHT = 'DIST_S3ACCESS_INFLIGHT';
 export const DIST_S3ACCESS_ERROR = 'DIST_S3ACCESS_ERROR';
 // Count
 export const COUNT = 'COUNT';
+export const COUNT_SIDEBAR = 'COUNT_SIDEBAR';
 export const COUNT_INFLIGHT = 'COUNT_INFLIGHT';
 export const COUNT_ERROR = 'COUNT_ERROR';
 // PDR

--- a/app/src/js/components/Collections/overview.js
+++ b/app/src/js/components/Collections/overview.js
@@ -20,7 +20,6 @@ import {
   collectionNameVersion,
   getCollectionId,
   lastUpdated,
-  tally,
 } from '../../utils/format';
 import pageSizeOptions from '../../utils/page-size';
 import statusOptions from '../../utils/status';
@@ -145,17 +144,6 @@ class CollectionOverview extends React.Component {
     ].filter(Boolean);
   }
 
-  renderOverview(record) {
-    const data = get(record, 'data', {});
-    const stats = get(data, 'stats', {});
-    const overview = [
-      [tally(stats.completed), strings.granules_completed],
-      [tally(stats.failed), strings.granules_failed],
-      [tally(stats.running), strings.granules_running],
-    ];
-    return <Overview items={overview} inflight={record.inflight} />;
-  }
-
   renderDeleteButton() {
     const {
       match: { params },
@@ -193,9 +181,6 @@ class CollectionOverview extends React.Component {
       (id1, id2) => id1.localeCompare(id2, 'en', { sensitivity: 'base' })
     );
     const record = collections.map[collectionId];
-
-    // create the overview boxes
-    const overview = record ? this.renderOverview(record) : <div></div>;
 
     return (
       <div className="page__component">
@@ -271,7 +256,7 @@ class CollectionOverview extends React.Component {
               Granule Metrics
             </h2>
           </div>
-          {overview}
+          {record && <Overview type='granules' inflight={record.inflight} />}
         </section>
         <section className="page__section">
           <div className="heading__wrapper--border">

--- a/app/src/js/components/Executions/index.js
+++ b/app/src/js/components/Executions/index.js
@@ -27,7 +27,8 @@ const Executions = ({
   function query () {
     dispatch(getCount({
       type: 'executions',
-      field: 'status'
+      field: 'status',
+      ...filteredQueryParams
     }));
     dispatch(listExecutions(filteredQueryParams));
   }

--- a/app/src/js/components/Executions/overview.js
+++ b/app/src/js/components/Executions/overview.js
@@ -9,20 +9,13 @@ import {
   filterExecutions,
   searchExecutions,
   clearExecutionsSearch,
-  getCount,
   getCumulusInstanceMetadata,
   listExecutions,
   listWorkflows,
-  getOptionsCollectionName
+  getOptionsCollectionName,
 } from '../../actions';
-import {
-  tally,
-  lastUpdated,
-  displayCase
-} from '../../utils/format';
-import {
-  workflowOptions
-} from '../../selectors';
+import { tally, lastUpdated } from '../../utils/format';
+import { workflowOptions } from '../../selectors';
 import statusOptions from '../../utils/status';
 import pageSizeOptions from '../../utils/page-size';
 import List from '../Table/Table';
@@ -34,39 +27,36 @@ import { tableColumns } from '../../utils/table-config/executions';
 import ListFilters from '../ListActions/ListFilters';
 
 class ExecutionOverview extends React.Component {
-  constructor (props) {
+  constructor(props) {
     super(props);
     this.queryMeta = this.queryMeta.bind(this);
-    this.renderOverview = this.renderOverview.bind(this);
     this.searchOperationId = this.searchOperationId.bind(this);
   }
 
-  componentDidMount () {
+  componentDidMount() {
     this.queryMeta();
     this.props.dispatch(getCumulusInstanceMetadata());
   }
 
-  queryMeta () {
-    this.props.dispatch(listWorkflows());
-    this.props.dispatch(getCount({
-      type: 'executions',
-      field: 'status'
-    }));
+  queryMeta() {
+    const { dispatch } = this.props;
+    dispatch(listWorkflows());
   }
 
-  searchOperationId (list, infix) {
+  searchOperationId(list, infix) {
     return list.filter((item) => {
-      if (item.asyncOperationId && item.asyncOperationId.includes(infix)) return item;
+      if (item.asyncOperationId && item.asyncOperationId.includes(infix)) { return item; }
     });
   }
 
-  renderOverview (count) {
-    const overview = count.map(d => [tally(d.count), displayCase(d.key)]);
-    return <Overview items={overview} inflight={false} />;
-  }
-
-  render () {
-    const { dispatch, stats, executions, collections, queryParams, workflowOptions } = this.props;
+  render() {
+    const {
+      collections,
+      dispatch,
+      executions,
+      queryParams,
+      workflowOptions,
+    } = this.props;
     const { dropdowns } = collections;
     const { list } = executions;
     const { count, queriedAt } = list.meta;
@@ -74,17 +64,24 @@ class ExecutionOverview extends React.Component {
       list.data = this.searchOperationId(list.data, list.infix.value);
     }
     return (
-      <div className='page__component'>
-        <section className='page__section page__section__header-wrapper'>
-          <div className='page__section__header'>
-            <h1 className='heading--large heading--shared-content with-description'>Execution Overview</h1>
+      <div className="page__component">
+        <section className="page__section page__section__header-wrapper">
+          <div className="page__section__header">
+            <h1 className="heading--large heading--shared-content with-description">
+              Execution Overview
+            </h1>
             {lastUpdated(queriedAt)}
-            {this.renderOverview(get(stats, 'count.data.executions.count', []))}
+            <Overview type='executions' inflight={false} />
           </div>
         </section>
-        <section className='page__section'>
-          <div className='heading__wrapper--border'>
-            <h2 className='heading--medium heading--shared-content with-description'>All Executions <span className='num-title'>{count ? ` ${tally(count)}` : 0}</span></h2>
+        <section className="page__section">
+          <div className="heading__wrapper--border">
+            <h2 className="heading--medium heading--shared-content with-description">
+              All Executions
+              <span className="num-title">
+                {count ? ` ${tally(count)}` : 0}
+              </span>
+            </h2>
           </div>
           <List
             list={list}
@@ -103,7 +100,7 @@ class ExecutionOverview extends React.Component {
                 paramKey={'status'}
                 label={'Status'}
                 inputProps={{
-                  placeholder: 'All'
+                  placeholder: 'All',
                 }}
               />
 
@@ -115,7 +112,7 @@ class ExecutionOverview extends React.Component {
                 paramKey={'collectionId'}
                 label={strings.collection_id}
                 inputProps={{
-                  placeholder: 'All'
+                  placeholder: 'All',
                 }}
               />
 
@@ -126,16 +123,17 @@ class ExecutionOverview extends React.Component {
                 paramKey={'type'}
                 label={'Workflow'}
                 inputProps={{
-                  placeholder: 'All'
+                  placeholder: 'All',
                 }}
               />
 
-              <Search dispatch={dispatch}
+              <Search
+                dispatch={dispatch}
                 action={searchExecutions}
                 clear={clearExecutionsSearch}
                 paramKey={'asyncOperationId'}
                 label={'Async Operation ID'}
-                placeholder='Search'
+                placeholder="Search"
               />
 
               <Dropdown
@@ -145,7 +143,7 @@ class ExecutionOverview extends React.Component {
                 paramKey={'limit'}
                 label={'Results Per Page'}
                 inputProps={{
-                  placeholder: 'Results Per Page'
+                  placeholder: 'Results Per Page',
                 }}
               />
             </ListFilters>
@@ -161,13 +159,11 @@ ExecutionOverview.propTypes = {
   dispatch: PropTypes.func,
   executions: PropTypes.object,
   queryParams: PropTypes.object,
-  stats: PropTypes.object,
   workflowOptions: PropTypes.object,
 };
 
 export default withRouter(connect(state => ({
   collections: state.collections,
   executions: state.executions,
-  stats: state.stats,
   workflowOptions: workflowOptions(state),
 }))(ExecutionOverview));

--- a/app/src/js/components/Granules/index.js
+++ b/app/src/js/components/Granules/index.js
@@ -16,7 +16,7 @@ import { filterQueryParams } from '../../utils/url-helper';
 
 const Granules = ({ dispatch, location, queryParams, stats }) => {
   const { pathname } = location;
-  const count = get(stats, 'count.data.granules.count');
+  const count = get(stats, 'count.sidebar.granules.count');
   const filteredQueryParams = filterQueryParams(queryParams);
 
   function query() {
@@ -28,8 +28,10 @@ const Granules = ({ dispatch, location, queryParams, stats }) => {
       getCount({
         type: 'granules',
         field: 'status',
+        sidebarCount: true
       })
     );
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch]);
 
   return (

--- a/app/src/js/components/Granules/index.js
+++ b/app/src/js/components/Granules/index.js
@@ -31,7 +31,6 @@ const Granules = ({ dispatch, location, queryParams, stats }) => {
         sidebarCount: true
       })
     );
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch]);
 
   return (

--- a/app/src/js/components/Granules/overview.js
+++ b/app/src/js/components/Granules/overview.js
@@ -4,6 +4,7 @@ import { Helmet } from 'react-helmet';
 import PropTypes from 'prop-types';
 import { withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
+import withQueryParams from 'react-router-query-params';
 import {
   searchGranules,
   clearGranulesSearch,
@@ -17,7 +18,7 @@ import {
   getGranuleCSV
 } from '../../actions';
 import { get } from 'object-path';
-import { lastUpdated, tally, displayCase } from '../../utils/format';
+import { lastUpdated, tally } from '../../utils/format';
 import {
   tableColumns,
   simpleDropdownOption,
@@ -139,12 +140,10 @@ class GranulesOverview extends React.Component {
   }
 
   render () {
-    const { collections, dispatch, granules, stats } = this.props;
+    const { collections, dispatch, granules } = this.props;
     const { list } = granules;
     const { dropdowns } = collections;
     const { count, queriedAt } = list.meta;
-    const statsCount = get(stats, 'count.data.granules.count', []);
-    const overviewItems = statsCount.map(d => [tally(d.count), displayCase(d.key)]);
     return (
       <div className='page__component'>
         <Helmet>
@@ -157,7 +156,7 @@ class GranulesOverview extends React.Component {
           <div className='page__section__header'>
             <h1 className='heading--large heading--shared-content with-description '>{strings.granule_overview}</h1>
             {lastUpdated(queriedAt)}
-            <Overview items={overviewItems} inflight={false} />
+            <Overview type='granules' inflight={false} />
           </div>
         </section>
         <section className='page__section'>
@@ -231,17 +230,15 @@ GranulesOverview.propTypes = {
   granuleCSV: PropTypes.object,
   granules: PropTypes.object,
   queryParams: PropTypes.object,
-  stats: PropTypes.object,
   workflowOptions: PropTypes.array,
 };
 
 export { GranulesOverview };
 
-export default withRouter(connect(state => ({
+export default withRouter(withQueryParams()(connect(state => ({
   collections: state.collections,
   config: state.config,
   granuleCSV: state.granuleCSV,
   granules: state.granules,
-  stats: state.stats,
   workflowOptions: workflowOptionNames(state),
-}))(GranulesOverview));
+}))(GranulesOverview)));

--- a/app/src/js/components/Operations/overview.js
+++ b/app/src/js/components/Operations/overview.js
@@ -56,14 +56,16 @@ class OperationOverview extends React.Component {
   }
 
   queryMeta () {
-    this.props.dispatch(listCollections({
+    const { dispatch, queryParams } = this.props;
+    dispatch(listCollections({
       limit: 100,
       fields: 'name,version'
     }));
-    this.props.dispatch(listWorkflows());
-    this.props.dispatch(getCount({
+    dispatch(listWorkflows());
+    dispatch(getCount({
       type: 'executions',
-      field: 'status'
+      field: 'status',
+      ...queryParams
     }));
   }
 

--- a/app/src/js/components/Overview/overview.js
+++ b/app/src/js/components/Overview/overview.js
@@ -1,37 +1,57 @@
 'use strict';
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import Loading from '../LoadingIndicator/loading-indicator';
+import { displayCase } from '../../utils/format';
+import withQueryParams from 'react-router-query-params';
+import { getCount } from '../../actions';
+import { connect } from 'react-redux';
+import { get } from 'object-path';
 
-class Overview extends React.Component {
-  constructor() {
-    super();
-    this.displayName = 'Overview';
-  }
+const Overview = ({
+  dispatch,
+  inflight,
+  queryParams,
+  stats,
+  type
+}) => {
+  const statsCount = get(stats, `count.data.${type}.count`, []);
 
-  render() {
-    const { inflight, items } = this.props;
-    return (
-      <div className="overview-num__wrapper" data-cy="overview-num">
-        {inflight ? <Loading /> : null}
-        <ul>
-          {items.map((d) => (
-            <li key={d[1]}>
+  useEffect(() => {
+    dispatch(getCount({
+      type,
+      field: 'status',
+      ...queryParams
+    }));
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dispatch, JSON.stringify(queryParams), type]);
+  return (
+    <div className="overview-num__wrapper" data-cy="overview-num">
+      {inflight && <Loading />}
+      <ul>
+        {statsCount.map((d) => {
+          return (
+            <li key={d.key}>
               <span className="overview-num overview-num--small" to="/">
-                <span className="num--large num--large--color">{d[0]}</span>
-                <span className="num-status">{d[1]}</span>
+                <span className="num--large num--large--color">{d.count}</span>
+                <span className={`num-status num-status--${d.key}`}>
+                  {displayCase(d.key)}
+                </span>
               </span>
             </li>
-          ))}
-        </ul>
-      </div>
-    );
-  }
-}
-
-Overview.propTypes = {
-  items: PropTypes.array,
-  inflight: PropTypes.bool,
+          );
+        })}
+      </ul>
+    </div>
+  );
 };
 
-export default Overview;
+Overview.propTypes = {
+  dispatch: PropTypes.func,
+  inflight: PropTypes.bool,
+  queryParams: PropTypes.object,
+  stats: PropTypes.object,
+  type: PropTypes.string,
+};
+
+export default withQueryParams()(connect(state => ({ stats: state.stats }))(Overview));

--- a/app/src/js/components/Pdr/index.js
+++ b/app/src/js/components/Pdr/index.js
@@ -17,7 +17,7 @@ import { filterQueryParams } from '../../utils/url-helper';
 
 const Pdrs = ({ dispatch, location, queryParams, params, stats }) => {
   const { pathname } = location;
-  const count = get(stats, 'count.data.pdrs.count');
+  const count = get(stats, 'count.sidebar.pdrs.count');
   const filteredQueryParams = filterQueryParams(queryParams);
 
   function query() {
@@ -29,6 +29,7 @@ const Pdrs = ({ dispatch, location, queryParams, params, stats }) => {
       getCount({
         type: 'pdrs',
         field: 'status',
+        sidebarCount: true
       })
     );
   }, [dispatch]);

--- a/app/src/js/components/Pdr/overview.js
+++ b/app/src/js/components/Pdr/overview.js
@@ -4,9 +4,13 @@ import { Helmet } from 'react-helmet';
 import PropTypes from 'prop-types';
 import { withRouter, Link } from 'react-router-dom';
 import { connect } from 'react-redux';
-import { get } from 'object-path';
-import { listPdrs, getCount, clearPdrsFilter, filterPdrs } from '../../actions';
-import { lastUpdated, tally, displayCase } from '../../utils/format';
+import {
+  listPdrs,
+  getCount,
+  clearPdrsFilter,
+  filterPdrs
+} from '../../actions';
+import { lastUpdated, tally } from '../../utils/format';
 import { bulkActions } from '../../utils/table-config/pdrs';
 import { tableColumns } from '../../utils/table-config/pdr-progress';
 import List from '../Table/Table';
@@ -34,7 +38,6 @@ class PdrOverview extends React.Component {
     this.queryStats = this.queryStats.bind(this);
     this.generateQuery = this.generateQuery.bind(this);
     this.generateBulkActions = this.generateBulkActions.bind(this);
-    this.renderOverview = this.renderOverview.bind(this);
   }
 
   componentDidMount() {
@@ -42,10 +45,12 @@ class PdrOverview extends React.Component {
   }
 
   queryStats() {
-    this.props.dispatch(
+    const { dispatch, queryParams } = this.props;
+    dispatch(
       getCount({
         type: 'pdrs',
         field: 'status',
+        ...queryParams,
       })
     );
   }
@@ -59,18 +64,11 @@ class PdrOverview extends React.Component {
     return bulkActions(this.props.pdrs);
   }
 
-  renderOverview(count) {
-    const overview = count.map((d) => [tally(d.count), displayCase(d.key)]);
-    return <Overview items={overview} inflight={false} />;
-  }
-
-  render() {
-    const { stats } = this.props;
-    const { list } = this.props.pdrs;
+  render () {
+    const { dispatch, pdrs } = this.props;
+    const { list } = pdrs;
     const { count, queriedAt } = list.meta;
     // create the overview boxes
-    const pdrCount = get(stats.count, 'data.pdrs.count', []);
-    const overview = this.renderOverview(pdrCount);
     return (
       <div className="page__component">
         <Helmet>
@@ -84,7 +82,7 @@ class PdrOverview extends React.Component {
             PDR Overview
           </h1>
           {lastUpdated(queriedAt)}
-          {overview}
+          <Overview type='pdrs' inflight={false} />
         </section>
         <section className="page__section">
           <div className="heading__wrapper--border">
@@ -97,7 +95,7 @@ class PdrOverview extends React.Component {
           </div>
           <List
             list={list}
-            dispatch={this.props.dispatch}
+            dispatch={dispatch}
             action={listPdrs}
             tableColumns={tableColumns}
             sortId="timestamp"
@@ -128,12 +126,10 @@ PdrOverview.propTypes = {
   dispatch: PropTypes.func,
   pdrs: PropTypes.object,
   queryParams: PropTypes.object,
-  stats: PropTypes.object,
 };
 
 export default withRouter(
   connect((state) => ({
-    stats: state.stats,
     pdrs: state.pdrs,
   }))(PdrOverview)
 );

--- a/app/src/js/components/Providers/overview.js
+++ b/app/src/js/components/Providers/overview.js
@@ -11,7 +11,7 @@ import {
   filterProviders,
   clearProvidersFilter,
 } from '../../actions';
-import { lastUpdated, tally, displayCase } from '../../utils/format';
+import { lastUpdated } from '../../utils/format';
 import { tableColumns } from '../../utils/table-config/providers';
 import List from '../Table/Table';
 import PropTypes from 'prop-types';
@@ -26,7 +26,6 @@ class ProvidersOverview extends React.Component {
     super();
     this.queryStats = this.queryStats.bind(this);
     this.generateQuery = this.generateQuery.bind(this);
-    this.renderOverview = this.renderOverview.bind(this);
   }
 
   componentDidMount() {
@@ -53,12 +52,7 @@ class ProvidersOverview extends React.Component {
     return { ...queryParams };
   }
 
-  renderOverview(count) {
-    const overview = count.map((d) => [tally(d.count), displayCase(d.key)]);
-    return <Overview items={overview} inflight={false} />;
-  }
-
-  render() {
+  render () {
     const { dispatch, providers, stats } = this.props;
     const { list } = providers;
     const { count, queriedAt } = list.meta;
@@ -85,8 +79,6 @@ class ProvidersOverview extends React.Component {
         0
       );
     });
-    const providerStatus = get(stats.count, 'data.providers.count', []);
-    const overview = this.renderOverview(providerStatus);
     return (
       <div className="page__component">
         <Helmet>
@@ -97,7 +89,7 @@ class ProvidersOverview extends React.Component {
             Provider Overview
           </h1>
           {lastUpdated(queriedAt)}
-          {overview}
+          <Overview type='providers' inflight={false} />
         </section>
         <section className="page__section">
           <div className="heading__wrapper--border">

--- a/app/src/js/components/Providers/overview.js
+++ b/app/src/js/components/Providers/overview.js
@@ -15,7 +15,6 @@ import { lastUpdated } from '../../utils/format';
 import { tableColumns } from '../../utils/table-config/providers';
 import List from '../Table/Table';
 import PropTypes from 'prop-types';
-import Overview from '../Overview/overview';
 import Dropdown from '../DropDown/dropdown';
 import pageSizeOptions from '../../utils/page-size';
 import ListFilters from '../ListActions/ListFilters';
@@ -37,12 +36,6 @@ class ProvidersOverview extends React.Component {
       getCount({
         type: 'collections',
         field: 'providers',
-      })
-    );
-    this.props.dispatch(
-      getCount({
-        type: 'providers',
-        field: 'status',
       })
     );
   }
@@ -89,7 +82,6 @@ class ProvidersOverview extends React.Component {
             Provider Overview
           </h1>
           {lastUpdated(queriedAt)}
-          <Overview type='providers' inflight={false} />
         </section>
         <section className="page__section">
           <div className="heading__wrapper--border">

--- a/app/src/js/components/ReconciliationReports/index.js
+++ b/app/src/js/components/ReconciliationReports/index.js
@@ -26,7 +26,8 @@ const ReconciliationReports = ({
     dispatch(listReconciliationReports(filteredQueryParams));
     dispatch(getCount({
       type: 'reconciliationReports',
-      field: 'status'
+      field: 'status',
+      ...filteredQueryParams
     }));
   }
 

--- a/app/src/js/components/ReconciliationReports/list.js
+++ b/app/src/js/components/ReconciliationReports/list.js
@@ -48,9 +48,11 @@ class ReconciliationReportList extends React.Component {
   }
 
   queryMeta () {
-    this.props.dispatch(getCount({
+    const { dispatch, queryParams } = this.props;
+    dispatch(getCount({
       type: 'reconciliationReports',
-      field: 'status'
+      field: 'status',
+      ...queryParams,
     }));
   }
 

--- a/app/src/js/components/Table/Table.js
+++ b/app/src/js/components/Table/Table.js
@@ -147,11 +147,10 @@ class List extends React.Component {
       selected,
       clearSelected,
       completedBulkActions,
-      bulkActionError
+      bulkActionError,
+      queryConfig
     } = this.state;
     const hasActions = Array.isArray(bulkActions) && bulkActions.length > 0;
-
-    const queryConfig = this.getQueryConfig();
 
     return (
       <>

--- a/app/src/js/components/home.js
+++ b/app/src/js/components/home.js
@@ -112,7 +112,7 @@ class Home extends React.Component {
           <div className='heading__wrapper'>
             <h2 className='heading--medium heading--shared-content--right'>{header}</h2>
           </div>
-          <div className="overview-num__wrapper-home">
+          <div className="overview-num__wrapper overview-num__wrapper-home">
             <ul id={listId}>
               {data.map(d => {
                 const value = d[0];
@@ -244,11 +244,8 @@ Home.propTypes = {
   dist: PropTypes.object,
   executions: PropTypes.object,
   granules: PropTypes.object,
-  pdrs: PropTypes.object,
   rules: PropTypes.object,
   stats: PropTypes.object,
-  queryParams: PropTypes.object,
-  setQueryParams: PropTypes.func,
   dispatch: PropTypes.func,
   location: PropTypes.object
 };

--- a/app/src/js/reducers/stats.js
+++ b/app/src/js/reducers/stats.js
@@ -7,6 +7,7 @@ import {
   STATS_INFLIGHT,
   STATS_ERROR,
   COUNT,
+  COUNT_SIDEBAR,
   COUNT_INFLIGHT,
   COUNT_ERROR,
 } from '../actions/types';
@@ -26,6 +27,7 @@ export const initialState = {
   count: {
     // aggregate stats from /stats/aggregate?type=<type>&field=status
     data: {},
+    sidebar: {},
     inflight: false,
     error: null,
   },
@@ -45,16 +47,36 @@ export default createReducer(initialState, {
     state.stats.error = action.error;
   },
   [COUNT]: (state, action) => {
-    const { count } = action.data;
-    const empty = [{ key: 'completed', count: 0 },
-      { key: 'failed', count: 0 },
-      { key: 'running', count: 0 }
-    ];
+    const { count, meta } = action.data;
+    const { field } = meta || {};
+    const completed = count.find((item) => item.key === 'completed') || {
+      key: 'completed',
+      count: 0,
+    };
+    const failed = count.find((item) => item.key === 'failed') || {
+      key: 'failed',
+      count: 0,
+    };
+    const running = count.find((item) => item.key === 'running') || {
+      key: 'running',
+      count: 0,
+    };
+    const statsCount =
+      field === 'status' ? [completed, failed, running] : count;
     state.count.inflight = false;
     state.count.error = null;
     state.count.data[action.config.qs.type] = {
       ...action.data,
-      count: (count.length === 0) ? empty : count
+      count: statsCount,
+    };
+  },
+  [COUNT_SIDEBAR]: (state, action) => {
+    const { count } = action.data;
+    state.count.inflight = false;
+    state.count.error = null;
+    state.count.sidebar[action.config.qs.type] = {
+      ...action.data,
+      count,
     };
   },
   [COUNT_INFLIGHT]: (state) => {

--- a/cypress/integration/collections_spec.js
+++ b/cypress/integration/collections_spec.js
@@ -174,14 +174,14 @@ describe('Dashboard Collections Page', () => {
         .should('have.attr', 'href', `/collections/collection/${name}/${version}`)
         .click();
       cy.contains('.heading--large', `${name} / ${version}`);
-      cy.contains(/Granules? Running/i);
+      cy.contains('.heading--large', 'Granule Metric');
 
       const collectionId = getCollectionId({ name: 'MOD09GQ', version: '006' });
       const formattedCollectionName = collectionName(collectionId);
 
       cy.get('#collection-chooser').select(collectionId);
       cy.contains('.heading--large', `${formattedCollectionName}`);
-      cy.contains(/Granules? Running/i);
+      cy.contains('.heading--large', 'Granule Metric');
       cy.get('#collection-chooser').find(':selected').contains(collectionId);
     });
 
@@ -519,9 +519,9 @@ describe('Dashboard Collections Page', () => {
       });
       cy.get('[data-cy=overview-num]').within(() => {
         cy.get('li')
-          .first().should('contain', '--').and('contain', 'Completed')
-          .next().should('contain', '--').and('contain', 'Failed')
-          .next().should('contain', '--').and('contain', 'Running');
+          .first().should('contain', 0).and('contain', 'Completed')
+          .next().should('contain', 0).and('contain', 'Failed')
+          .next().should('contain', 0).and('contain', 'Running');
       });
 
       cy.get('[data-cy=endDateTime] > .react-datetime-picker > .react-datetime-picker__wrapper > .react-datetime-picker__clear-button > .react-datetime-picker__clear-button__icon').click();
@@ -531,6 +531,28 @@ describe('Dashboard Collections Page', () => {
           .first().should('contain', 7).and('contain', 'Completed')
           .next().should('contain', 2).and('contain', 'Failed')
           .next().should('contain', 2).and('contain', 'Running');
+      });
+    });
+
+    it('Should display Granule Metrics that match the dropdown selection', () => {
+      cy.visit('/collections/collection/MOD09GQ/006');
+
+      cy.get('[data-cy=overview-num]').within(() => {
+        cy.get('li')
+          .first().should('contain', 7).and('contain', 'Completed')
+          .next().should('contain', 2).and('contain', 'Failed')
+          .next().should('contain', 2).and('contain', 'Running');
+      });
+
+      cy.get('#form-Status-status > div > input').as('status-input');
+      cy.get('@status-input').click().type('fai').type('{enter}');
+      cy.url().should('include', '?status=failed');
+
+      cy.get('[data-cy=overview-num]').within(() => {
+        cy.get('li')
+          .first().should('contain', 0).and('contain', 'Completed')
+          .next().should('contain', 2).and('contain', 'Failed')
+          .next().should('contain', 0).and('contain', 'Running');
       });
     });
   });

--- a/cypress/integration/pdrs_spec.js
+++ b/cypress/integration/pdrs_spec.js
@@ -27,8 +27,8 @@ describe('Dashboard PDRs Page', () => {
       // shows a summary count of completed and failed pdrs
       cy.get('.overview-num__wrapper ul li')
         .first().contains('li', 'Completed').contains('li', 4)
-        .next().contains('li', 'Running').contains('li', 4)
-        .next().contains('li', 'Failed').contains('li', 2);
+        .next().contains('li', 'Failed').contains('li', 2)
+        .next().contains('li', 'Running').contains('li', 4);
 
       // shows a list of PDRs
       cy.getFakeApiFixture('pdrs').as('pdrsListFixture');


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2029: Overview cards do not match what is displayed in the table](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2029)

## Changes

* Updated how stats reducer shims in empty count values.
* Added a reducer for storing the count to be used in the sidebar separately. That way, the sidebar will always represent the unfiltered count
* Updated the Overview component so it dispatches the filtered count instead of having the items to display passed in.
* Updated `getCount` calls so they include query params

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Adhoc testing
- [x] Integration tests