### PR TITLE
CUMULUS-2245 Clear selected items in table when filter is applied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **CUMULUS-2242** and **CUMULUS-2177**
   - building with `npm run build` will now build a distribution that can be served from behind cloudfront.
 
+- **CUMULUS-1873**
+  - Clear selected items in table when filter is applied
+
 - **CUMULUS-2249**
   - clear infix search parameter when Search component is unmounted
 

--- a/app/src/js/components/Collections/list.js
+++ b/app/src/js/components/Collections/list.js
@@ -103,7 +103,6 @@ class CollectionList extends React.Component {
           <List
             list={list}
             tableColumns={tableColumns}
-            dispatch={this.props.dispatch}
             action={listCollections}
             query={this.generateQuery()}
             bulkActions={this.generateBulkActions()}

--- a/app/src/js/components/Collections/overview.js
+++ b/app/src/js/components/Collections/overview.js
@@ -277,7 +277,6 @@ class CollectionOverview extends React.Component {
           </div>
           <List
             list={list}
-            dispatch={this.props.dispatch}
             action={listGranules}
             tableColumns={tableColumns}
             query={this.generateQuery()}

--- a/app/src/js/components/Executions/overview.js
+++ b/app/src/js/components/Executions/overview.js
@@ -48,7 +48,6 @@ class ExecutionOverview extends React.Component {
   render() {
     const {
       collections,
-      dispatch,
       executions,
       queryParams,
       workflowOptions,
@@ -81,7 +80,6 @@ class ExecutionOverview extends React.Component {
           </div>
           <List
             list={list}
-            dispatch={dispatch}
             action={listExecutions}
             tableColumns={tableColumns}
             query={{ ...queryParams }}

--- a/app/src/js/components/Operations/overview.js
+++ b/app/src/js/components/Operations/overview.js
@@ -60,7 +60,7 @@ class OperationOverview extends React.Component {
   }
 
   render () {
-    const { dispatch, operations } = this.props;
+    const { operations } = this.props;
     const { list } = operations;
     const { count } = list.meta;
     const mutableList = cloneDeep(list);
@@ -89,7 +89,6 @@ class OperationOverview extends React.Component {
           </div>
           <List
             list={mutableList}
-            dispatch={dispatch}
             action={listOperations}
             tableColumns={tableColumns}
             query={this.generateQuery()}

--- a/app/src/js/components/Pdr/list.js
+++ b/app/src/js/components/Pdr/list.js
@@ -79,7 +79,6 @@ const ActivePdrs = ({ dispatch, location, pdrs, queryParams }) => {
         </div>
         <List
           list={list}
-          dispatch={dispatch}
           action={listPdrs}
           tableColumns={view === 'failed' ? errorTableColumns : tableColumns}
           query={query}

--- a/app/src/js/components/Pdr/overview.js
+++ b/app/src/js/components/Pdr/overview.js
@@ -64,7 +64,7 @@ class PdrOverview extends React.Component {
   }
 
   render () {
-    const { dispatch, pdrs } = this.props;
+    const { pdrs } = this.props;
     const { list } = pdrs;
     const { count, queriedAt } = list.meta;
     // create the overview boxes
@@ -94,7 +94,6 @@ class PdrOverview extends React.Component {
           </div>
           <List
             list={list}
-            dispatch={dispatch}
             action={listPdrs}
             tableColumns={tableColumns}
             sortId="timestamp"

--- a/app/src/js/components/Pdr/pdr.js
+++ b/app/src/js/components/Pdr/pdr.js
@@ -220,7 +220,6 @@ class PDR extends React.Component {
 
           <List
             list={list}
-            dispatch={this.props.dispatch}
             action={listGranules}
             tableColumns={granuleTableColumns}
             query={this.generateQuery()}

--- a/app/src/js/components/Providers/overview.js
+++ b/app/src/js/components/Providers/overview.js
@@ -42,7 +42,7 @@ class ProvidersOverview extends React.Component {
   }
 
   render () {
-    const { dispatch, providers, stats } = this.props;
+    const { providers, stats } = this.props;
     const { list } = providers;
     const { count, queriedAt } = list.meta;
 
@@ -88,7 +88,6 @@ class ProvidersOverview extends React.Component {
           </div>
           <List
             list={mutableList}
-            dispatch={dispatch}
             action={listProviders}
             tableColumns={tableColumns}
             query={this.generateQuery()}

--- a/app/src/js/components/Rules/overview.js
+++ b/app/src/js/components/Rules/overview.js
@@ -44,7 +44,7 @@ class RulesOverview extends React.Component {
   }
 
   render() {
-    const { dispatch, queryParams, rules } = this.props;
+    const { queryParams, rules } = this.props;
     const { list } = rules;
     const { count, queriedAt } = list.meta;
     return (
@@ -75,7 +75,6 @@ class RulesOverview extends React.Component {
 
           <List
             list={list}
-            dispatch={dispatch}
             action={listRules}
             tableColumns={tableColumns}
             query={{ ...queryParams }}

--- a/app/src/js/components/Table/Table.js
+++ b/app/src/js/components/Table/Table.js
@@ -243,4 +243,6 @@ List.propTypes = {
   queryParams: PropTypes.object,
 };
 
+export { List };
+
 export default withQueryParams()(List);

--- a/app/src/js/components/Table/Table.js
+++ b/app/src/js/components/Table/Table.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import withQueryParams from 'react-router-query-params';
 import isNil from 'lodash/isNil';
 import isEqual from 'lodash/isEqual';
 import omitBy from 'lodash/omitBy';
@@ -51,7 +51,7 @@ class List extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    const { query, list } = this.props;
+    const { list, query, queryParams } = this.props;
 
     if (!isEqual(query, prevProps.query)) {
       // eslint-disable-next-line react/no-did-update-set-state
@@ -67,13 +67,19 @@ class List extends React.Component {
         queryConfig: this.getQueryConfig(),
       }));
     }
+
+    const { limit, page, ...filters } = queryParams;
+    const { limit: prevLimit, page: prevPage, ...prevFilters } = prevProps.queryParams;
+    if (!isEqual(filters, prevFilters)) {
+      // eslint-disable-next-line react/no-did-update-set-state
+      this.setState({ clearSelected: true });
+    }
   }
 
   queryNewPage(page) {
     this.setState({
       page,
       queryConfig: this.getQueryConfig({ page }),
-      clearSelected: true,
     });
   }
 
@@ -83,7 +89,6 @@ class List extends React.Component {
       queryConfig: this.getQueryConfig({
         sort_key: buildSortKey(sortProps),
       }),
-      clearSelected: true,
     });
   }
 
@@ -190,8 +195,9 @@ class List extends React.Component {
                 clear={filterClear}
                 count={count}
                 limit={limit}
-                page={page}
                 onNewPage={this.queryNewPage}
+                page={page}
+                selected={selected}
               />
             )}
             <SortableTable
@@ -234,7 +240,7 @@ List.propTypes = {
   sortId: PropTypes.string,
   tableColumns: PropTypes.array,
   onSelect: PropTypes.func,
+  queryParams: PropTypes.object,
 };
 
-export { List };
-export default connect()(List);
+export default withQueryParams()(List);

--- a/app/src/js/components/Table/Table.js
+++ b/app/src/js/components/Table/Table.js
@@ -170,7 +170,6 @@ class List extends React.Component {
       queryConfig,
     } = this.state;
     const hasActions = Array.isArray(bulkActions) && bulkActions.length > 0;
-    console.log(this.props);
 
     return (
       <>

--- a/app/src/js/components/Table/Table.js
+++ b/app/src/js/components/Table/Table.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
 import withQueryParams from 'react-router-query-params';
 import isNil from 'lodash/isNil';
 import isEqual from 'lodash/isEqual';
@@ -169,6 +170,7 @@ class List extends React.Component {
       queryConfig,
     } = this.state;
     const hasActions = Array.isArray(bulkActions) && bulkActions.length > 0;
+    console.log(this.props);
 
     return (
       <>
@@ -245,4 +247,4 @@ List.propTypes = {
 
 export { List };
 
-export default withQueryParams()(List);
+export default withQueryParams()(connect()(List));

--- a/app/src/js/components/TableHeader/table-header.js
+++ b/app/src/js/components/TableHeader/table-header.js
@@ -28,17 +28,17 @@ const TableHeader = ({
 
   const numberChecked = selected.length;
 
-  function handleLimitChange({ selections: dropdownSelections, updateSelection: updateDropdownSelection }) {
-    if (dropdownSelections.length === 0) {
+  function handleLimitChange({ selections, updateSelection }) {
+    if (selections.length === 0) {
       setSelectedValues([]);
     } else {
-      const { id: value } = dropdownSelections[0];
+      const { id: value } = selections[0];
       setSelectedValues([{
         id: value,
         label: value,
       }]);
     }
-    updateDropdownSelection();
+    updateSelection();
   }
 
   return (

--- a/app/src/js/components/TableHeader/table-header.js
+++ b/app/src/js/components/TableHeader/table-header.js
@@ -17,31 +17,34 @@ const TableHeader = ({
   clear,
   count,
   limit = defaultPageLimit,
-  page,
   onNewPage,
+  page,
+  selected = [],
 }) => {
   const [selectedValues, setSelectedValues] = useState([{
     id: limit,
     label: limit.toString(),
   }]);
 
-  function handleLimitChange({ selections, updateSelection }) {
-    if (selections.length === 0) {
+  const numberChecked = selected.length;
+
+  function handleLimitChange({ selections: dropdownSelections, updateSelection: updateDropdownSelection }) {
+    if (dropdownSelections.length === 0) {
       setSelectedValues([]);
     } else {
-      const { id: value } = selections[0];
+      const { id: value } = dropdownSelections[0];
       setSelectedValues([{
         id: value,
         label: value,
       }]);
     }
-    updateSelection();
+    updateDropdownSelection();
   }
 
   return (
     <div className="table__header">
       <span>
-        Showing <b>{count}</b> records
+        {count && <><b>{count}</b> total records</>} {numberChecked > 0 && <>(<b>{numberChecked}</b> selected)</>}
       </span>
       <Pagination
         action={action}
@@ -77,6 +80,7 @@ TableHeader.propTypes = {
   limit: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
   onNewPage: PropTypes.func,
   page: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+  selected: PropTypes.array,
 };
 
 export default TableHeader;

--- a/app/src/js/components/TableHeader/table-header.js
+++ b/app/src/js/components/TableHeader/table-header.js
@@ -44,7 +44,7 @@ const TableHeader = ({
   return (
     <div className="table__header">
       <span>
-        {count && <><b>{count}</b> total records</>} {numberChecked > 0 && <>(<b>{numberChecked}</b> selected)</>}
+        <b>{count}</b> total records {numberChecked > 0 && <>(<b>{numberChecked}</b> selected)</>}
       </span>
       <Pagination
         action={action}

--- a/app/src/js/components/Workflows/overview.js
+++ b/app/src/js/components/Workflows/overview.js
@@ -36,7 +36,6 @@ const WorkflowOverview = ({
         </div>
         <List
           list={workflows.list}
-          dispatch={dispatch}
           action={listWorkflows}
           tableColumns={tableColumns}
           query={{ ...queryParams }}

--- a/app/src/js/components/home.js
+++ b/app/src/js/components/home.js
@@ -203,7 +203,6 @@ class Home extends React.Component {
               </div>
               <List
                 list={list}
-                dispatch={this.props.dispatch}
                 action={listGranules}
                 tableColumns={errorTableColumns}
                 sortId='timestamp'

--- a/cypress/integration/granules_spec.js
+++ b/cypress/integration/granules_spec.js
@@ -432,5 +432,46 @@ describe('Dashboard Granules Page', () => {
 
       cy.url().should('include', '/granules/lists');
     });
+
+    it('should show number of selected results in table', () => {
+      cy.visit('/granules');
+      cy.get('.table .thead').as('table-head');
+      cy.get('@table-head').find('input[type="checkbox"]').check();
+      cy.contains('.table__header', '(11 selected)');
+    });
+
+    it('should clear the selection when a filter is applied', () => {
+      const granuleIds = [
+        'MOD09GQ.A0142558.ee5lpE.006.5112577830916',
+        'MOD09GQ.A9344328.K9yI3O.006.4625818663028'
+      ];
+      cy.visit('/granules');
+
+      cy.get('.table .tbody').as('table-body');
+      cy.get('.table .tbody .tr').as('list');
+      cy.get('.filter-status .rbt-input-main').as('status-input');
+
+      cy.get('@list').should('have.length', 11);
+      cy.get('@table-body').contains('.td', granuleIds[0]).as('granule1');
+      cy.get('@granule1').siblings().contains('.td', 'Completed');
+      cy.get('@granule1').siblings().find('input[type="checkbox"]').check();
+
+      cy.get('@table-body').contains('.td', granuleIds[1]).as('granule2');
+      cy.get('@granule2').siblings().contains('.td', 'Failed');
+      cy.get('@granule2').siblings().find('input[type="checkbox"]').check();
+
+      cy.contains('.table__header', '(2 selected)');
+
+      // (X selected) only in header when items are selected
+      // verify that nothing is selected when filter is applied
+      cy.get('@status-input').click().type('run').type('{enter}');
+      cy.get('@list').should('have.length', 2);
+      cy.get('.table__header').should('not.contain.text', 'selected');
+
+      // verify items still not selected when filter is cleared
+      cy.get('@status-input').clear();
+      cy.get('@list').should('have.length', 11);
+      cy.get('.table__header').should('not.contain.text', 'selected');
+    });
   });
 });

--- a/test/components/collections/list.js
+++ b/test/components/collections/list.js
@@ -45,7 +45,7 @@ test('Collections Overview generates bulkAction for recovery button', function (
     </Provider>);
 
   const collectionsWrapper = providerWrapper.find('CollectionList').dive();
-  const listWrapper = collectionsWrapper.find('Connect(List)');
+  const listWrapper = collectionsWrapper.find('withRouter(withQueryParams(List))');
   const listBulkActions = listWrapper.prop('bulkActions');
 
   const recoverFilter = (object) => object.text === 'Recover';
@@ -73,7 +73,7 @@ test('Collections Overview does not generate bulkAction for recovery button', fu
     </Provider>);
 
   const collectionsWrapper = providerWrapper.find('CollectionList').dive();
-  const listWrapper = collectionsWrapper.find('Connect(List)');
+  const listWrapper = collectionsWrapper.find('withRouter(withQueryParams(List))');
   const listBulkActions = listWrapper.prop('bulkActions');
 
   const recoverFilter = (object) => object.text === 'Recover';

--- a/test/components/collections/list.js
+++ b/test/components/collections/list.js
@@ -45,7 +45,7 @@ test('Collections Overview generates bulkAction for recovery button', function (
     </Provider>);
 
   const collectionsWrapper = providerWrapper.find('CollectionList').dive();
-  const listWrapper = collectionsWrapper.find('withRouter(withQueryParams(List))');
+  const listWrapper = collectionsWrapper.find('withRouter(withQueryParams(Connect(List)))');
   const listBulkActions = listWrapper.prop('bulkActions');
 
   const recoverFilter = (object) => object.text === 'Recover';
@@ -73,7 +73,7 @@ test('Collections Overview does not generate bulkAction for recovery button', fu
     </Provider>);
 
   const collectionsWrapper = providerWrapper.find('CollectionList').dive();
-  const listWrapper = collectionsWrapper.find('withRouter(withQueryParams(List))');
+  const listWrapper = collectionsWrapper.find('withRouter(withQueryParams(Connect(List)))');
   const listBulkActions = listWrapper.prop('bulkActions');
 
   const recoverFilter = (object) => object.text === 'Recover';

--- a/test/components/granules/overview.js
+++ b/test/components/granules/overview.js
@@ -70,7 +70,7 @@ test('GranulesOverview generates bulkAction for recovery button', function (t) {
     </Provider>);
 
   const overviewWrapper = providerWrapper.find('GranulesOverview').dive();
-  const listWrapper = overviewWrapper.find('withRouter(withQueryParams(List))');
+  const listWrapper = overviewWrapper.find('withRouter(withQueryParams(Connect(List)))');
   const listBulkActions = listWrapper.prop('bulkActions');
 
   const recoverFilter = (object) => object.text === 'Recover Granule';
@@ -94,7 +94,7 @@ test('GranulesOverview does not generate bulkAction for recovery button', functi
     </Provider>);
 
   const overviewWrapper = providerWrapper.find('GranulesOverview').dive();
-  const listWrapper = overviewWrapper.find('withRouter(withQueryParams(List))');
+  const listWrapper = overviewWrapper.find('withRouter(withQueryParams(Connect(List)))');
   const listBulkActions = listWrapper.prop('bulkActions');
 
   const recoverFilter = (object) => object.text === 'Recover Granule';

--- a/test/components/granules/overview.js
+++ b/test/components/granules/overview.js
@@ -70,7 +70,7 @@ test('GranulesOverview generates bulkAction for recovery button', function (t) {
     </Provider>);
 
   const overviewWrapper = providerWrapper.find('GranulesOverview').dive();
-  const listWrapper = overviewWrapper.find('Connect(List)');
+  const listWrapper = overviewWrapper.find('withRouter(withQueryParams(List))');
   const listBulkActions = listWrapper.prop('bulkActions');
 
   const recoverFilter = (object) => object.text === 'Recover Granule';
@@ -94,7 +94,7 @@ test('GranulesOverview does not generate bulkAction for recovery button', functi
     </Provider>);
 
   const overviewWrapper = providerWrapper.find('GranulesOverview').dive();
-  const listWrapper = overviewWrapper.find('Connect(List)');
+  const listWrapper = overviewWrapper.find('withRouter(withQueryParams(List))');
   const listBulkActions = listWrapper.prop('bulkActions');
 
   const recoverFilter = (object) => object.text === 'Recover Granule';

--- a/test/components/table/list-view.js
+++ b/test/components/table/list-view.js
@@ -40,6 +40,7 @@ test('table should properly initialize timer config prop', async (t) => {
         tableColumns={errorTableColumns}
         sortId="timestamp"
         query={query}
+        queryParams={{}}
       />
     </Provider>,
     {


### PR DESCRIPTION
**Summary:** Clear selected when filter is applied

Addresses [CUMULUS-2245: Selected items in table not cleared when filter is applied](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2245)

## Changes

* When queryParams are changed (i.e. filter are applied or removed), update `this.state.clearSelected` in `List` to true so that the table will clear the selected items. 
* Removed `dispatch` from props passed to `List` throughout the app because the `connect` higher order component already adds that as a prop.
* Updated table header area to indicate to the user how many items are selected. This made it both easier to test, and just generally makes the selected items clearer for the user.

To test:
1. Go to `/granules`
2. Select some items in the table
3. Apply a status filter
4. Verify items are no longer selected
5. Clear the filter
6. Verify items are still not selected

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Adhoc testing
- [x] Integration tests