### PR TITLE
[CUMULUS-2021] Update search to use typeahead component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
+- **CUMULUS-2021**
+  - Update search to use react-bootstrap-typeahead to get autocomplete functionality
+  - Adds clear button when search option is selected
+  - Highlights text on input focus
+
 - **CUMULUS-2023**
   - Update filter drop downs to have the same order as columns
 

--- a/app/src/js/components/Collections/granules.js
+++ b/app/src/js/components/Collections/granules.js
@@ -154,11 +154,12 @@ const CollectionGranules = ({
         >
           <ListFilters>
             <Search
-              dispatch={dispatch}
               action={searchGranules}
               clear={clearGranulesSearch}
               label="Search"
+              labelKey="granuleId"
               placeholder="Granule ID"
+              searchKey="granules"
             />
             {view === 'all' && (
               <Dropdown

--- a/app/src/js/components/Collections/list.js
+++ b/app/src/js/components/Collections/list.js
@@ -13,12 +13,7 @@ import {
   filterCollections,
   clearCollectionsFilter,
 } from '../../actions';
-import {
-  collectionSearchResult,
-  lastUpdated,
-  tally,
-  getCollectionId,
-} from '../../utils/format';
+import { lastUpdated, tally, getCollectionId } from '../../utils/format';
 import {
   bulkActions,
   recoverAction,
@@ -125,12 +120,12 @@ class CollectionList extends React.Component {
           >
             <ListFilters>
               <Search
-                dispatch={this.props.dispatch}
                 action={searchCollections}
-                format={collectionSearchResult}
                 clear={clearCollectionsSearch}
                 label="Search"
+                labelKey="name"
                 placeholder="Collection Name"
+                searchKey="collections"
               />
             </ListFilters>
           </List>
@@ -146,7 +141,7 @@ CollectionList.propTypes = {
   datepicker: PropTypes.object,
   dispatch: PropTypes.func,
   mmtLinks: PropTypes.object,
-  queryParams: PropTypes.object
+  queryParams: PropTypes.object,
 };
 
 CollectionList.displayName = 'CollectionList';

--- a/app/src/js/components/Collections/overview.js
+++ b/app/src/js/components/Collections/overview.js
@@ -289,11 +289,12 @@ class CollectionOverview extends React.Component {
           >
             <ListFilters>
               <Search
-                dispatch={this.props.dispatch}
                 action={searchGranules}
                 clear={clearGranulesSearch}
                 label="Search"
+                labelKey="granuleId"
                 placeholder="Granule ID"
+                searchKey="granules"
               />
               <Dropdown
                 options={statusOptions}

--- a/app/src/js/components/DropDown/dropdown.js
+++ b/app/src/js/components/DropDown/dropdown.js
@@ -3,70 +3,8 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import withQueryParams from 'react-router-query-params';
-import {
-  Typeahead,
-  Menu,
-  MenuItem,
-  Hint,
-  Input,
-} from 'react-bootstrap-typeahead';
-
-function renderInput({ inputRef, referenceElementRef, ...inputProps }) {
-  return (
-    <Hint
-      // Selects the hint when the user hits the 'enter' key.
-      shouldSelect={(shouldSelect, e) => e.keyCode === 13 || shouldSelect}
-    >
-      <Input
-        {...inputProps}
-        ref={(input) => {
-          inputRef(input);
-          referenceElementRef(input);
-        }}
-      />
-    </Hint>
-  );
-}
-
-renderInput.propTypes = {
-  inputRef: PropTypes.oneOfType([
-    PropTypes.func,
-    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
-  ]),
-  referenceElementRef: PropTypes.func,
-};
-
-function renderMenu(results, menuProps) {
-  const customOption = results.find((result) => result.customOption);
-  return (
-    <Menu {...menuProps} className="autocomplete__menu">
-      {customOption &&
-        <MenuItem
-          className="autocomplete__select"
-          key={0}
-          option={customOption}
-          position={0}
-        >
-          {customOption.label}
-        </MenuItem>
-      }
-      {results.map((result, index) => {
-        if (result.customOption) return;
-        const position = customOption ? index + 1 : index;
-        return (
-          <MenuItem
-            className="autocomplete__select"
-            key={position}
-            option={result}
-            position={position}
-          >
-            {result.label}
-          </MenuItem>
-        );
-      })}
-    </Menu>
-  );
-}
+import { Typeahead } from 'react-bootstrap-typeahead';
+import { renderTypeaheadInput, renderTypeaheadMenu } from '../../utils/typeahead-helpers';
 
 const Dropdown = ({
   action,
@@ -184,8 +122,8 @@ const Dropdown = ({
         onKeyDown={handleKeyDown}
         options={options}
         ref={typeaheadRef}
-        renderInput={renderInput}
-        renderMenu={renderMenu}
+        renderInput={renderTypeaheadInput}
+        renderMenu={renderTypeaheadMenu}
         selected={selected}
       />
     </div>

--- a/app/src/js/components/Executions/execution-events.js
+++ b/app/src/js/components/Executions/execution-events.js
@@ -76,7 +76,7 @@ class ExecutionEvents extends React.Component {
   }
 
   render () {
-    const { executionStatus, dispatch } = this.props;
+    const { executionStatus } = this.props;
     if (!executionStatus.execution) return null;
 
     const errors = this.errors();
@@ -131,11 +131,12 @@ class ExecutionEvents extends React.Component {
             </div>
             <div className='filters'>
               <Search
-                dispatch={dispatch}
                 action={searchExecutionEvents}
                 clear={clearExecutionEventsSearch}
-                label='Search'
+                label="Search"
+                labelKey="type"
                 placeholder="Search Type"
+                searchKey="executions"
               />
             </div>
 

--- a/app/src/js/components/Executions/overview.js
+++ b/app/src/js/components/Executions/overview.js
@@ -92,12 +92,13 @@ class ExecutionOverview extends React.Component {
           >
             <ListFilters>
               <Search
-                dispatch={dispatch}
                 action={searchExecutions}
                 clear={clearExecutionsSearch}
-                paramKey={'asyncOperationId'}
-                label={'Async Operation ID'}
+                paramKey="asyncOperationId"
+                label="Async Operation ID"
+                labelKey="asyncOperationId"
                 placeholder="Search"
+                searchKey="executions"
               />
               <Dropdown
                 options={statusOptions}

--- a/app/src/js/components/Granules/list.js
+++ b/app/src/js/components/Granules/list.js
@@ -176,11 +176,12 @@ const AllGranules = ({
               />
             )}
             <Search
-              dispatch={dispatch}
               action={searchGranules}
               clear={clearGranulesSearch}
               label="Search"
+              labelKey="granuleId"
               placeholder="Granule ID"
+              searchKey="granules"
             />
           </ListFilters>
         </List>

--- a/app/src/js/components/Granules/overview.js
+++ b/app/src/js/components/Granules/overview.js
@@ -150,7 +150,7 @@ class GranulesOverview extends React.Component {
   }
 
   render () {
-    const { collections, dispatch, granules } = this.props;
+    const { collections, granules } = this.props;
     const { list } = granules;
     const { dropdowns } = collections;
     const { count, queriedAt } = list.meta;
@@ -190,11 +190,12 @@ class GranulesOverview extends React.Component {
           >
             <ListFilters>
               <Search
-                dispatch={dispatch}
                 action={searchGranules}
                 clear={clearGranulesSearch}
                 label='Search'
+                labelKey="granuleId"
                 placeholder='Granule ID'
+                searchKey="granules"
               />
               <Dropdown
                 options={statusOptions}

--- a/app/src/js/components/Operations/overview.js
+++ b/app/src/js/components/Operations/overview.js
@@ -99,9 +99,11 @@ class OperationOverview extends React.Component {
             filterClear={clearOperationsFilter}
           >
             <ListFilters>
-              <Search dispatch={dispatch}
+              <Search
                 action={searchOperations}
                 clear={clearOperationsSearch}
+                labelKey="id"
+                searchKey="operations"
               />
               <Dropdown
                 options={operationStatus}

--- a/app/src/js/components/Pdr/list.js
+++ b/app/src/js/components/Pdr/list.js
@@ -91,9 +91,10 @@ const ActivePdrs = ({ dispatch, location, pdrs, queryParams }) => {
         >
           <ListFilters>
             <Search
-              dispatch={dispatch}
               action={searchPdrs}
               clear={clearPdrsSearch}
+              labelKey="pdrName"
+              searchKey="pdrs"
             />
           </ListFilters>
         </List>

--- a/app/src/js/components/Pdr/pdr.js
+++ b/app/src/js/components/Pdr/pdr.js
@@ -16,7 +16,6 @@ import {
   getOptionsCollectionName,
 } from '../../actions';
 import {
-  granuleSearchResult,
   lastUpdated,
   nullValue,
   fullDate,
@@ -245,10 +244,10 @@ class PDR extends React.Component {
                 label={'Status'}
               />
               <Search
-                dispatch={this.props.dispatch}
                 action={searchGranules}
-                format={granuleSearchResult}
                 clear={clearGranulesSearch}
+                labelKey="granuleId"
+                searchKey="granules"
               />
             </ListFilters>
           </List>

--- a/app/src/js/components/ReconciliationReports/gnf-report.js
+++ b/app/src/js/components/ReconciliationReports/gnf-report.js
@@ -14,7 +14,6 @@ import { getFilesSummary, getGranuleFilesSummary } from './reshape-report';
 import { getCollectionId } from '../../utils/format';
 
 const GnfReport = ({
-  dispatch,
   filterString,
   recordData,
   reportName,
@@ -108,10 +107,11 @@ const GnfReport = ({
         </div>
         <div className="filters">
           <Search
-            dispatch={dispatch}
             action={searchReconciliationReport}
             clear={clearReconciliationSearch}
             label="Search"
+            labelKey="granuleId"
+            options={combinedGranules}
             placeholder="Search"
           />
         </div>
@@ -128,7 +128,6 @@ const GnfReport = ({
 };
 
 GnfReport.propTypes = {
-  dispatch: PropTypes.func,
   filterString: PropTypes.string,
   recordData: PropTypes.object,
   reportName: PropTypes.string,

--- a/app/src/js/components/ReconciliationReports/inventory-report.js
+++ b/app/src/js/components/ReconciliationReports/inventory-report.js
@@ -36,7 +36,6 @@ const bucketsForFilter = (allBuckets) => {
 };
 
 const InventoryReport = ({
-  dispatch,
   filterBucket,
   filterString,
   recordData,
@@ -51,6 +50,7 @@ const InventoryReport = ({
     allBuckets,
   } = reshapeReport(recordData, filterString, filterBucket);
   const reportComparisons = [...internalComparison, ...cumulusVsCmrComparison];
+  console.log(reportComparisons);
   const theReportState = reportState(reportComparisons);
   const activeCardTables = reportComparisons.find(
     (displayObj) => displayObj.id === activeId
@@ -161,10 +161,11 @@ const InventoryReport = ({
 
           <div className="filters">
             <Search
-              dispatch={dispatch}
               action={searchReconciliationReport}
               clear={clearReconciliationSearch}
               label="Search"
+              labelKey="granuleId"
+              options={[]}
               placeholder="Search"
             />
             <Dropdown
@@ -230,7 +231,6 @@ const InventoryReport = ({
 };
 
 InventoryReport.propTypes = {
-  dispatch: PropTypes.func,
   filterBucket: PropTypes.string,
   filterString: PropTypes.string,
   recordData: PropTypes.object,

--- a/app/src/js/components/ReconciliationReports/list.js
+++ b/app/src/js/components/ReconciliationReports/list.js
@@ -117,11 +117,12 @@ class ReconciliationReportList extends React.Component {
           >
             <ListFilters>
               <Search
-                dispatch={this.props.dispatch}
                 action={searchReconciliationReports}
                 clear={clearReconciliationReportSearch}
                 label="Search"
+                labelKey="name"
                 placeholder="Report Name"
+                searchKey="reconciliationReports"
               />
               <Dropdown
                 options={reportTypeOptions}

--- a/app/src/js/components/ReconciliationReports/reconciliation-report.js
+++ b/app/src/js/components/ReconciliationReports/reconciliation-report.js
@@ -32,14 +32,12 @@ const ReconciliationReport = ({
       {
         {
           Inventory: <InventoryReport
-            dispatch={dispatch}
             filterBucket={filterBucket}
             filterString={filterString}
             recordData={recordData}
             reportName={reconciliationReportName}
           />,
           'Granule Not Found': <GnfReport
-            dispatch={dispatch}
             filterString={filterString}
             recordData={recordData}
             reportName={reconciliationReportName}

--- a/app/src/js/components/Rules/overview.js
+++ b/app/src/js/components/Rules/overview.js
@@ -87,11 +87,12 @@ class RulesOverview extends React.Component {
           >
             <ListFilters>
               <Search
-                dispatch={dispatch}
                 action={searchRules}
                 clear={clearRulesSearch}
-                placeholder="Search Rules"
                 label="Search"
+                labelKey="name"
+                placeholder="Search Rules"
+                searchKey="rules"
               />
             </ListFilters>
           </List>

--- a/app/src/js/components/Search/search.js
+++ b/app/src/js/components/Search/search.js
@@ -7,7 +7,7 @@ import { AsyncTypeahead } from 'react-bootstrap-typeahead';
 import { get } from 'object-path';
 import { getInitialValueFromLocation } from '../../utils/url-helper';
 import {
-  renderNoHintInput,
+  renderSearchInput,
   renderSearchMenu,
 } from '../../utils/typeahead-helpers';
 
@@ -81,6 +81,9 @@ const Search = ({
           defaultInputValue={initialValue}
           highlightOnlyResult={true}
           id="Search"
+          inputProps={{
+            className: 'search'
+          }}
           isLoading={inflight}
           labelKey={labelKey}
           onChange={handleChange}
@@ -91,7 +94,7 @@ const Search = ({
           options={searchOptions || options}
           placeholder={placeholder}
           ref={searchRef}
-          renderInput={renderNoHintInput}
+          renderInput={renderSearchInput}
           renderMenu={(results, menuProps) => renderSearchMenu(results, menuProps, labelKey)}
         />
       </form>

--- a/app/src/js/components/Search/search.js
+++ b/app/src/js/components/Search/search.js
@@ -11,6 +11,15 @@ import {
   renderSearchMenu,
 } from '../../utils/typeahead-helpers';
 
+/**
+ * Search
+ * @description Search component
+ * @param {string} labelKey The propery of the search results that will be displayed in the dropdown menu
+ * (ex: for a granule, this would be set to 'granuleId')
+ * @param {string} paramKey The parameter that should be appended to the url when searching
+ * @param {string} searchKey This defines what is being searched (ex: collections, granules, rules, etc)
+ */
+
 const Search = ({
   action,
   clear,

--- a/app/src/js/components/Search/search.js
+++ b/app/src/js/components/Search/search.js
@@ -1,84 +1,102 @@
-import React from 'react';
+import React, { createRef } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import withQueryParams from 'react-router-query-params';
 import { withRouter } from 'react-router-dom';
-import { initialValueFromLocation } from '../../utils/url-helper';
+import { AsyncTypeahead } from 'react-bootstrap-typeahead';
+import { get } from 'object-path';
+import { getInitialValueFromLocation } from '../../utils/url-helper';
+import {
+  renderNoHintInput,
+  renderSearchMenu,
+} from '../../utils/typeahead-helpers';
 
-class Search extends React.Component {
-  constructor (props) {
-    super(props);
-    this.displayName = 'Search';
-    const value = initialValueFromLocation(props);
-    this.state = { value };
-    this.complete = this.complete.bind(this);
-    this.submit = this.submit.bind(this);
-    this.delayedQuery = this.delayedQuery.bind(this);
+const Search = ({
+  action,
+  clear,
+  dispatch,
+  label,
+  labelKey,
+  location,
+  options,
+  paramKey = 'search',
+  placeholder,
+  queryParams,
+  searchKey = '',
+  setQueryParams,
+  ...rest
+}) => {
+  const searchRef = createRef();
+  const formID = `form-${label}-${paramKey}`;
+  const initialValue = getInitialValueFromLocation({
+    location,
+    paramKey,
+    queryParams,
+  });
+  const searchList = get(rest[searchKey], 'list');
+  const { data: searchOptions, inflight = false } = searchList || {};
+
+  function handleSearch(query) {
+    if (query) dispatch(action(query));
+    else dispatch(clear);
   }
 
-  componentDidMount () {
-    const { dispatch, action, paramKey, queryParams } = this.props;
-    const queryValue = queryParams[paramKey];
-    if (queryValue) dispatch(action(queryValue));
-  }
-
-  componentDidUpdate (prevProps, prevState, snapshot) {
-    const { paramKey, dispatch, action, queryParams } = this.props;
-    const queryValue = queryParams[paramKey];
-    if (queryValue !== prevProps.queryParams[paramKey]) {
-      dispatch(action(queryValue));
-      this.setState({ queryValue }); // eslint-disable-line react/no-did-update-set-state
+  function handleChange(selections) {
+    if (selections && selections.length > 0) {
+      const query = selections[0][labelKey];
+      dispatch(action(query));
+      setQueryParams({ [paramKey]: query });
+    } else {
+      dispatch(clear());
+      setQueryParams({ [paramKey]: undefined });
     }
   }
 
-  componentWillUnmount () {
-    if (this.cancelDelay) { this.cancelDelay(); }
-    const { dispatch, clear } = this.props;
-    dispatch(clear());
+  function handleInputChange(text, event) {
+    if (text) {
+      dispatch(action(text));
+      setQueryParams({ [paramKey]: text });
+    } else {
+      dispatch(clear());
+      setQueryParams({ [paramKey]: undefined });
+    }
   }
 
-  complete (e) {
-    const value = e.currentTarget.value || null;
-    this.setState({ value });
-    if (this.cancelDelay) { this.cancelDelay(); }
-    this.cancelDelay = this.delayedQuery(value);
+  function handleFocus(event) {
+    event.target.select();
   }
 
-  submit (e) {
-    e.preventDefault();
+  function handleKeyDown(event) {
+    if (event.keyCode === 13) {
+      searchRef.current.hideMenu();
+    }
   }
 
-  delayedQuery (value) {
-    const { dispatch, action, clear, paramKey, setQueryParams } = this.props;
-    const timeoutId = setTimeout(() => {
-      if (value && value.length) {
-        setQueryParams({ [paramKey]: value });
-        dispatch(action(value));
-      } else {
-        setQueryParams({ [paramKey]: undefined });
-        dispatch(clear());
-      }
-    }, 650);
-    return () => clearTimeout(timeoutId);
-  }
-
-  render () {
-    const { label, paramKey } = this.props;
-    const formID = `form-${label}-${paramKey}`;
-    return (
-      <div className='filter__item'>
-        {label ? <label htmlFor={formID}>{label}</label> : null}
-        <form className='search__wrapper form-group__element' onSubmit={this.submit} >
-          <input className='search' type='search' onChange={this.complete} value={this.state.value || ''} placeholder={this.props.placeholder || ''}/>
-          <span className='search__icon'/>
-        </form>
-      </div>
-    );
-  }
-}
-
-Search.defaultProps = {
-  paramKey: 'search'
+  return (
+    <div className="filter__item">
+      {label && <label htmlFor={formID}>{label}</label>}
+      <form className="search__wrapper form-group__element">
+        <AsyncTypeahead
+          clearButton={true}
+          defaultInputValue={initialValue}
+          highlightOnlyResult={true}
+          id="Search"
+          isLoading={inflight}
+          labelKey={labelKey}
+          onChange={handleChange}
+          onFocus={handleFocus}
+          onInputChange={handleInputChange}
+          onKeyDown={handleKeyDown}
+          onSearch={handleSearch}
+          options={searchOptions || options}
+          placeholder={placeholder}
+          ref={searchRef}
+          renderInput={renderNoHintInput}
+          renderMenu={(results, menuProps) => renderSearchMenu(results, menuProps, labelKey)}
+        />
+      </form>
+    </div>
+  );
 };
 
 Search.propTypes = {
@@ -87,12 +105,14 @@ Search.propTypes = {
   clear: PropTypes.func,
   paramKey: PropTypes.string,
   label: PropTypes.any,
+  labelKey: PropTypes.string,
   location: PropTypes.object,
-  router: PropTypes.object,
+  options: PropTypes.array,
   query: PropTypes.object,
   queryParams: PropTypes.object,
+  searchKey: PropTypes.string,
   setQueryParams: PropTypes.func,
-  placeholder: PropTypes.string
+  placeholder: PropTypes.string,
 };
 
 export default withRouter(withQueryParams()(connect((state) => state)(Search)));

--- a/app/src/js/components/Workflows/overview.js
+++ b/app/src/js/components/Workflows/overview.js
@@ -45,11 +45,12 @@ const WorkflowOverview = ({
             {/* Someone needs to define the search parameters for workflows,
             e.g. steps, collections, granules, etc. } */}
             <Search
-              dispatch={dispatch}
               action={searchWorkflows}
               clear={clearWorkflowsSearch}
               label="Search"
+              labelKey="name"
               placeholder="Workflow Name"
+              searchKey="workflows"
             />
           </ListFilters>
         </List>

--- a/app/src/js/utils/typeahead-helpers.js
+++ b/app/src/js/utils/typeahead-helpers.js
@@ -1,0 +1,97 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Menu, MenuItem, Hint, Input } from 'react-bootstrap-typeahead';
+
+export function renderTypeaheadInput({ inputRef, referenceElementRef, ...inputProps }) {
+  return (
+    <Hint
+      // Selects the hint when the user hits the 'enter' key.
+      shouldSelect={(shouldSelect, e) => e.keyCode === 13 || shouldSelect}
+    >
+      <Input
+        {...inputProps}
+        ref={(input) => {
+          inputRef(input);
+          referenceElementRef(input);
+        }}
+      />
+    </Hint>
+  );
+}
+
+renderTypeaheadInput.propTypes = {
+  inputRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
+  referenceElementRef: PropTypes.func,
+};
+
+export function renderNoHintInput({ inputRef, referenceElementRef, ...inputProps }) {
+  return (
+    <Input
+      {...inputProps}
+      ref={(input) => {
+        inputRef(input);
+        referenceElementRef(input);
+      }}
+    />
+  );
+}
+
+renderNoHintInput.propTypes = {
+  inputRef: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
+  ]),
+  referenceElementRef: PropTypes.func,
+};
+
+export function renderTypeaheadMenu(results, menuProps) {
+  const customOption = results.find((result) => result.customOption);
+  return (
+    <Menu {...menuProps} className="autocomplete__menu">
+      {customOption && (
+        <MenuItem
+          className="autocomplete__select"
+          key={0}
+          option={customOption}
+          position={0}
+        >
+          {customOption.label}
+        </MenuItem>
+      )}
+      {results.map((result, index) => {
+        if (result.customOption) return;
+        const position = customOption ? index + 1 : index;
+        return (
+          <MenuItem
+            className="autocomplete__select"
+            key={position}
+            option={result}
+            position={position}
+          >
+            {result.label}
+          </MenuItem>
+        );
+      })}
+    </Menu>
+  );
+}
+
+export function renderSearchMenu(results, menuProps, labelKey) {
+  return (
+    <Menu {...menuProps} className="autocomplete__menu">
+      {results.map((result, index) => (
+        <MenuItem
+          className="autocomplete__select"
+          key={index}
+          option={result}
+          position={index}
+        >
+          {result[labelKey]}
+        </MenuItem>
+      ))}
+    </Menu>
+  );
+}

--- a/app/src/js/utils/typeahead-helpers.js
+++ b/app/src/js/utils/typeahead-helpers.js
@@ -27,19 +27,22 @@ renderTypeaheadInput.propTypes = {
   referenceElementRef: PropTypes.func,
 };
 
-export function renderNoHintInput({ inputRef, referenceElementRef, ...inputProps }) {
+export function renderSearchInput({ inputRef, referenceElementRef, ...inputProps }) {
   return (
-    <Input
-      {...inputProps}
-      ref={(input) => {
-        inputRef(input);
-        referenceElementRef(input);
-      }}
-    />
+    <>
+      <Input
+        {...inputProps}
+        ref={(input) => {
+          inputRef(input);
+          referenceElementRef(input);
+        }}
+      />
+      <span className='search__icon'/>
+    </>
   );
 }
 
-renderNoHintInput.propTypes = {
+renderSearchInput.propTypes = {
   inputRef: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.shape({ current: PropTypes.instanceOf(Element) }),

--- a/app/src/js/utils/url-helper.js
+++ b/app/src/js/utils/url-helper.js
@@ -9,7 +9,7 @@ import { history } from '../store/configureStore';
  * @param {Object} props - react component props
  * @returns {string} - value of this component's query string from the url .
  */
-export function initialValueFromLocation (props) {
+export function getInitialValueFromLocation (props) {
   const { location, paramKey, queryParams } = props;
   // eslint-disable-next-line lodash/path-style
   return get(location, ['query', paramKey], get(queryParams, paramKey, ''));

--- a/cypress/integration/collections_spec.js
+++ b/cypress/integration/collections_spec.js
@@ -80,6 +80,18 @@ describe('Dashboard Collections Page', () => {
       cy.get('@listItems').should('have.length', 11).contains('.td', /second|minute/);
     });
 
+    it('should search collections by name', () => {
+      const infix = 'https';
+      cy.visit('/collections');
+      cy.wait('@getCollections');
+      cy.get('.search').as('search');
+      cy.get('@search').click().type(infix);
+      cy.url().should('include', `search=${infix}`);
+      cy.get('.table .tbody .tr').should('have.length', 1);
+      cy.get('.table .tbody .tr').eq(0).children('.td').eq(1)
+        .contains(infix);
+    });
+
     it('should display expected MMT Links for collections list', () => {
       cy.visit('/collections');
       cy.clearStartDateTime();

--- a/cypress/integration/granules_spec.js
+++ b/cypress/integration/granules_spec.js
@@ -218,7 +218,7 @@ describe('Dashboard Granules Page', () => {
       cy.visit('/granules');
       cy.get('.search').as('search');
       cy.get('@search').click().type(infix);
-      cy.url().should('include', 'search=A0142558');
+      cy.url().should('include', `search=${infix}`);
       cy.get('.table .tbody .tr').should('have.length', 1);
       cy.get('.table .tbody .tr').eq(0).children('.td').eq(2)
         .contains(infix);

--- a/test/utils/url-helper.js
+++ b/test/utils/url-helper.js
@@ -4,7 +4,7 @@ import test from 'ava';
 import sinon from 'sinon';
 
 import {
-  initialValueFromLocation,
+  getInitialValueFromLocation,
   initialValuesFromLocation,
   getPersistentQueryParams,
   historyPushWithQueryParams,
@@ -34,30 +34,30 @@ test.afterEach((t) => {
   URLHelperRewireAPI.__ResetDependency__('historyPushWithQueryParams');
 });
 
-test('initialValueFromLocation returns empty string if location query empty', (t) => {
+test('getInitialValueFromLocation returns empty string if location query empty', (t) => {
   const testLocation = { ...location };
   const expectedInitialValue = '';
-  const actualInitialValue = initialValueFromLocation({
+  const actualInitialValue = getInitialValueFromLocation({
     location: testLocation,
   });
   t.is(expectedInitialValue, actualInitialValue);
 });
 
-test('initialValueFromLocation returns empty string if paramKey missing', (t) => {
+test('getInitialValueFromLocation returns empty string if paramKey missing', (t) => {
   const testLocation = { ...location };
   testLocation.query = { status: 'running' };
   const expectedInitialValue = '';
-  const actualInitialValue = initialValueFromLocation({
+  const actualInitialValue = getInitialValueFromLocation({
     location: testLocation,
   });
   t.is(expectedInitialValue, actualInitialValue);
 });
 
-test('initialValueFromLocation returns query initialValue if paramKey found', (t) => {
+test('getInitialValueFromLocation returns query initialValue if paramKey found', (t) => {
   const testLocation = { ...location };
   testLocation.query = { status: 'running' };
   const expectedInitialValue = 'running';
-  const actualInitialValue = initialValueFromLocation({
+  const actualInitialValue = getInitialValueFromLocation({
     location: testLocation,
     paramKey: 'status',
   });


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2021: Search Module: Search Input Fixes](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2021)

## Changes

* Updates the search component to use react-bootstrap-typeahead. This is the same package we're using for for the filter dropdowns, but here we're using the async version. This gives us autocomplete functionality as well as a clear button. 
* Also added a focus handler so that text gets highlighted when clicking into it.
* Adds additional params (and documentation for those params) to <Search> for easier use with the new component

To test: perform searches across the various app pages.

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Adhoc testing
- [x] Integration tests