### PR TITLE
CUMULUS-2114: Add download button to the Internal report link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **CUMULUS-2089**
   - Add component for Granule Not Found reports
 
+- **CUMULUS-2114**
+  - Add download button to the Internal report link
+
 ### Changed
 
 - **CUMULUS-2068**

--- a/app/src/js/utils/table-config/reconciliation-reports.js
+++ b/app/src/js/utils/table-config/reconciliation-reports.js
@@ -9,7 +9,12 @@ export const tableColumns = ({ dispatch }) => ([
   {
     Header: 'Name',
     accessor: 'name',
-    Cell: ({ cell: { value } }) => <Link to={(location) => ({ pathname: `/reconciliation-reports/report/${value}`, search: getPersistentQueryParams(location) })}>{value}</Link> // eslint-disable-line react/prop-types
+    Cell: ({ cell: { value }, row: { original: { type } } }) => { // eslint-disable-line react/prop-types
+      const link = (location) => ({ pathname: `/reconciliation-reports/report/${value}`, search: getPersistentQueryParams(location) });
+      return (type !== 'Internal')
+        ? <Link to={link} >{value}</Link>
+        : <Link to={link} onClick={(e) => handleDownloadClick(e, value, dispatch)}>{value}</Link>;
+    }
   },
   {
     Header: 'Report Type',

--- a/cypress/integration/reconciliation_spec.js
+++ b/cypress/integration/reconciliation_spec.js
@@ -211,6 +211,13 @@ describe('Dashboard Reconciliation Reports Page', () => {
       cy.get('.table .tr[data-value="4"] .td').eq(4).find('span').should('have.class', 'status-indicator--success');
     });
 
+    it('downloads the Internal report when the report link is clicked', () => {
+      const reportName = 'InternalReport092020';
+      cy.visit('/reconciliation-reports');
+      cy.get(`[data-value="${reportName}"]`).as('internalReport');
+      cy.get('@internalReport').find('.button__row--download').should('have.length', 1);
+    });
+
     it('should include legend on list page', () => {
       cy.visit('/reconciliation-reports');
 

--- a/cypress/integration/reconciliation_spec.js
+++ b/cypress/integration/reconciliation_spec.js
@@ -211,11 +211,10 @@ describe('Dashboard Reconciliation Reports Page', () => {
       cy.get('.table .tr[data-value="4"] .td').eq(4).find('span').should('have.class', 'status-indicator--success');
     });
 
-    it('downloads the Internal report when the report link is clicked', () => {
+    it('should download the Internal report with the report link', () => {
       const reportName = 'InternalReport092020';
       cy.visit('/reconciliation-reports');
-      cy.get(`[data-value="${reportName}"]`).as('internalReport');
-      cy.get('@internalReport').find('.button__row--download').should('have.length', 1);
+      cy.get(`[data-value="${reportName}"]`).find('.button__row--download').should('have.length', 1);
     });
 
     it('should include legend on list page', () => {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2114: Internal-Consistency report can be generated from the dashboard](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2114)

## Changes

* Add download button to the Internal report link
* CUMULUS-2087 was merged to create an Internal Report

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Adhoc testing
- [x] Integration tests