### PR TITLE
Replace Docker scripts with multistage Dockerfile used by docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+*.md
+.git
+ancillary
+bin
+cypress
+dist
+localAPI
+ngap
+node_modules
+test
+tmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   **CUMULUS-2262**
   - Revised `Delete Granule` workflow to allow removing from CMR and then deleting in one step
 
+  **CUMULUS-2242**
+  - Changes underlying Docker files for building dashboard bundle and dashboard image via docker.  The user interface remains the same.
+
 ## [v3.0.0]
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The dashboard source is available on github and can be cloned with git.
 ```
 The cloned directory `./cumulus-dashboard` will be refered as the root directory of the project and commands that are referenced in this document, should start from that directory.
 
-### Build the dashboard using Docker
+### Build the dashboard using Docker and Docker Compose
 
 It is easy to build a producution-ready, deployable version of the Cumulus dashboard without having to learn the complicated build process details.  A single script, `./bin/build_dashboard_via_docker.sh`, when combined with your dashboard's environment customizations, allows you to run the entire build process within a Docker container.
 

--- a/audit-ci.json
+++ b/audit-ci.json
@@ -2,5 +2,5 @@
   "high": true,
   "pass-enoaudit": true,
   "retry-count": 20,
-  "whitelist": []
+  "allowlist": ["xml-crypto"]
 }

--- a/bin/build_dashboard_image.sh
+++ b/bin/build_dashboard_image.sh
@@ -1,35 +1,17 @@
 #!/bin/sh
 #
 # Script to build a Docker image that uses a basic nginx configuration to serve
-# a pre-built dashboard located in ${root}/dist.
-
+# the Cumulus dashboard
+# example:
+# > ./bin/build_dashboard_via_docker.sh
+# > ....
+# Successfully built f39c114cc432
+# Successfully tagged cumulus-dashboard:latest
+# >
 # The resulting image can be run exposing the dashboard with a simple command
 # docker run --rm -p 3000:80 cumulus-dashboard:latest
 
 set -evx
 
 IMAGE_NAME="${1:-cumulus-dashboard:latest}"
-
-if [ ! -d dist ]; then
-  echo "No dist directory found" >&2
-  exit 1
-fi
-
-if [ -z "$(ls -A dist)" ]; then
-  echo "Nothing found in the dist directory" >&2
-  exit 1
-fi
-
-rm -rf docker/html
-mkdir docker/html
-rsync \
-  --archive \
-  --delete \
-  --verbose \
-  ./dist/ ./docker/html/
-
-if [ "$IMAGE_NAME" == "" ]; then
-  docker build docker
-else
-  docker build --tag "$IMAGE_NAME" docker
-fi
+IMAGE_NAME=$IMAGE_NAME docker-compose -f docker/docker-compose.yml build dashboard

--- a/bin/build_dashboard_via_docker.sh
+++ b/bin/build_dashboard_via_docker.sh
@@ -8,84 +8,13 @@
 
 set -evx
 
+TAG=${TAG:-latest}
 DIST="$(pwd)/dist"
 
 echo "Cleaning $DIST directory"
 rm -rf $DIST && mkdir $DIST
 
-mkdir -p tmp
-DOCKER_UID=$(id -u)
-DOCKER_GID=$(id -g)
-cat > tmp/script.sh <<EOS
-#!/bin/sh
-
-set -evx
-
-apt-get update && apt-get install -y \
-  rsync \
-  git
-
-mkdir /build
-rsync -av \
-  --exclude .git \
-  --exclude ancillary \
-  --exclude bin \
-  --exclude cypress \
-  --exclude dist \
-  --exclude localAPI \
-  --exclude ngap \
-  --exclude node_modules \
-  --exclude test \
-  --exclude tmp \
-  /cumulus-dashboard/ /build/
-
-(
-  set -evx
-  cd /build
-  npm install --no-optional
-
-  APIROOT=$APIROOT \
-  AUTH_METHOD=$AUTH_METHOD \
-  AWS_REGION=$AWS_REGION \
-  DAAC_NAME=$DAAC_NAME \
-  ENABLE_RECOVERY=$ENABLE_RECOVERY \
-  ESROOT=$ESROOT \
-  ES_PASSWORD=$ES_PASSWORD \
-  ES_USER=$ES_USER \
-  HIDE_PDR=$HIDE_PDR \
-  KIBANAROOT=$KIBANAROOT \
-  LABELS=$LABELS \
-  SERVED_BY_CUMULUS_API=$SERVED_BY_CUMULUS_API \
-  SHOW_DISTRIBUTION_API_METRICS=$SHOW_DISTRIBUTION_API_METRICS \
-  SHOW_TEA_METRICS=$SHOW_TEA_METRICS \
-  STAGE=$STAGE \
-  npm run build
-
-  rsync -av ./dist/ /dist/
-  chown -R "${DOCKER_UID}:${DOCKER_GID}" /dist/
-)
-EOS
-chmod +x tmp/script.sh
-
-echo "Building to $DIST"
-docker run \
-  --rm \
-  --volume "${DIST}:/dist" \
-  --volume "$(pwd):/cumulus-dashboard:ro" \
-  --env APIROOT=$APIROOT \
-  --env AUTH_METHOD=$AUTH_METHOD \
-  --env AWS_REGION=$AWS_REGION \
-  --env DAAC_NAME=$DAAC_NAME \
-  --env ENABLE_RECOVERY=$ENABLE_RECOVERY \
-  --env ESROOT=$ESROOT \
-  --env ES_PASSWORD=$ES_PASSWORD \
-  --env ES_USER=$ES_USER \
-  --env HIDE_PDR=$HIDE_PDR \
-  --env KIBANAROOT=$KIBANAROOT \
-  --env LABELS=$LABELS \
-  --env SERVED_BY_CUMULUS_API=$SERVED_BY_CUMULUS_API \
-  --env SHOW_DISTRIBUTION_API_METRICS=$SHOW_DISTRIBUTION_API_METRICS \
-  --env SHOW_TEA_METRICS=$SHOW_TEA_METRICS \
-  --env STAGE=$STAGE \
-  node:12 \
-  /cumulus-dashboard/tmp/script.sh
+TAG=${TAG} docker-compose -f docker/docker-compose.yml build build
+docker create --name dashboard-build-container dashboard-build:${TAG}
+docker cp dashboard-build-container:/cumulus-dashboard/dist/. ./dist
+docker rm dashboard-build-container

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,52 @@
-FROM nginx:alpine
+FROM node:12.18.0 as build
+WORKDIR /cumulus-dashboard
+COPY package.json package-lock.json ./
+RUN npm install --no-optional
 
+ARG APIROOT
+ARG AUTH_METHOD
+ARG AWS_REGION
+ARG DAAC_NAME
+ARG ENABLE_RECOVERY
+ARG ESROOT
+ARG ES_PASSWORD
+ARG ES_USER
+ARG HIDE_PDR
+ARG KIBANAROOT
+ARG LABELS
+ARG SERVED_BY_CUMULUS_API
+ARG SHOW_DISTRIBUTION_API_METRICS
+ARG SHOW_TEA_METRICS
+ARG STAGE
+
+COPY . ./
+
+RUN bash -c "echo -e API ROOT IS : $APIROOT"
+
+RUN \
+ APIROOT=$APIROOT \
+ AUTH_METHOD=$AUTH_METHOD \
+ AWS_REGION=$AWS_REGION \
+ DAAC_NAME=$DAAC_NAME \
+ ENABLE_RECOVERY=$ENABLE_RECOVERY \
+ ESROOT=$ESROOT \
+ ES_PASSWORD=$ES_PASSWORD \
+ ES_USER=$ES_USER \
+ HIDE_PDR=$HIDE_PDR \
+ KIBANAROOT=$KIBANAROOT \
+ LABELS=$LABELS \
+ SERVED_BY_CUMULUS_API=$SERVED_BY_CUMULUS_API \
+ SHOW_DISTRIBUTION_API_METRICS=$SHOW_DISTRIBUTION_API_METRICS \
+ SHOW_TEA_METRICS=$SHOW_TEA_METRICS \
+ STAGE=$STAGE \
+ npm run build
+
+FROM nginx:alpine as app
 STOPSIGNAL SIGQUIT
 
-COPY nginx.conf /etc/nginx/nginx.conf
-COPY run-nginx.sh /usr/local/sbin/run-nginx.sh
+COPY docker/nginx.conf /etc/nginx/nginx.conf
+COPY docker/run-nginx.sh /usr/local/sbin/run-nginx.sh
 
 CMD ["/usr/local/sbin/run-nginx.sh"]
 
-COPY html/ /usr/share/nginx/html/
+COPY --from=build /cumulus-dashboard/dist/ /usr/share/nginx/html/

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,46 @@
+version: '3.8'
+
+services:
+  build:
+    working_dir: /cumulus-dashboard
+    image: dashboard-build:${TAG-}
+    build:
+      dockerfile: docker/Dockerfile
+      context: ../
+      target: build
+      args:
+        - APIROOT
+        - AUTH_METHOD
+        - AWS_REGION
+        - DAAC_NAME
+        - ENABLE_RECOVERY
+        - ESROOT
+        - ES_PASSWORD
+        - ES_USER
+        - HIDE_PDR
+        - KIBANAROOT
+        - SERVED_BY_CUMULUS_API
+        - SHOW_DISTRIBUTION_API_METRICS
+        - SHOW_TEA_METRICS
+        - STAGE
+  dashboard:
+    working_dir: /cumulus-dashboard
+    image: ${IMAGE_NAME}
+    build:
+      dockerfile: docker/Dockerfile
+      context: ../
+      args:
+        - APIROOT
+        - AUTH_METHOD
+        - AWS_REGION
+        - DAAC_NAME
+        - ENABLE_RECOVERY
+        - ESROOT
+        - ES_PASSWORD
+        - ES_USER
+        - HIDE_PDR
+        - KIBANAROOT
+        - SERVED_BY_CUMULUS_API
+        - SHOW_DISTRIBUTION_API_METRICS
+        - SHOW_TEA_METRICS
+        - STAGE


### PR DESCRIPTION
This switches the existing build scripts to use docker-compose and a new
Dockerfile that allows us to cache intermediate images.  
This doesn't litter the directories with extra files.

**Summary:** Summary of changes

Addresses [CUMULUS-2242: improve Docker](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2242)

## Changes

* Modernize the docker build to use a multistage container rather than a script that writes to a temp dir and runs a build command via docker.

 

## PR Checklist

- [ x] Update CHANGELOG
- [ na ] Unit tests
- [ x] Adhoc testing
- [ na ] Integration tests

To test, you can follow the quick start guide and ensure that you can still run ./bin/build_dashboard_via_docker.sh and ./bin/build_dashboard_image.sh as you could before.
