### PR TITLE
CUMULUS-2263 Clear pagination input on focus for cleaner UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **CUMULUS-2072**
   - Add 'Show More' and 'Show Less' buttons to error report
 
+- **CUMULUS-2263**
+  - Update Pagination input to show possible page options in dropdown
+
 ### Added
 - **CUMULUS-1895**
   - Update execution events to display more details in modal

--- a/app/src/js/components/DropDown/dropdown.js
+++ b/app/src/js/components/DropDown/dropdown.js
@@ -20,6 +20,7 @@ const Dropdown = ({
   queryParams,
   selectedValues = [],
   setQueryParams,
+  clearOnClick,
 }) => {
   const typeaheadRef = createRef();
   const [initialQueryParams] = useState(queryParams);
@@ -110,6 +111,12 @@ const Dropdown = ({
     if (getOptions) dispatch(getOptions());
   }, [dispatch, getOptions]);
 
+  function handleFocus(e) {
+    if (clearOnClick) {
+      setSelected([]);
+    }
+  }
+
   return (
     <div className={`filter__item form-group__element filter-${paramKey.includes('.') ? paramKey.split('.')[0] : paramKey}`}>
       {label && <label htmlFor={paramKey}>{label}</label>}
@@ -125,6 +132,7 @@ const Dropdown = ({
         renderInput={renderTypeaheadInput}
         renderMenu={renderTypeaheadMenu}
         selected={selected}
+        onFocus={handleFocus}
       />
     </div>
   );
@@ -144,6 +152,7 @@ Dropdown.propTypes = {
   queryParams: PropTypes.object,
   selectedValues: PropTypes.array,
   setQueryParams: PropTypes.func,
+  clearOnClick: PropTypes.bool,
 };
 
 export default withRouter(withQueryParams()(connect()(Dropdown)));

--- a/app/src/js/components/Pagination/pagination.js
+++ b/app/src/js/components/Pagination/pagination.js
@@ -41,6 +41,21 @@ const Pagination = ({
     }
   }
 
+  function renderOptions(totalPages) {
+    const pages = [];
+
+    for (let p = 1; p <= totalPages; p++) {
+      pages.push(
+        {
+          id: p,
+          label: p.toString(),
+        }
+      );
+    }
+
+    return pages;
+  }
+
   if (Number.isNaN(count) && Number.isNaN(limit) && Number.isNaN(page)) return null;
 
   const currentPage = +page;
@@ -91,13 +106,9 @@ const Pagination = ({
             inputProps={{ 'aria-label': 'Page' }}
             label={<span className="sr-only">Page</span>}
             onChange={handleDropdownChange}
-            options={[
-              {
-                id: meta.total_pages,
-                label: meta.total_pages.toString(),
-              },
-            ]}
+            options={renderOptions(meta.total_pages)}
             paramKey="page"
+            clearOnClick={true}
             selectedValues={[
               {
                 id: currentPage,


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2263:Dashboard: Table Header Input Interaction Tweaks](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2263)

## Changes

* Updates the Pagination Typeahead input to clear when focused
* Populates the Pagination dropdown list with the appropriate page numbers

Previously a user would click the pagination input and a dropdown would appear showing only the number entered (or any page numbers starting with that number). This is a little confusing because you would either expect to see no dropdown (text input only) or a dropdown containing all available page options.

I opted to keep the dropdown but try to make it useful. Now, when a user clicks the input, the field will clear and show all available pages in the dropdown. You can select one or type any number. This way, if there are 100s of pages, the typeahead might come in handy.

Totally open to feedback if there's a preference for hiding the dropdown in this case instead.

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Adhoc testing
- [ ] Integration tests