### PR TITLE
CUMULUS-2070 Adds css padding for homepage and editing collections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   **CUMULUS-2242**
   - Changes underlying Docker files for building dashboard bundle and dashboard image via docker.  The user interface remains the same.
 
+  **CUMULUS-2070**
+  - Styling changes included a small css refactor.
+
 ## [v3.0.0]
 
 ### Fixed

--- a/app/src/css/_base.scss
+++ b/app/src/css/_base.scss
@@ -396,29 +396,28 @@ a:active {
   margin-bottom: 1em;
 }
 
-.page__content--nosidebar {
-  margin-top: 2em;
-  flex-direction: column;
-  padding-bottom: 2em;
-}
-
 .page__content {
   width: 100%;
   @extend .clearfix;
-}
 
-.page__content--shortened {
-  flex: 10;
-  padding: 2em 4em 2em 4em;
-  /*float: left;*/
-  width: 80%;
-}
+  &--nosidebar {
+    margin-top: 2em;
+    flex-direction: column;
+    padding-bottom: 2em;
+  }
 
-.page__content--shortened--centered {
-  width: 70%;
-  margin: 0 auto;
-  padding-top: 4em;
-  padding-bottom: 2em;
+  &--shortened {
+    flex: 10;
+    padding: 2em 4em 2em 4em;
+    /*float: left;*/
+    width: 80%;
+    &--centered {
+      width: 70%;
+      margin: 0 auto;
+      padding-top: 4em;
+      padding-bottom: 2em;
+    }
+  }
 }
 
 .page__section {

--- a/app/src/css/_base.scss
+++ b/app/src/css/_base.scss
@@ -411,6 +411,7 @@ a:active {
     padding: 2em 4em 2em 4em;
     /*float: left;*/
     width: 80%;
+
     &--centered {
       width: 70%;
       margin: 0 auto;

--- a/app/src/css/_base.scss
+++ b/app/src/css/_base.scss
@@ -396,9 +396,10 @@ a:active {
   margin-bottom: 1em;
 }
 
-.page__content__nosidebar {
+.page__content--nosidebar {
   margin-top: 2em;
   flex-direction: column;
+  padding-bottom: 2em;
 }
 
 .page__content {
@@ -417,6 +418,7 @@ a:active {
   width: 70%;
   margin: 0 auto;
   padding-top: 4em;
+  padding-bottom: 2em;
 }
 
 .page__section {

--- a/app/src/js/components/home.js
+++ b/app/src/js/components/home.js
@@ -158,7 +158,7 @@ class Home extends React.Component {
           </div>
         </div>
 
-        <div className='page__content page__content__nosidebar'>
+        <div className='page__content page__content--nosidebar'>
           <section className='page__section datetime'>
             <div className='row'>
               <div className='heading__wrapper'>


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2070: UI fix: tables](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2070)

## Changes

* added padding to the bottom of all page__content modifiers 


## PR Checklist

- [ n/a ] Update CHANGELOG
- [ n/a ] Unit tests
- [ X ] Adhoc testing
- [ n/a ] Integration tests

See Before and after PIX:

![before-homepage](https://user-images.githubusercontent.com/479480/100679304-733eb880-332c-11eb-8ec5-01542c74fc00.png)
![after-homepage](https://user-images.githubusercontent.com/479480/100679310-78036c80-332c-11eb-9a3f-84f760f08470.png)
![before edit collections](https://user-images.githubusercontent.com/479480/100679317-7c2f8a00-332c-11eb-8ed1-cc27d1dad2f4.png)
![after edit collections](https://user-images.githubusercontent.com/479480/100679324-7fc31100-332c-11eb-8fda-f035fcbeeb26.png)

