### PR TITLE
Remove the eslint plugin for webpack.

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -50,12 +50,6 @@ const CommonConfig = {
                 '@babel/preset-react'
               ]
             }
-          },
-          {
-            loader: 'eslint-loader',
-            options: {
-              emitWarning: true
-            }
           }
         ]
       },


### PR DESCRIPTION
We test the code during CI with an explicit eslint step. This just wastes time.

I used 'speed-measure-webpack-plugin' to determine that the startup time for
`npm run serve` went from ~40 sec to ~20 sec on my machine.
