### PR TITLE
Bugfix: Update error name in tests. 

### DIFF
--- a/cypress/integration/main_page_spec.js
+++ b/cypress/integration/main_page_spec.js
@@ -178,8 +178,8 @@ describe('Dashboard Home Page', () => {
       cy.get('[id="Ingest Rules"]').contains('1');
 
       // Test there are values in Granule Error list
-      cy.get('[data-value="0"]').contains('FileNotFound');
-      cy.get('[data-value="1"]').contains('UnexpectedFileSize');
+      cy.get('[data-value="0"]').contains('Error');
+      cy.get('[data-value="1"]').contains('Error');
 
       cy.get('[data-cy=startDateTime]').within(() => {
         cy.get('input[name=month]').click().type(1);


### PR DESCRIPTION

**Summary:** Summary of changes

In a previous PR I changed the type of errors returned in our fixture. They were previously the same. The trick in this test is that the order of the returned granules might change and the test might fail. We don't actually care about the order here, just that the two granules are listed.

## Changes

* Updates 1 spec

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [x] Integration tests