### PR TITLE
CUMULUS-2170-2 Fix empty granuleId array

### DIFF
--- a/app/src/js/components/Granules/overview.js
+++ b/app/src/js/components/Granules/overview.js
@@ -141,7 +141,7 @@ class GranulesOverview extends React.Component {
       collectionId,
       // granuleId accepts a string or an array of granuleIds.
       // In this case, the granuleIdFilter is a search infix and selected is an array of granuleIds.
-      granuleId: granuleIdFilter || selected,
+      granuleId: granuleIdFilter || ((selected.length > 0) ? selected : undefined),
     };
 
     this.setState({ isListRequestSubmitted: true });


### PR DESCRIPTION
Quick fix to make sure we aren't passing an empty array to the granuleId param when creating a Granule Inventory report