### PR TITLE
Mhs/cumulus 2215/update collection api calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **CUMULUS-2063**
   - Updates the dashboard to use alpha version `@cumulus/api@3.0.1-alpha.2` for testing.
   - Code changes to allow for private CMR collections to have links to the MMT.
+- **CUMULUS-2215**
+  - Omits unnecesary statistics request when building the option list of collection names on the granules page.
+
 
 ## [v2.0.0]
 

--- a/app/src/js/actions/index.js
+++ b/app/src/js/actions/index.js
@@ -118,7 +118,7 @@ export const checkApiVersion = () => (dispatch, getState) => {
 };
 
 export const listCollections = (options = {}) => {
-  const { listAll = false, getMMT = true, ...queryOptions } = options;
+  const { listAll = false, getMMT = true, includeStats = true, ...queryOptions } = options;
   return (dispatch, getState) => {
     const timeFilters = listAll ? {} : fetchCurrentTimeFilters(getState().datepicker);
     const urlPath = `collections${isEmpty(timeFilters) || listAll ? '' : '/active'}`;
@@ -128,7 +128,7 @@ export const listCollections = (options = {}) => {
         method: 'GET',
         id: null,
         url: new URL(urlPath, root).href,
-        qs: { limit: defaultPageLimit, ...queryOptions, ...timeFilters, getMMT }
+        qs: { limit: defaultPageLimit, ...queryOptions, ...timeFilters, getMMT, includeStats }
       }
     });
   };

--- a/app/src/js/actions/index.js
+++ b/app/src/js/actions/index.js
@@ -76,7 +76,7 @@ export const getCollection = (name, version) => (dispatch, getState) => {
       type: types.COLLECTION,
       method: 'GET',
       id: getCollectionId({ name, version }),
-      path: `collections?name=${name}&version=${version}`,
+      path: `collections?name=${name}&version=${version}&includeStats=true`,
       qs: timeFilters,
     },
   });

--- a/app/src/js/utils/format.js
+++ b/app/src/js/utils/format.js
@@ -111,38 +111,6 @@ export const lastUpdated = (datestring, text) => {
   );
 };
 
-export const collectionSearchResult = (collection) => {
-  const { name, version } = collection;
-  return (
-    <li key={name}>
-      <Link
-        to={(location) => ({
-          pathname: `collections/collection/${name}/${version}`,
-          search: getPersistentQueryParams(location),
-        })}
-      >
-        {name} / {version}
-      </Link>
-    </li>
-  );
-};
-
-export const granuleSearchResult = (granule) => {
-  const { granuleId, status } = granule;
-  return (
-    <li key={granuleId}>
-      <Link
-        to={(location) => ({
-          pathname: `granules/granules/${granuleId}/${status}`,
-          search: getPersistentQueryParams(location),
-        })}
-      >
-        {granuleId} / {status}
-      </Link>
-    </li>
-  );
-};
-
 export const granuleLink = (granuleId) => {
   if (!granuleId) return nullValue;
   return (

--- a/cypress/integration/collections_spec.js
+++ b/cypress/integration/collections_spec.js
@@ -427,7 +427,6 @@ describe('Dashboard Collections Page', () => {
 
       cy.get('.modal.show > .modal-dialog > .modal-content > .modal-body > p').should('contain', 'must first delete the granules associated with it');
 
-
       // modal should ask if user wants to go to granules page
       cy.contains('.button--cancel', 'Cancel Request')
         .should('be.visible').wait(200).click();

--- a/cypress/integration/collections_spec.js
+++ b/cypress/integration/collections_spec.js
@@ -425,6 +425,9 @@ describe('Dashboard Collections Page', () => {
       cy.contains('.button__deletecollections', 'Delete Collection')
         .should('be.visible').wait(200).click();
 
+      cy.get('.modal.show > .modal-dialog > .modal-content > .modal-body > p').should('contain', 'must first delete the granules associated with it');
+
+
       // modal should ask if user wants to go to granules page
       cy.contains('.button--cancel', 'Cancel Request')
         .should('be.visible').wait(200).click();

--- a/cypress/integration/collections_spec.js
+++ b/cypress/integration/collections_spec.js
@@ -42,6 +42,10 @@ describe('Dashboard Collections Page', () => {
       cy.contains('.heading--xlarge', 'Collections');
 
       cy.get('.table .tbody .tr').should('have.length', 1);
+      cy.get('.tbody > .tr > :nth-child(4)').should('contain', '11');
+      cy.get('.tbody > .tr > :nth-child(5)').should('contain', '7');
+      cy.get('.tbody > .tr > :nth-child(6)').should('contain', '2');
+      cy.get('.tbody > .tr > :nth-child(7)').should('contain', '2');
 
       cy.clearStartDateTime();
       cy.wait('@getCollections');

--- a/package-lock.json
+++ b/package-lock.json
@@ -3835,9 +3835,9 @@
       "dev": true
     },
     "@cumulus/api": {
-      "version": "3.0.1-alpha.3",
-      "resolved": "https://registry.npmjs.org/@cumulus/api/-/api-3.0.1-alpha.3.tgz",
-      "integrity": "sha512-qN25Va1Z4t7cerwaodblimt3dvlkNP3RT3SVuNWYEZ6UiV4deeoKgzI28/nmZGHkkO7RpOGgxJK5Q3udGk9YrA==",
+      "version": "3.0.2-alpha.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/api/-/api-3.0.2-alpha.0.tgz",
+      "integrity": "sha512-N1dZqmAISxxFZqTOQEfo6YpLWAlCQOMIaS5y9OSfeX/Om2FHvMgj3yi7nzRq3YNdXIfciO+5CPYmrbmr97YiDA==",
       "dev": true,
       "requires": {
         "@cumulus/aws-client": "3.0.0",
@@ -3856,7 +3856,7 @@
         "@elastic/elasticsearch": "^5.6.20",
         "@mapbox/dyno": "^1.4.2",
         "aggregate-error": "^3.0.1",
-        "ajv": "^5.2.2",
+        "ajv": "^6.12.3",
         "aws-elasticsearch-connector": "8.2.0",
         "aws-sdk": "^2.585.0",
         "aws-serverless-express": "^3.3.5",
@@ -3868,14 +3868,14 @@
         "express": "^4.16.4",
         "express-boom": "^3.0.0",
         "express-promise-router": "^3.0.3",
-        "googleapis": "^47.0.0",
-        "got": "^8.3.0",
+        "googleapis": "^49.0.0",
+        "got": "^11.7.0",
         "hsts": "^2.1.0",
         "is-valid-hostname": "0.0.1",
         "json2csv": "^4.5.1",
         "jsonpath-plus": "^1.1.0",
         "jsonwebtoken": "^8.4.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.20",
         "moment": "2.24.0",
         "morgan": "^1.9.1",
         "nodeify": "^1.0.1",
@@ -4080,6 +4080,18 @@
         "uuid": "^3.2.1"
       },
       "dependencies": {
+        "ajv": {
+          "version": "5.5.2",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+          "dev": true,
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
+        },
         "got": {
           "version": "9.6.0",
           "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
@@ -4130,123 +4142,6 @@
       "dev": true,
       "requires": {
         "got": "^11.2.0"
-      },
-      "dependencies": {
-        "@sindresorhus/is": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-3.1.2.tgz",
-          "integrity": "sha512-JiX9vxoKMmu8Y3Zr2RVathBL1Cdu4Nt4MuNWemt1Nc06A0RAin9c5FArkhGsyMBWfCu4zj+9b+GxtjAnE4qqLQ==",
-          "dev": true
-        },
-        "@szmarczak/http-timer": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
-          "integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
-          "dev": true,
-          "requires": {
-            "defer-to-connect": "^2.0.0"
-          }
-        },
-        "cacheable-request": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
-          "integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
-          "dev": true,
-          "requires": {
-            "clone-response": "^1.0.2",
-            "get-stream": "^5.1.0",
-            "http-cache-semantics": "^4.0.0",
-            "keyv": "^4.0.0",
-            "lowercase-keys": "^2.0.0",
-            "normalize-url": "^4.1.0",
-            "responselike": "^2.0.0"
-          }
-        },
-        "decompress-response": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-          "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-          "dev": true,
-          "requires": {
-            "mimic-response": "^3.1.0"
-          }
-        },
-        "defer-to-connect": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
-          "integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==",
-          "dev": true
-        },
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "got": {
-          "version": "11.7.0",
-          "resolved": "https://registry.npmjs.org/got/-/got-11.7.0.tgz",
-          "integrity": "sha512-7en2XwH2MEqOsrK0xaKhbWibBoZqy+f1RSUoIeF1BLcnf+pyQdDsljWMfmOh+QKJwuvDIiKx38GtPh5wFdGGjg==",
-          "dev": true,
-          "requires": {
-            "@sindresorhus/is": "^3.1.1",
-            "@szmarczak/http-timer": "^4.0.5",
-            "@types/cacheable-request": "^6.0.1",
-            "@types/responselike": "^1.0.0",
-            "cacheable-lookup": "^5.0.3",
-            "cacheable-request": "^7.0.1",
-            "decompress-response": "^6.0.0",
-            "http2-wrapper": "^1.0.0-beta.5.2",
-            "lowercase-keys": "^2.0.0",
-            "p-cancelable": "^2.0.0",
-            "responselike": "^2.0.0"
-          }
-        },
-        "json-buffer": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-          "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-          "dev": true
-        },
-        "keyv": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
-          "integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
-          "dev": true,
-          "requires": {
-            "json-buffer": "3.0.1"
-          }
-        },
-        "lowercase-keys": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-          "dev": true
-        },
-        "mimic-response": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-          "dev": true
-        },
-        "p-cancelable": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
-          "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==",
-          "dev": true
-        },
-        "responselike": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
-          "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
-          "dev": true,
-          "requires": {
-            "lowercase-keys": "^2.0.0"
-          }
-        }
       }
     },
     "@cumulus/errors": {
@@ -4346,123 +4241,6 @@
         "got": "^11.5.1",
         "lodash": "^4.17.15",
         "uuid": "^3.2.1"
-      },
-      "dependencies": {
-        "@sindresorhus/is": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-3.1.2.tgz",
-          "integrity": "sha512-JiX9vxoKMmu8Y3Zr2RVathBL1Cdu4Nt4MuNWemt1Nc06A0RAin9c5FArkhGsyMBWfCu4zj+9b+GxtjAnE4qqLQ==",
-          "dev": true
-        },
-        "@szmarczak/http-timer": {
-          "version": "4.0.5",
-          "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
-          "integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
-          "dev": true,
-          "requires": {
-            "defer-to-connect": "^2.0.0"
-          }
-        },
-        "cacheable-request": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
-          "integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
-          "dev": true,
-          "requires": {
-            "clone-response": "^1.0.2",
-            "get-stream": "^5.1.0",
-            "http-cache-semantics": "^4.0.0",
-            "keyv": "^4.0.0",
-            "lowercase-keys": "^2.0.0",
-            "normalize-url": "^4.1.0",
-            "responselike": "^2.0.0"
-          }
-        },
-        "decompress-response": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
-          "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-          "dev": true,
-          "requires": {
-            "mimic-response": "^3.1.0"
-          }
-        },
-        "defer-to-connect": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
-          "integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==",
-          "dev": true
-        },
-        "get-stream": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-          "dev": true,
-          "requires": {
-            "pump": "^3.0.0"
-          }
-        },
-        "got": {
-          "version": "11.7.0",
-          "resolved": "https://registry.npmjs.org/got/-/got-11.7.0.tgz",
-          "integrity": "sha512-7en2XwH2MEqOsrK0xaKhbWibBoZqy+f1RSUoIeF1BLcnf+pyQdDsljWMfmOh+QKJwuvDIiKx38GtPh5wFdGGjg==",
-          "dev": true,
-          "requires": {
-            "@sindresorhus/is": "^3.1.1",
-            "@szmarczak/http-timer": "^4.0.5",
-            "@types/cacheable-request": "^6.0.1",
-            "@types/responselike": "^1.0.0",
-            "cacheable-lookup": "^5.0.3",
-            "cacheable-request": "^7.0.1",
-            "decompress-response": "^6.0.0",
-            "http2-wrapper": "^1.0.0-beta.5.2",
-            "lowercase-keys": "^2.0.0",
-            "p-cancelable": "^2.0.0",
-            "responselike": "^2.0.0"
-          }
-        },
-        "json-buffer": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-          "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-          "dev": true
-        },
-        "keyv": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
-          "integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
-          "dev": true,
-          "requires": {
-            "json-buffer": "3.0.1"
-          }
-        },
-        "lowercase-keys": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
-          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-          "dev": true
-        },
-        "mimic-response": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
-          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-          "dev": true
-        },
-        "p-cancelable": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
-          "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==",
-          "dev": true
-        },
-        "responselike": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
-          "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
-          "dev": true,
-          "requires": {
-            "lowercase-keys": "^2.0.0"
-          }
-        }
       }
     },
     "@cumulus/logger": {
@@ -5596,9 +5374,9 @@
       }
     },
     "agent-base": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
-      "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "dev": true,
       "requires": {
         "debug": "4"
@@ -5776,15 +5554,29 @@
       }
     },
     "ajv": {
-      "version": "5.5.2",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "version": "6.12.6",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+      "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
       "requires": {
-        "co": "^4.6.0",
-        "fast-deep-equal": "^1.0.0",
+        "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.3.0"
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "dependencies": {
+        "fast-deep-equal": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+          "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+          "dev": true
+        },
+        "json-schema-traverse": {
+          "version": "0.4.1",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+          "dev": true
+        }
       }
     },
     "ajv-errors": {
@@ -12821,9 +12613,9 @@
       }
     },
     "gaxios": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-2.3.4.tgz",
-      "integrity": "sha512-US8UMj8C5pRnao3Zykc4AAVr+cffoNKRTg9Rsf2GiuZCW69vgJj38VK2PzlPuQU73FZ/nTk9/Av6/JGcE1N9vA==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.0.0.tgz",
+      "integrity": "sha512-Ge+S+8L8xe/LAjC2tHXFuBMVhjjm4sMevjEHshJeMZ0d37fspa9BO8WEMlYxk4lyydR/v63iHWZZ1Ri7hAqzSg==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
@@ -12838,12 +12630,6 @@
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
           "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
           "dev": true
-        },
-        "node-fetch": {
-          "version": "2.6.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
-          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
-          "dev": true
         }
       }
     },
@@ -12857,13 +12643,34 @@
       }
     },
     "gcp-metadata": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-3.5.0.tgz",
-      "integrity": "sha512-ZQf+DLZ5aKcRpLzYUyBS3yo3N0JSa82lNDO8rj3nMSlovLcz2riKFBsYgDzeXcv75oo5eqB2lx+B14UvPoCRnA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.2.0.tgz",
+      "integrity": "sha512-vQZD57cQkqIA6YPGXM/zc+PIZfNRFdukWGsGZ5+LcJzesi5xp6Gn7a02wRJi4eXPyArNMIYpPET4QMxGqtlk6Q==",
       "dev": true,
       "requires": {
-        "gaxios": "^2.1.0",
-        "json-bigint": "^0.3.0"
+        "gaxios": "^3.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "dependencies": {
+        "gaxios": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-3.2.0.tgz",
+          "integrity": "sha512-+6WPeVzPvOshftpxJwRi2Ozez80tn/hdtOUag7+gajDHRJvAblKxTFSSMPtr2hmnLy7p0mvYz0rMXLBl8pSO7Q==",
+          "dev": true,
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^5.0.0",
+            "is-stream": "^2.0.0",
+            "node-fetch": "^2.3.0"
+          }
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
+        }
       }
     },
     "gensync": {
@@ -13038,20 +12845,20 @@
       }
     },
     "google-auth-library": {
-      "version": "5.10.1",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-5.10.1.tgz",
-      "integrity": "sha512-rOlaok5vlpV9rSiUu5EpR0vVpc+PhN62oF4RyX/6++DG1VsaulAFEMlDYBLjJDDPI6OcNOCGAKy9UVB/3NIDXg==",
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.3.tgz",
+      "integrity": "sha512-m9mwvY3GWbr7ZYEbl61isWmk+fvTmOt0YNUfPOUY2VH8K5pZlAIWJjxEi0PqR3OjMretyiQLI6GURMrPSwHQ2g==",
       "dev": true,
       "requires": {
         "arrify": "^2.0.0",
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
         "fast-text-encoding": "^1.0.0",
-        "gaxios": "^2.1.0",
-        "gcp-metadata": "^3.4.0",
-        "gtoken": "^4.1.0",
+        "gaxios": "^4.0.0",
+        "gcp-metadata": "^4.2.0",
+        "gtoken": "^5.0.4",
         "jws": "^4.0.0",
-        "lru-cache": "^5.0.0"
+        "lru-cache": "^6.0.0"
       },
       "dependencies": {
         "jwa": {
@@ -13074,184 +12881,197 @@
             "jwa": "^2.0.0",
             "safe-buffer": "^5.0.1"
           }
-        }
-      }
-    },
-    "google-p12-pem": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-2.0.4.tgz",
-      "integrity": "sha512-S4blHBQWZRnEW44OcR7TL9WR+QCqByRvhNDZ/uuQfpxywfupikf/miba8js1jZi6ZOGv5slgSuoshCWh6EMDzg==",
-      "dev": true,
-      "requires": {
-        "node-forge": "^0.9.0"
-      },
-      "dependencies": {
-        "node-forge": {
-          "version": "0.9.2",
-          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.2.tgz",
-          "integrity": "sha512-naKSScof4Wn+aoHU6HBsifh92Zeicm1GDQKd1vp3Y/kOi8ub0DozCa9KpvYNCXslFHYRmLNiqRopGdTGwNLpNw==",
+        },
+        "lru-cache": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+          "dev": true,
+          "requires": {
+            "yallist": "^4.0.0"
+          }
+        },
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
           "dev": true
         }
       }
     },
-    "googleapis": {
-      "version": "47.0.0",
-      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-47.0.0.tgz",
-      "integrity": "sha512-+Fnjgcc3Na/rk57dwxqW1V0HJXJFjnt3aqFlckULqAqsPkmex/AyJJe6MSlXHC37ZmlXEb9ZtPGUp5ZzRDXpHg==",
+    "google-p12-pem": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.3.tgz",
+      "integrity": "sha512-wS0ek4ZtFx/ACKYF3JhyGe5kzH7pgiQ7J5otlumqR9psmWMYc+U9cErKlCYVYHoUaidXHdZ2xbo34kB+S+24hA==",
       "dev": true,
       "requires": {
-        "google-auth-library": "^5.6.1",
-        "googleapis-common": "^3.2.0"
+        "node-forge": "^0.10.0"
+      }
+    },
+    "googleapis": {
+      "version": "49.0.0",
+      "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-49.0.0.tgz",
+      "integrity": "sha512-UoUuDbOzLxtU6fZnDyj6IvYvczBYP08RK3Sn0AknssQJceUYiHldaCjEFT1PDcT9MiKSJrbPze6PRdzQDny0Xw==",
+      "dev": true,
+      "requires": {
+        "google-auth-library": "^6.0.0",
+        "googleapis-common": "^4.0.0"
       }
     },
     "googleapis-common": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-3.2.2.tgz",
-      "integrity": "sha512-sTEXlauVce4eMX0S6hVoiWgxVzQZ7dc16KcGF7eh+A+uIyDgXqnuwOMZw+svX4gOJv6w4ACecm23Qh9UDaldsw==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-4.4.1.tgz",
+      "integrity": "sha512-F1QcH8oU7TOuZex9p+XW7TeyLY0332NwBwJ3dZoN+51pXZXB5JjrKswrpgbhuREuIe8xAy8J1rlmFqxeP2mFfA==",
       "dev": true,
       "requires": {
         "extend": "^3.0.2",
-        "gaxios": "^2.0.1",
-        "google-auth-library": "^5.6.1",
+        "gaxios": "^3.2.0",
+        "google-auth-library": "^6.0.0",
         "qs": "^6.7.0",
         "url-template": "^2.0.8",
-        "uuid": "^7.0.0"
+        "uuid": "^8.0.0"
       },
       "dependencies": {
+        "gaxios": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-3.2.0.tgz",
+          "integrity": "sha512-+6WPeVzPvOshftpxJwRi2Ozez80tn/hdtOUag7+gajDHRJvAblKxTFSSMPtr2hmnLy7p0mvYz0rMXLBl8pSO7Q==",
+          "dev": true,
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "extend": "^3.0.2",
+            "https-proxy-agent": "^5.0.0",
+            "is-stream": "^2.0.0",
+            "node-fetch": "^2.3.0"
+          }
+        },
+        "is-stream": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
+          "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
+          "dev": true
+        },
         "uuid": {
-          "version": "7.0.3",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
-          "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+          "version": "8.3.1",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+          "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg==",
           "dev": true
         }
       }
     },
     "got": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/got/-/got-8.3.2.tgz",
-      "integrity": "sha512-qjUJ5U/hawxosMryILofZCkm3C84PLJS/0grRIpjAwu+Lkxxj5cxeCU25BG0/3mDSpXKTyZr8oh8wIgLaH0QCw==",
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.0.tgz",
+      "integrity": "sha512-k9noyoIIY9EejuhaBNLyZ31D5328LeqnyPNXJQb2XlJZcKakLqN5m6O/ikhq/0lw56kUYS54fVm+D1x57YC9oQ==",
       "dev": true,
       "requires": {
-        "@sindresorhus/is": "^0.7.0",
-        "cacheable-request": "^2.1.1",
-        "decompress-response": "^3.3.0",
-        "duplexer3": "^0.1.4",
-        "get-stream": "^3.0.0",
-        "into-stream": "^3.1.0",
-        "is-retry-allowed": "^1.1.0",
-        "isurl": "^1.0.0-alpha5",
-        "lowercase-keys": "^1.0.0",
-        "mimic-response": "^1.0.0",
-        "p-cancelable": "^0.4.0",
-        "p-timeout": "^2.0.1",
-        "pify": "^3.0.0",
-        "safe-buffer": "^5.1.1",
-        "timed-out": "^4.0.1",
-        "url-parse-lax": "^3.0.0",
-        "url-to-options": "^1.0.1"
+        "@sindresorhus/is": "^4.0.0",
+        "@szmarczak/http-timer": "^4.0.5",
+        "@types/cacheable-request": "^6.0.1",
+        "@types/responselike": "^1.0.0",
+        "cacheable-lookup": "^5.0.3",
+        "cacheable-request": "^7.0.1",
+        "decompress-response": "^6.0.0",
+        "http2-wrapper": "^1.0.0-beta.5.2",
+        "lowercase-keys": "^2.0.0",
+        "p-cancelable": "^2.0.0",
+        "responselike": "^2.0.0"
       },
       "dependencies": {
         "@sindresorhus/is": {
-          "version": "0.7.0",
-          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
-          "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.0.0.tgz",
+          "integrity": "sha512-FyD2meJpDPjyNQejSjvnhpgI/azsQkA4lGbuu5BQZfjvJ9cbRZXzeWL2HceCekW4lixO9JPesIIQkSoLjeJHNQ==",
           "dev": true
+        },
+        "@szmarczak/http-timer": {
+          "version": "4.0.5",
+          "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-4.0.5.tgz",
+          "integrity": "sha512-PyRA9sm1Yayuj5OIoJ1hGt2YISX45w9WcFbh6ddT0Z/0yaFxOtGLInr4jUfU1EAFVs0Yfyfev4RNwBlUaHdlDQ==",
+          "dev": true,
+          "requires": {
+            "defer-to-connect": "^2.0.0"
+          }
         },
         "cacheable-request": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-2.1.4.tgz",
-          "integrity": "sha1-DYCIAbY0KtM8kd+dC0TcCbkeXD0=",
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-7.0.1.tgz",
+          "integrity": "sha512-lt0mJ6YAnsrBErpTMWeu5kl/tg9xMAWjavYTN6VQXM1A/teBITuNcccXsCxF0tDQQJf9DfAaX5O4e0zp0KlfZw==",
           "dev": true,
           "requires": {
-            "clone-response": "1.0.2",
-            "get-stream": "3.0.0",
-            "http-cache-semantics": "3.8.1",
-            "keyv": "3.0.0",
-            "lowercase-keys": "1.0.0",
-            "normalize-url": "2.0.1",
-            "responselike": "1.0.2"
-          },
-          "dependencies": {
-            "lowercase-keys": {
-              "version": "1.0.0",
-              "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.0.tgz",
-              "integrity": "sha1-TjNms55/VFfjXxMkvfb4jQv8cwY=",
-              "dev": true
-            }
+            "clone-response": "^1.0.2",
+            "get-stream": "^5.1.0",
+            "http-cache-semantics": "^4.0.0",
+            "keyv": "^4.0.0",
+            "lowercase-keys": "^2.0.0",
+            "normalize-url": "^4.1.0",
+            "responselike": "^2.0.0"
           }
+        },
+        "decompress-response": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+          "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+          "dev": true,
+          "requires": {
+            "mimic-response": "^3.1.0"
+          }
+        },
+        "defer-to-connect": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
+          "integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==",
+          "dev": true
         },
         "get-stream": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
-          "dev": true
-        },
-        "http-cache-semantics": {
-          "version": "3.8.1",
-          "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-3.8.1.tgz",
-          "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w==",
-          "dev": true
-        },
-        "into-stream": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/into-stream/-/into-stream-3.1.0.tgz",
-          "integrity": "sha1-lvsKk2wSur1v8XUqF9BWFqvQlMY=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+          "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
           "dev": true,
           "requires": {
-            "from2": "^2.1.1",
-            "p-is-promise": "^1.1.0"
+            "pump": "^3.0.0"
           }
+        },
+        "json-buffer": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+          "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+          "dev": true
         },
         "keyv": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.0.0.tgz",
-          "integrity": "sha512-eguHnq22OE3uVoSYG0LVWNP+4ppamWr9+zWBe1bsNcovIMy6huUJFPgy4mGwCd/rnl3vOLGW1MTlu4c57CT1xA==",
+          "version": "4.0.3",
+          "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.0.3.tgz",
+          "integrity": "sha512-zdGa2TOpSZPq5mU6iowDARnMBZgtCqJ11dJROFi6tg6kTn4nuUdU09lFyLFSaHrWqpIJ+EBq4E8/Dc0Vx5vLdA==",
           "dev": true,
           "requires": {
-            "json-buffer": "3.0.0"
+            "json-buffer": "3.0.1"
           }
         },
-        "normalize-url": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-2.0.1.tgz",
-          "integrity": "sha512-D6MUW4K/VzoJ4rJ01JFKxDrtY1v9wrgzCX5f2qj/lzH1m/lW6MhUZFKerVsnyjOhOsYzI9Kqqak+10l4LvLpMw==",
-          "dev": true,
-          "requires": {
-            "prepend-http": "^2.0.0",
-            "query-string": "^5.0.1",
-            "sort-keys": "^2.0.0"
-          }
+        "lowercase-keys": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
+          "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
+          "dev": true
+        },
+        "mimic-response": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+          "dev": true
         },
         "p-cancelable": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
-          "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ==",
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
+          "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==",
           "dev": true
         },
-        "p-is-promise": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-1.1.0.tgz",
-          "integrity": "sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=",
-          "dev": true
-        },
-        "p-timeout": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-2.0.1.tgz",
-          "integrity": "sha512-88em58dDVB/KzPEx1X0N3LwFfYZPyDc4B6eF38M1rk9VTZMbxXXgjugz8mmwpS9Ox4BDZ+t6t3QP5+/gazweIA==",
+        "responselike": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
+          "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
           "dev": true,
           "requires": {
-            "p-finally": "^1.0.0"
-          }
-        },
-        "query-string": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/query-string/-/query-string-5.1.1.tgz",
-          "integrity": "sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==",
-          "dev": true,
-          "requires": {
-            "decode-uri-component": "^0.2.0",
-            "object-assign": "^4.1.0",
-            "strict-uri-encode": "^1.0.0"
+            "lowercase-keys": "^2.0.0"
           }
         }
       }
@@ -13277,13 +13097,13 @@
       "dev": true
     },
     "gtoken": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-4.1.4.tgz",
-      "integrity": "sha512-VxirzD0SWoFUo5p8RDP8Jt2AGyOmyYcT/pOUgDKJCK+iSw0TMqwrVfY37RXTNmoKwrzmDHSk0GMT9FsgVmnVSA==",
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.0.5.tgz",
+      "integrity": "sha512-wvjkecutFh8kVfbcdBdUWqDRrXb+WrgD79DBDEYf1Om8S1FluhylhtFjrL7Tx69vNhh259qA3Q1P4sPtb+kUYw==",
       "dev": true,
       "requires": {
-        "gaxios": "^2.1.0",
-        "google-p12-pem": "^2.0.0",
+        "gaxios": "^4.0.0",
+        "google-p12-pem": "^3.0.3",
         "jws": "^4.0.0",
         "mime": "^2.2.0"
       },
@@ -13413,25 +13233,10 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
-    "has-symbol-support-x": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz",
-      "integrity": "sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==",
-      "dev": true
-    },
     "has-symbols": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
       "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
-    },
-    "has-to-string-tag-x": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/has-to-string-tag-x/-/has-to-string-tag-x-1.4.1.tgz",
-      "integrity": "sha512-vdbKfmw+3LoOYVr+mtxHaX5a96+0f3DljYd8JOqvOLsf5mw2Otda2qCDT9qRqLAhrjyQ0h7ual5nOiASpsGNFw==",
-      "dev": true,
-      "requires": {
-        "has-symbol-support-x": "^1.4.1"
-      }
     },
     "has-unicode": {
       "version": "2.0.1",
@@ -14666,12 +14471,6 @@
       "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
       "dev": true
     },
-    "is-object": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-object/-/is-object-1.0.1.tgz",
-      "integrity": "sha1-iVJojF7C/9awPsyF52ngKQMINHA=",
-      "dev": true
-    },
     "is-observable": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-1.1.0.tgz",
@@ -14737,12 +14536,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
       "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
-      "dev": true
-    },
-    "is-retry-allowed": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-      "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
       "dev": true
     },
     "is-stream": {
@@ -14842,16 +14635,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
       "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
-    },
-    "isurl": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isurl/-/isurl-1.0.0.tgz",
-      "integrity": "sha512-1P/yWsxPlDtn7QeRD+ULKQPaIaN6yF368GZ2vDfv0AL0NwpStafjWCDDdn0k8wgFMWpVAqG7oJhxHnlud42i9w==",
-      "dev": true,
-      "requires": {
-        "has-to-string-tag-x": "^1.2.0",
-        "is-object": "^1.0.1"
-      }
     },
     "jest-worker": {
       "version": "26.5.0",
@@ -15047,9 +14830,9 @@
       }
     },
     "json-bigint": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-0.3.1.tgz",
-      "integrity": "sha512-DGWnSzmusIreWlEupsUelHrhwmPPE+FiQvg+drKfk2p+bdEYa5mp4PJ8JsCWqae0M2jQNb0HPvnwvf1qOTThzQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
       "dev": true,
       "requires": {
         "bignumber.js": "^9.0.0"
@@ -16845,6 +16628,12 @@
         "lodash.toarray": "^4.4.0"
       }
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
+    },
     "node-forge": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
@@ -17097,15 +16886,6 @@
           "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
           "integrity": "sha1-MVc3YcBX4zwukaq56W2gjO++duU=",
           "dev": true
-        },
-        "promise": {
-          "version": "1.3.0",
-          "resolved": "https://registry.npmjs.org/promise/-/promise-1.3.0.tgz",
-          "integrity": "sha1-5cyaTIJ45GZP/twBx9qEhCsEAXU=",
-          "dev": true,
-          "requires": {
-            "is-promise": "~1"
-          }
         }
       }
     },
@@ -17965,12 +17745,6 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-      "dev": true
-    },
-    "pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true
     },
     "pinkie": {
@@ -19537,6 +19311,23 @@
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
       "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true
+    },
+    "promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/promise/-/promise-1.3.0.tgz",
+      "integrity": "sha1-5cyaTIJ45GZP/twBx9qEhCsEAXU=",
+      "dev": true,
+      "requires": {
+        "is-promise": "~1"
+      },
+      "dependencies": {
+        "is-promise": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
+          "integrity": "sha1-MVc3YcBX4zwukaq56W2gjO++duU=",
+          "dev": true
+        }
+      }
     },
     "promise-inflight": {
       "version": "1.0.1",
@@ -21182,16 +20973,16 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "saml2-js": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/saml2-js/-/saml2-js-2.0.5.tgz",
-      "integrity": "sha512-8OOZxeMxpdtEszFbvR01TcjKb8g/HsE1si/EGdTawSQY0KgwtvPTG2Ctc5xhEW45xhU+j+UrU5ttZxC72YXSUQ==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/saml2-js/-/saml2-js-2.0.6.tgz",
+      "integrity": "sha512-fWGlF0vMpx0MtOgXYWZ5EoHOy2yIEzVkCk28vlNeXOPcvNMH9FQqxWjHCUm+E7aBSLBugB7FeNSx0tYdkQe72Q==",
       "dev": true,
       "requires": {
         "async": "^2.5.0",
         "debug": "^2.6.0",
         "underscore": "^1.8.0",
         "xml-crypto": "^0.10.0",
-        "xml-encryption": "^0.11.0",
+        "xml-encryption": "^1.2.1",
         "xml2js": "^0.4.0",
         "xmlbuilder": "~2.2.0",
         "xmldom": "^0.1.0"
@@ -22229,15 +22020,6 @@
             "websocket-driver": ">=0.5.1"
           }
         }
-      }
-    },
-    "sort-keys": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
-      "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
-      "dev": true,
-      "requires": {
-        "is-plain-obj": "^1.0.0"
       }
     },
     "source-list-map": {
@@ -23278,12 +23060,6 @@
       "integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=",
       "dev": true
     },
-    "timed-out": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
-      "dev": true
-    },
     "timers-browserify": {
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
@@ -23920,12 +23696,6 @@
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
       "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE=",
-      "dev": true
-    },
-    "url-to-options": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/url-to-options/-/url-to-options-1.0.1.tgz",
-      "integrity": "sha1-FQWgOiiaSMvXpDTvuu7FBV9WM6k=",
       "dev": true
     },
     "use": {
@@ -25946,33 +25716,15 @@
       }
     },
     "xml-encryption": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/xml-encryption/-/xml-encryption-0.11.2.tgz",
-      "integrity": "sha512-jVvES7i5ovdO7N+NjgncA326xYKjhqeAnnvIgRnY7ROLCfFqEDLwP0Sxp/30SHG0AXQV1048T5yinOFyvwGFzg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/xml-encryption/-/xml-encryption-1.2.1.tgz",
+      "integrity": "sha512-hn5w3l5p2+nGjlmM0CAhMChDzVGhW+M37jH35Z+GJIipXbn9PUlAIRZ6I5Wm7ynlqZjFrMAr83d/CIp9VZJMTA==",
       "dev": true,
       "requires": {
-        "async": "^2.1.5",
-        "ejs": "^2.5.6",
-        "node-forge": "^0.7.0",
+        "escape-html": "^1.0.3",
+        "node-forge": "^0.10.0",
         "xmldom": "~0.1.15",
         "xpath": "0.0.27"
-      },
-      "dependencies": {
-        "async": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.14"
-          }
-        },
-        "node-forge": {
-          "version": "0.7.6",
-          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.7.6.tgz",
-          "integrity": "sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw==",
-          "dev": true
-        }
       }
     },
     "xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@babel/preset-react": "^7.10.4",
     "@babel/register": "^7.12.0",
     "@babel/runtime": "^7.12.0",
-    "@cumulus/api": "3.0.1-alpha.3",
+    "@cumulus/api": "3.0.2-alpha.0",
     "@cumulus/aws-client": "3.0.0",
     "@cypress/webpack-preprocessor": "^4.1.5",
     "audit-ci": "^3.1.1",

--- a/test/actions/recover.js
+++ b/test/actions/recover.js
@@ -51,7 +51,7 @@ test.beforeEach((t) => {
 
 test.serial('appylyRecoveryWorkflowToCollection fails to acquire collection, dispatches COLLECTION_APPLYWORKFLOW_ERROR', async (t) => {
   nock('https://example.com')
-    .get(`/collections?name=${name}&version=${version}`)
+    .get(`/collections?name=${name}&version=${version}&includeStats=true`)
     .reply(404);
 
   return store.dispatch(applyRecoveryWorkflowToCollection(collectionId)).then(() => {
@@ -76,7 +76,7 @@ test.serial('applyRecoveryWorkflowToCollection dispatches error with collection 
   };
 
   nock('https://example.com')
-    .get(`/collections?name=${name}&version=${version}`)
+    .get(`/collections?name=${name}&version=${version}&includeStats=true`)
     .reply(200, getCollectionResponse);
 
   return store.dispatch(applyRecoveryWorkflowToCollection(collectionId)).then(() => {
@@ -103,7 +103,7 @@ test.serial('applyRecoveryWorkflowToCollection successfully sends applyWorkflow 
   };
 
   nock('https://example.com')
-    .get(`/collections?name=${name}&version=${version}`)
+    .get(`/collections?name=${name}&version=${version}&includeStats=true`)
     .reply(200, getCollectionResponse)
     .put(`/collections/${name}/${version}`)
     .reply(200);
@@ -154,7 +154,7 @@ test.serial('applyRecoveryWorkflowToGranule dispatches GRANULE_APPLYWORKFLOW_ERR
     .get(`/granules/${granuleId}`)
     .reply(200, getGranuleResponse);
   nock('https://example.com')
-    .get(`/collections?name=${name}&version=${version}`)
+    .get(`/collections?name=${name}&version=${version}&includeStats=true`)
     .reply(200, getCollectionResponse);
 
   return store.dispatch(applyRecoveryWorkflowToGranule(granuleId)).then(() => {
@@ -180,7 +180,7 @@ test.serial('applyRecoveryWorkflowToGranule fails to acquire collection and disp
     .get(`/granules/${granuleId}`)
     .reply(200, getGranuleResponse);
   nock('https://example.com')
-    .get(`/collections?name=${name}&version=${version}`)
+    .get(`/collections?name=${name}&version=${version}&includeStats=true`)
     .reply(404);
 
   return store.dispatch(applyRecoveryWorkflowToGranule(granuleId)).then(() => {
@@ -212,7 +212,7 @@ test.serial('applyRecoveryWorkflowToGranule dispatches applyWorkflow', async (t)
   };
 
   nock('https://example.com')
-    .get(`/collections?name=${name}&version=${version}`)
+    .get(`/collections?name=${name}&version=${version}&includeStats=true`)
     .reply(200, getCollectionResponse);
   nock('https://example.com')
     .get(`/granules/${granuleId}`)


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2215 : Rearchitect dashboard calls for the collections list in Granule search](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2215)


## Changes

* Adds request for statistics on the listCollection, and getCollection requests.
* Leaves statistics off of requests for getOptionsCollectionName, which is used on the granules overview page (and what was causing problems before)
* Adds CI test to ensure we're still displaying the statistics on the collections page.
* deletes unused code
* updates @cumulus/api for testing to @cumulus/api@3.0.2-alpha.0

## PR Checklist

- [X] Update CHANGELOG
- [ ] Unit tests
- [X] Adhoc testing
- [X] Integration tests