### PR TITLE
CUMULUS-2170 Granule inventory param

### DIFF
--- a/app/src/js/components/Granules/overview.js
+++ b/app/src/js/components/Granules/overview.js
@@ -150,7 +150,7 @@ class GranulesOverview extends React.Component {
     };
 
     if (granuleIds.length > 0) {
-      requestBody.granuleIds = granuleIds;
+      requestBody.granuleId = granuleIds;
     }
 
     this.setState({ isListRequestSubmitted: true });

--- a/app/src/js/components/Granules/overview.js
+++ b/app/src/js/components/Granules/overview.js
@@ -134,24 +134,13 @@ class GranulesOverview extends React.Component {
     const queryParams = this.generateQuery();
     const { collectionId, status, search: granuleIdFilter } = queryParams;
 
-    let granuleIds = selected;
-
-    // If there are no selected granules but a Granule ID is specified
-    // in the search filter, use only that.
-    if (granuleIds.length < 1 && granuleIdFilter) {
-      granuleIds = [granuleIdFilter];
-    }
-
     const requestBody = {
       reportName: listName,
       reportType: 'Granule Inventory',
       status,
-      collectionId
+      collectionId,
+      granuleId: granuleIdFilter || selected,
     };
-
-    if (granuleIds.length > 0) {
-      requestBody.granuleId = granuleIds;
-    }
 
     this.setState({ isListRequestSubmitted: true });
     this.props.dispatch(createReconciliationReport(

--- a/app/src/js/components/Granules/overview.js
+++ b/app/src/js/components/Granules/overview.js
@@ -139,6 +139,8 @@ class GranulesOverview extends React.Component {
       reportType: 'Granule Inventory',
       status,
       collectionId,
+      // granuleId accepts a string or an array of granuleIds.
+      // In this case, the granuleIdFilter is a search infix and selected is an array of granuleIds.
       granuleId: granuleIdFilter || selected,
     };
 

--- a/cypress/integration/granules_spec.js
+++ b/cypress/integration/granules_spec.js
@@ -403,7 +403,7 @@ describe('Dashboard Granules Page', () => {
         expect(requestBody).to.have.property('reportName', listName);
         expect(requestBody).to.have.property('status', status);
         expect(requestBody).to.have.property('collectionId', collectionId);
-        expect(requestBody.granuleIds.sort()).to.deep.equal(granuleIds);
+        expect(requestBody.granuleId.sort()).to.deep.equal(granuleIds);
       }).as('createList');
 
       cy.visit('/granules');


### PR DESCRIPTION
**Summary:** Quick fix to pass `granuleId` instead of `granuleIds` as a param when creating a Granule Inventory report. Ties into the changes from here: https://github.com/nasa/cumulus-dashboard/pull/863

Addresses [CUMULUS-2170: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-XXX)

## Changes

* Pass `granuleId` instead of `granuleIds`

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests