### PR TITLE
CUMULUS-2226 Disable auto-scrolling on failed granules table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
+- **CUMULUS-2226**
+  - Loading and sorting the Failed Granules table no longer causes the screen to jump to the top of the table.
+
 - **CUMULUS-2242** and **CUMULUS-2177**
   - building with `npm run build` will now build a distribution that can be served from behind cloudfront.
 

--- a/app/src/js/utils/table-config/granules.js
+++ b/app/src/js/utils/table-config/granules.js
@@ -92,7 +92,7 @@ export const errorTableColumns = [
     accessor: (row) => get(row, 'error.Cause', nullValue),
     id: 'error',
     Cell: ({ row: { original } }) => ( // eslint-disable-line react/prop-types
-      <ErrorReport report={get(original, 'error.Cause', nullValue)} truncate={true} />),
+      <ErrorReport report={get(original, 'error.Cause', nullValue)} truncate={true} disableScroll={true} />),
     disableSortBy: true,
     width: 175
   },


### PR DESCRIPTION
**Summary:** 

Addresses [CUMULUS-2226: Dashboard: When user goes to page it jumps to the bottom while table loads](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2226)

We share a common component here called `ErrorReport` that is used to display errors both on the entire page as a banner and in individual table cells. In the case of the Granules table, we don't want the creation of that component to cause the screen to scroll. In other situations we would because the user needs to be drawn to the error so we're just setting the `disableScroll` flag if the component is being rendered in the table component.

## Changes

* Sets `disableScroll` to `true` when rendering errors inside of the Failed Granules table

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Adhoc testing
- [ ] Integration tests