### PR TITLE
Disables push to SIT to keep demo smooth.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,20 +150,21 @@ jobs:
               -e APIROOT=${SIT_API_ROOT} \
               node:12.18.0 \
               npm run build
-
-      - run:
-          name: Deploy to Cumulus SIT
-          command: |
-            aws s3 sync $(pwd)/dist s3://${SIT_DASHBOARD_BUCKET}
+      # TODO [MHS, 2020-08-07] Re-enable deployment to SIT after
+      # - run:
+      #     name: Deploy to Cumulus SIT
+      #     command: |
+      #       aws s3 sync $(pwd)/dist s3://${SIT_DASHBOARD_BUCKET}
 
 workflows:
   version: 2
   build_test_deploy:
     jobs:
       - build
-      - deploy:
-          requires:
-            - build
-          filters:
-            branches:
-              only: develop
+      # TODO [MHS, 2020-08-07]  re-enable deployment to SIT
+      # - deploy:
+      #     requires:
+      #       - build
+      #     filters:
+      #       branches:
+      #         only: develop


### PR DESCRIPTION
Acked-by: Matt Savoie <savoie@nsidc.org>

**Summary:** Disable deploy job (with belts and suspenders disabling the actual rsync) to prevent merges to develop from writing to the SIT bucket for Lauren's demo.