### PR TITLE
Mhs/cumulus 2242/tweaks for running and building dashboard

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,6 +118,7 @@ jobs:
               -v /home/circleci/.cache:/root/.cache \
               -v $(pwd):/home \
               --workdir /home \
+              -e AWS_REGION=${SANDBOX_AWS_REGION} \
               -e APIROOT=${SANDBOX_API_ROOT} \
               node:12.18.0 \
               npm run build
@@ -142,6 +143,7 @@ jobs:
               -v /home/circleci/.cache:/root/.cache \
               -v $(pwd):/home \
               --workdir /home \
+              -e AWS_REGION=${SIT_AWS_REGION} \
               -e APIROOT=${SIT_API_ROOT} \
               node:12.18.0 \
               npm run build

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "scripts": {
     "audit-ci": "audit-ci --config $(pwd)/audit-ci.json",
-    "serve:prod": "NODE_ENV=production http-server dist -p 3000 --proxy http://localhost:3000?",
+    "serve:prod": "NODE_ENV=production http-server dist -p ${PORT:-3000} --proxy http://localhost:${PORT:-3000}?",
     "serve": "NODE_ENV=development webpack-dev-server --open --config webpack.dev.js",
     "serve-hot": "NODE_ENV=development webpack-dev-server --open --hot --config webpack.dev.js",
     "serve-cypress": "SHOW_DISTRIBUTION_API_METRICS=true ESROOT=http://example.com npm run serve",


### PR DESCRIPTION
**Summary:** adds ability to override default port when running `npm run serve:prod` and explicitly passes AWS_REGION to override default us-west-2 in CI.

No real user facing changes.