### PR TITLE
Cumulus 2171 filtered granules csv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Updates the dashboard to use alpha version `@cumulus/api@3.0.1-alpha.2` for testing.
   - Code changes to allow for private CMR collections to have links to the MMT.
 
+- **CUMULUS-2171**
+  - Allows filtering of the Granule Inventory List CSV download based on Granule IDs, Status, and Collection.
+
 ## [v2.0.0]
 
 ### BREAKING CHANGES

--- a/app/src/js/components/Granules/overview.js
+++ b/app/src/js/components/Granules/overview.js
@@ -131,14 +131,13 @@ class GranulesOverview extends React.Component {
   submitListRequest(e) {
     const { listName, selected } = this.state;
     const queryParams = this.generateQuery();
-    const selectedGranuleIds = selected;
     const granuleIdFilter = queryParams.search;
-    const granuleIds = [];
+    let granuleIds = selected;
     
     // If there are no selected granules but a Granule ID is specified
     // in the search filter, use only that.
-    if (selectedGranuleIds.length < 1 && granuleIdFilter) {
-      granuleIds.push(granuleIdFilter);
+    if (granuleIds.length < 1 && granuleIdFilter) {
+      granuleIds = [granuleIdFilter];
     }
 
     const requestBody = {
@@ -207,7 +206,7 @@ class GranulesOverview extends React.Component {
   }
 
   render () {
-    const { isModalOpen, isListRequestSubmitted, listName } = this.state;
+    const { isModalOpen, isListRequestSubmitted, listName, selected } = this.state;
     const { collections, granules } = this.props;
     const { list } = granules;
     const { dropdowns } = collections;
@@ -275,7 +274,7 @@ class GranulesOverview extends React.Component {
             sortId='timestamp'
             filterAction={filterGranules}
             filterClear={clearGranulesFilter}
-            onSelect={this.updateSelection}
+            onSelect={this.updateSelection.bind(this)}
           >
             <ListFilters>
               <Search
@@ -333,5 +332,6 @@ export default withRouter(withQueryParams()(connect((state) => ({
   collections: state.collections,
   config: state.config,
   granules: state.granules,
+  selected: state.selected,
   workflowOptions: workflowOptionNames(state),
 }))(GranulesOverview)));

--- a/app/src/js/components/Granules/overview.js
+++ b/app/src/js/components/Granules/overview.js
@@ -206,7 +206,7 @@ class GranulesOverview extends React.Component {
   }
 
   render () {
-    const { isModalOpen, isListRequestSubmitted, listName, selected } = this.state;
+    const { isModalOpen, isListRequestSubmitted, listName } = this.state;
     const { collections, granules } = this.props;
     const { list } = granules;
     const { dropdowns } = collections;

--- a/app/src/js/components/Granules/overview.js
+++ b/app/src/js/components/Granules/overview.js
@@ -133,7 +133,7 @@ class GranulesOverview extends React.Component {
     const queryParams = this.generateQuery();
     const granuleIdFilter = queryParams.search;
     let granuleIds = selected;
-    
+
     // If there are no selected granules but a Granule ID is specified
     // in the search filter, use only that.
     if (granuleIds.length < 1 && granuleIdFilter) {

--- a/app/src/js/components/Granules/overview.js
+++ b/app/src/js/components/Granules/overview.js
@@ -67,6 +67,7 @@ class GranulesOverview extends React.Component {
     this.submitListRequest = this.submitListRequest.bind(this);
     this.goToListPage = this.goToListPage.bind(this);
     this.handleReportTypeInputChange = this.handleReportTypeInputChange.bind(this);
+    this.updateSelection = this.updateSelection.bind(this);
     this.defaultListName = () => `granuleList-${moment().format('YYYYMMDDTHHmmssSSS')}`;
     this.state = {
       isModalOpen: false,
@@ -131,7 +132,8 @@ class GranulesOverview extends React.Component {
   submitListRequest(e) {
     const { listName, selected } = this.state;
     const queryParams = this.generateQuery();
-    const granuleIdFilter = queryParams.search;
+    const { collectionId, status, search: granuleIdFilter } = queryParams;
+
     let granuleIds = selected;
 
     // If there are no selected granules but a Granule ID is specified
@@ -143,8 +145,8 @@ class GranulesOverview extends React.Component {
     const requestBody = {
       reportName: listName,
       reportType: 'Granule Inventory',
-      status: queryParams.status,
-      collectionId: queryParams.collectionId
+      status: status,
+      collectionId: collectionId
     };
 
     if (granuleIds.length > 0) {
@@ -274,7 +276,7 @@ class GranulesOverview extends React.Component {
             sortId='timestamp'
             filterAction={filterGranules}
             filterClear={clearGranulesFilter}
-            onSelect={this.updateSelection.bind(this)}
+            onSelect={this.updateSelection}
           >
             <ListFilters>
               <Search

--- a/app/src/js/components/Granules/overview.js
+++ b/app/src/js/components/Granules/overview.js
@@ -145,8 +145,8 @@ class GranulesOverview extends React.Component {
     const requestBody = {
       reportName: listName,
       reportType: 'Granule Inventory',
-      status: status,
-      collectionId: collectionId
+      status,
+      collectionId
     };
 
     if (granuleIds.length > 0) {

--- a/app/src/js/components/Table/Table.js
+++ b/app/src/js/components/Table/Table.js
@@ -27,7 +27,7 @@ class List extends React.Component {
     this.getQueryConfig = this.getQueryConfig.bind(this);
     
     if (typeof props.onSelect === 'function') {
-      this.onSelect = props.onSelect.bind(this);
+      this.onSelect = props.onSelect;
     }
 
     const initialPage = 1;

--- a/app/src/js/components/Table/Table.js
+++ b/app/src/js/components/Table/Table.js
@@ -25,6 +25,10 @@ class List extends React.Component {
     this.onBulkActionSuccess = this.onBulkActionSuccess.bind(this);
     this.onBulkActionError = this.onBulkActionError.bind(this);
     this.getQueryConfig = this.getQueryConfig.bind(this);
+    
+    if (typeof props.onSelect === 'function') {
+      this.onSelect = props.onSelect.bind(this);
+    }
 
     const initialPage = 1;
     const initialSortId = props.sortId;
@@ -92,6 +96,11 @@ class List extends React.Component {
       selected,
       clearSelected: false,
     });
+
+    // Current selection is passed to the parent component
+    if (typeof this.onSelect === 'function') {
+      this.onSelect(selected);
+    }
   }
 
   onBulkActionSuccess(results, error) {
@@ -228,6 +237,7 @@ List.propTypes = {
   rowId: PropTypes.any,
   sortId: PropTypes.string,
   tableColumns: PropTypes.array,
+  onSelect: PropTypes.func,
 };
 
 export { List };

--- a/app/src/js/components/Table/Table.js
+++ b/app/src/js/components/Table/Table.js
@@ -26,10 +26,6 @@ class List extends React.Component {
     this.onBulkActionError = this.onBulkActionError.bind(this);
     this.getQueryConfig = this.getQueryConfig.bind(this);
 
-    if (typeof props.onSelect === 'function') {
-      this.onSelect = props.onSelect;
-    }
-
     const initialPage = 1;
     const initialSortId = props.sortId;
     const initialOrder = 'desc';
@@ -98,8 +94,8 @@ class List extends React.Component {
     });
 
     // Current selection is passed to the parent component
-    if (typeof this.onSelect === 'function') {
-      this.onSelect(selected);
+    if (typeof this.props.onSelect === 'function') {
+      this.props.onSelect(selected);
     }
   }
 

--- a/app/src/js/components/Table/Table.js
+++ b/app/src/js/components/Table/Table.js
@@ -25,7 +25,7 @@ class List extends React.Component {
     this.onBulkActionSuccess = this.onBulkActionSuccess.bind(this);
     this.onBulkActionError = this.onBulkActionError.bind(this);
     this.getQueryConfig = this.getQueryConfig.bind(this);
-    
+
     if (typeof props.onSelect === 'function') {
       this.onSelect = props.onSelect;
     }

--- a/cypress/integration/granules_spec.js
+++ b/cypress/integration/granules_spec.js
@@ -389,8 +389,8 @@ describe('Dashboard Granules Page', () => {
       const status = 'running';
       const collectionId = 'MOD09GQ___006';
       const granuleIds = [
-        'MOD09GQ.A1657416.CbyoRi.006.9697917818587',
-        'MOD09GQ.A0501579.PZB_CG.006.8580266395214'
+        'MOD09GQ.A0501579.PZB_CG.006.8580266395214',
+        'MOD09GQ.A1657416.CbyoRi.006.9697917818587'
       ];
 
       cy.route2({
@@ -402,7 +402,7 @@ describe('Dashboard Granules Page', () => {
         expect(requestBody).to.have.property('reportName', listName);
         expect(requestBody).to.have.property('status', status);
         expect(requestBody).to.have.property('collectionId', collectionId);
-        expect(requestBody.granuleIds).to.deep.equal(granuleIds);
+        expect(requestBody.granuleIds.sort()).to.deep.equal(granuleIds);
       }).as('createList');
 
       cy.visit('/granules');

--- a/cypress/integration/granules_spec.js
+++ b/cypress/integration/granules_spec.js
@@ -386,6 +386,13 @@ describe('Dashboard Granules Page', () => {
 
     it('Should open modal to create granule inventory report', () => {
       const listName = 'GranuleListTest';
+      const status = 'running';
+      const collectionId = 'MOD09GQ___006';
+      const granuleIds = [
+        "MOD09GQ.A1657416.CbyoRi.006.9697917818587",
+        "MOD09GQ.A0501579.PZB_CG.006.8580266395214"
+      ];
+
       cy.route2({
         url: '/reconciliationReports',
         method: 'POST'
@@ -393,9 +400,24 @@ describe('Dashboard Granules Page', () => {
         const requestBody = JSON.parse(req.body);
         expect(requestBody).to.have.property('reportType', 'Granule Inventory');
         expect(requestBody).to.have.property('reportName', listName);
+        expect(requestBody).to.have.property('status', status);
+        expect(requestBody).to.have.property('collectionId', collectionId);
+        expect(requestBody).to.have.property('granuleIds', granuleIds);
       }).as('createList');
 
       cy.visit('/granules');
+
+      // Enter status field
+      cy.get('.filter-status .rbt-input-main').as('status-input');
+      cy.get('@status-input').click().type(status).type('{enter}');
+
+      // Enter collection field
+      cy.get('.filter-collectionId .rbt-input-main').as('collection-input');
+      cy.get('@collection-input').click().type(collectionId).type('{enter}');
+
+      // Select both granules in list
+      cy.get('.table .tbody .tr .td input[type=checkbox]').as('granule-checkbox');
+      cy.get('@granule-checkbox').click({ multiple: true });
 
       cy.get('.csv__download').click();
       cy.get('.default-modal.granule-inventory ').as('modal');

--- a/cypress/integration/granules_spec.js
+++ b/cypress/integration/granules_spec.js
@@ -384,13 +384,13 @@ describe('Dashboard Granules Page', () => {
       cy.wait('@getList').its('response.body').should('include', 'url');
     });
 
-    it('Should open modal to create granule inventory report', () => {
+    it.only('Should open modal to create granule inventory report', () => {
       const listName = 'GranuleListTest';
       const status = 'running';
       const collectionId = 'MOD09GQ___006';
       const granuleIds = [
-        "MOD09GQ.A1657416.CbyoRi.006.9697917818587",
-        "MOD09GQ.A0501579.PZB_CG.006.8580266395214"
+        'MOD09GQ.A1657416.CbyoRi.006.9697917818587',
+        'MOD09GQ.A0501579.PZB_CG.006.8580266395214'
       ];
 
       cy.route2({
@@ -402,7 +402,7 @@ describe('Dashboard Granules Page', () => {
         expect(requestBody).to.have.property('reportName', listName);
         expect(requestBody).to.have.property('status', status);
         expect(requestBody).to.have.property('collectionId', collectionId);
-        expect(requestBody).to.have.property('granuleIds', granuleIds);
+        expect(requestBody.granuleIds).to.deep.equal(granuleIds);
       }).as('createList');
 
       cy.visit('/granules');

--- a/cypress/integration/granules_spec.js
+++ b/cypress/integration/granules_spec.js
@@ -384,10 +384,11 @@ describe('Dashboard Granules Page', () => {
       cy.wait('@getList').its('response.body').should('include', 'url');
     });
 
-    it.only('Should open modal to create granule inventory report', () => {
+    it('Should open modal to create granule inventory report', () => {
       const listName = 'GranuleListTest';
       const status = 'running';
       const collectionId = 'MOD09GQ___006';
+      // granule IDs in alphanumeric order. We sort the actual result for comparison.
       const granuleIds = [
         'MOD09GQ.A0501579.PZB_CG.006.8580266395214',
         'MOD09GQ.A1657416.CbyoRi.006.9697917818587'


### PR DESCRIPTION
**Summary:** 

Addresses [CUMULUS-2171: Dashboard's Granule overview page should provide option to download filtered granules](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2171)

## Changes

* Adds `status`, `collectionId`, and `granuleIds` properties to reconciliation report request
* Collects GranuleIds based on selected granules in the granule list or, if none selected, the granule ID search filter (or selects all granules if neither are available).

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Adhoc testing
- [x] Integration tests