### PR TITLE
[CUMULUS-2086] GNF Report Styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **CUMULUS-2068**
   - Converts select dropdowns to react-select component
 
+- **CUMULUS-2086**
+  - Update the styling on the Granule Not Found report page
+
 - **CUMULUS-2090**
   - Moved report headings that include breadcrumbs, name, dates, status, and download button into a reusable ReportHeading component to be used for all report types.
 

--- a/app/src/css/_base.scss
+++ b/app/src/css/_base.scss
@@ -324,7 +324,7 @@ a:active {
   .sidebar-toggle {
     position: absolute;
     top: -1em;
-    
+
     &:hover {
       box-shadow: 0px 4px 8px rgba(0, 0, 0, 0.12);
     }
@@ -520,6 +520,12 @@ a:active {
     padding-left: 1em;
     border-left: 1px solid lighten($lighter-grey, 20%);
   }
+}
+
+.title-count {
+  border-bottom: 1px solid $lightest-grey;
+  padding-bottom: 1em;
+  margin-top: 1.5em;
 }
 
 /**************************************************

--- a/app/src/js/components/ReconciliationReports/gnf-report.js
+++ b/app/src/js/components/ReconciliationReports/gnf-report.js
@@ -89,7 +89,7 @@ const GnfReport = ({
 
   return (
     <div className="page__component">
-      <div className="heading__wrapper--border">
+      <div className="heading__wrapper">
         <ReportHeading
           endTime={createEndTime}
           error={error}
@@ -99,9 +99,13 @@ const GnfReport = ({
           startTime={createStartTime}
           type='Granule Not Found'
         />
-        <h2 className='heading--medium heading--shared-content with-description'>Granules Not Found <span className='num-title'>{totalMissingGranules}</span></h2>
       </div>
       <section className="page__section">
+        <div className="title-count">
+          <h2 className="heading--medium heading--shared-content with-description">
+            Granules Not Found <span className="num-title">{totalMissingGranules}</span>
+          </h2>
+        </div>
         <div className="filters">
           <Search
             dispatch={dispatch}

--- a/app/src/js/components/ReconciliationReports/gnf-report.js
+++ b/app/src/js/components/ReconciliationReports/gnf-report.js
@@ -71,6 +71,16 @@ const GnfReport = ({
       .includes(filterString.toLowerCase()));
   }
 
+  function calculateMissingGranules(totalMissing, currentGranuleData) {
+    const missingS3 = currentGranuleData.s3 === 'notFound' || currentGranuleData.s3 === false ? 1 : 0;
+    const missingCumulus = currentGranuleData.cumulus === 'notFound' || currentGranuleData.cumulus === false ? 1 : 0;
+    const missingCmr = currentGranuleData.cmr === 'notFound' || currentGranuleData.cmr === false ? 1 : 0;
+
+    return totalMissing + missingS3 + missingCumulus + missingCmr;
+  }
+
+  const totalMissingGranules = combinedGranules.reduce(calculateMissingGranules, 0);
+
   const reportState = combinedGranules.length > 0 ? 'CONFLICT' : 'PASSED';
 
   function handleDownloadClick(e) {
@@ -79,15 +89,18 @@ const GnfReport = ({
 
   return (
     <div className="page__component">
-      <ReportHeading
-        endTime={createEndTime}
-        error={error}
-        name={reportName}
-        onDownloadClick={handleDownloadClick}
-        reportState={reportState}
-        startTime={createStartTime}
-        type='Granule Not Found'
-      />
+      <div className="heading__wrapper--border">
+        <ReportHeading
+          endTime={createEndTime}
+          error={error}
+          name={reportName}
+          onDownloadClick={handleDownloadClick}
+          reportState={reportState}
+          startTime={createStartTime}
+          type='Granule Not Found'
+        />
+        <h2 className='heading--medium heading--shared-content with-description'>Granules Not Found <span className='num-title'>{totalMissingGranules}</span></h2>
+      </div>
       <section className="page__section">
         <div className="filters">
           <Search

--- a/app/src/js/components/ReconciliationReports/report-heading.js
+++ b/app/src/js/components/ReconciliationReports/report-heading.js
@@ -99,7 +99,7 @@ const ReportHeading = ({
                 className="form-group__element--right button button--small button--download"
                 onClick={onDownloadClick}
               >
-                Downlaod Report
+                Download Report
               </button>
             )}
           </div>

--- a/cypress/integration/reconciliation_spec.js
+++ b/cypress/integration/reconciliation_spec.js
@@ -255,6 +255,9 @@ describe('Dashboard Reconciliation Reports Page', () => {
       cy.visit(path);
       cy.contains('.heading--large', `Granule Not Found Report: ${reportName}`);
 
+      cy.contains('.heading--medium', 'Granules Not Found');
+      cy.contains('.num-title', '7');
+
       cy.get('.table .th').eq(0).should('contain', 'Collection ID');
       cy.get('.table .th').eq(1).should('contain', 'Granule ID');
       cy.get('.table .th').eq(2).should('contain', 'S3');


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2086: Reports: GNF View - Overall Style](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2086)

## Changes

* Added the Granule Not Found count, which sums the red dots in the table
* Added a border between the heading and the table

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [X] Adhoc testing
- [x] Integration tests