### PR TITLE
CUMULUS-2271 Allow horizontal scrolling on table columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,16 +37,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **CUMULUS-2251**
   - Add the `Granule Actions` button
 
-  **CUMULUS-2262**
+- **CUMULUS-2262**
   - Revised `Delete Granule` workflow to allow removing from CMR and then deleting in one step
 
-  **CUMULUS-2242**
+- **CUMULUS-2242**
   - Changes underlying Docker files for building dashboard bundle and dashboard image via docker.  The user interface remains the same.
 
 - **CUMULUS-2271**
   - Allow horizontal scrolling in table cells when content doesn't fit in view
 
-  **CUMULUS-2070**
+- **CUMULUS-2070**
   - Styling changes included a small css refactor.
 
 ## [v3.0.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   **CUMULUS-2242**
   - Changes underlying Docker files for building dashboard bundle and dashboard image via docker.  The user interface remains the same.
 
+- **CUMULUS-2271**
+  - Allow horizontal scrolling in table cells when content doesn't fit in view
+
 ## [v3.0.0]
 
 ### Fixed

--- a/app/src/css/modules/_table.scss
+++ b/app/src/css/modules/_table.scss
@@ -37,6 +37,22 @@
         &:hover {
           overflow: auto;
         }
+
+        /*
+         * From https://stackoverflow.com/questions/7492062/css-overflow-scroll-always-show-vertical-scroll-bar/10100209#10100209
+         * The horizontal scrollbar does not always show, depending on the user's OS settings.
+         * This forces a bar to render.
+        */
+        &::-webkit-scrollbar {
+          -webkit-appearance: none;
+          height: 8px;
+        }
+
+        &::-webkit-scrollbar-thumb {
+          border-radius: 4px;
+          background-color: rgba(0, 0, 0, .5);
+          box-shadow: 0 0 1px rgba(255, 255, 255, .5);
+        }
       }
       .table__main-asset {
         font-weight: $base-font-semibold;

--- a/app/src/css/modules/_table.scss
+++ b/app/src/css/modules/_table.scss
@@ -34,10 +34,10 @@
         padding: 1em 2em;
         vertical-align: middle;
         overflow: hidden;
-        text-overflow: ellipsis;
-        /*&:first-of-type {
-          padding: 1em 0 1em 2em;
-        }*/
+        min-height: 65px;
+        &:hover {
+          overflow: auto;
+        }
       }
       .table__main-asset {
         font-weight: $base-font-semibold;

--- a/app/src/css/modules/_table.scss
+++ b/app/src/css/modules/_table.scss
@@ -34,7 +34,6 @@
         padding: 1em 2em;
         vertical-align: middle;
         overflow: hidden;
-        min-height: 65px;
         &:hover {
           overflow: auto;
         }


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2271: Dashboard: Table Column Horizontal Scroll
](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2271)

## Changes

* Shows the overflow on table cells when hovered

Previously the only way to show the full contents of a cell was to expand the cell's width by dragging the header. You can still do that but now, if there is overflow, you can hover on a cell and a scrollbar will appear.

Note that this removes the ellipses from truncated text. We can keep it and show the "..." when text is truncated, then remove the ellipses on hover BUT then the issue is what happens when the user moves their mouse outside of the cell? I'm not sure there's a great way to keep the full, non-truncated text in that case. We can of course handle it in JS but I'm wary of adding any handlers on a table with potentially hundreds of rows.

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Adhoc testing
- [ ] Integration tests