### PR TITLE
CUMULUS-2270 Add provider drop down filter to Collections Overview page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Implement lazy loading for SortableTable, Datepicker, and Sidebar
   - Improve performance
 
+- **CUMULUS-2270**
+  - Add provider drop down filter to Collections Overview page
+
 ### Changed
 
 - **CUMULUS-2251**

--- a/app/src/js/actions/index.js
+++ b/app/src/js/actions/index.js
@@ -121,7 +121,8 @@ export const listCollections = (options = {}) => {
   const { listAll = false, getMMT = true, includeStats = true, ...queryOptions } = options;
   return (dispatch, getState) => {
     const timeFilters = listAll ? {} : fetchCurrentTimeFilters(getState().datepicker);
-    const urlPath = `collections${isEmpty(timeFilters) || listAll ? '' : '/active'}`;
+    const providerFilter = get(queryOptions, 'provider');
+    const urlPath = `collections${(isEmpty(timeFilters) && providerFilter === undefined) || listAll ? '' : '/active'}`;
     return dispatch({
       [CALL_API]: {
         type: types.COLLECTIONS,

--- a/app/src/js/components/Collections/list.js
+++ b/app/src/js/components/Collections/list.js
@@ -1,4 +1,5 @@
 // This is the main Collections Overview page
+import { get } from 'object-path';
 import React from 'react';
 import { Helmet } from 'react-helmet';
 import PropTypes from 'prop-types';
@@ -8,6 +9,7 @@ import {
   applyRecoveryWorkflowToCollection,
   clearCollectionsSearch,
   getCumulusInstanceMetadata,
+  getOptionsProviderName,
   listCollections,
   searchCollections,
   filterCollections,
@@ -19,6 +21,7 @@ import {
   recoverAction,
   tableColumns,
 } from '../../utils/table-config/collections';
+import Dropdown from '../DropDown/dropdown';
 import Search from '../Search/search';
 import List from '../Table/Table';
 import { strings } from '../locale';
@@ -68,7 +71,7 @@ class CollectionList extends React.Component {
   }
 
   render() {
-    const { collections, datepicker } = this.props;
+    const { collections, datepicker, providers: { dropdowns } } = this.props;
     const { list } = collections;
     const { startDateTime, endDateTime } = datepicker || {};
     const hasTimeFilter = startDateTime || endDateTime;
@@ -123,6 +126,17 @@ class CollectionList extends React.Component {
                 placeholder="Collection Name"
                 searchKey="collections"
               />
+              <Dropdown
+                getOptions={getOptionsProviderName}
+                options={get(dropdowns, ['provider', 'options'])}
+                action={filterCollections}
+                clear={clearCollectionsFilter}
+                paramKey="provider"
+                label="Provider"
+                inputProps={{
+                  placeholder: 'All'
+                }}
+              />
             </ListFilters>
           </List>
         </section>
@@ -136,6 +150,7 @@ CollectionList.propTypes = {
   config: PropTypes.object,
   datepicker: PropTypes.object,
   dispatch: PropTypes.func,
+  providers: PropTypes.object,
   queryParams: PropTypes.object,
 };
 
@@ -147,5 +162,6 @@ export default withRouter(
     collections: state.collections,
     config: state.config,
     datepicker: state.datepicker,
+    providers: state.providers,
   }))(CollectionList)
 );

--- a/cypress/integration/collections_spec.js
+++ b/cypress/integration/collections_spec.js
@@ -90,6 +90,21 @@ describe('Dashboard Collections Page', () => {
         .contains(infix);
     });
 
+    it.only('should display collections with active granules when a provider is selected from dropdown', () => {
+      cy.visit('/collections');
+      cy.wait('@getCollections');
+
+      cy.get('.filter-provider .rbt-input-main').as('provider-input');
+      cy.get('@provider-input').click().type('s3').type('{enter}');
+      cy.url().should('include', 'provider=s3_provider');
+      cy.get('.table .tbody .tr').should('have.length', 1);
+
+      cy.get('@provider-input').click().clear().type('POD')
+        .type('{enter}');
+      cy.url().should('include', 'provider=PODAAC_SWOT');
+      cy.get('.table .tbody .tr').should('not.exist');
+    });
+
     it('should display expected MMT Links for a collections list', () => {
       cy.route({
         method: 'GET',

--- a/test/components/collections/list.js
+++ b/test/components/collections/list.js
@@ -25,6 +25,30 @@ const collections = {
   updated: {}
 };
 
+const providers = {
+  providers: {
+    list: {
+      data: [],
+      meta: {},
+      params: {}
+    },
+    dropdowns: {
+      provider: {
+        options: [
+          {
+            id: 's3_provider',
+            label: 's3_provider'
+          },
+          {
+            id: 'http_provider',
+            label: 'http_provider'
+          }
+        ],
+      }
+    }
+  }
+};
+
 test('Collections Overview generates bulkAction for recovery button', function (t) {
   const dispatch = () => {};
   const logs = {};
@@ -41,7 +65,8 @@ test('Collections Overview generates bulkAction for recovery button', function (
         collections = {collections}
         dispatch = {dispatch}
         logs = {logs}
-        config = {config}/>
+        config = {config}
+        providers = {providers}/>
     </Provider>);
 
   const collectionsWrapper = providerWrapper.find('CollectionList').dive();
@@ -69,7 +94,8 @@ test('Collections Overview does not generate bulkAction for recovery button', fu
         collections = {collections}
         dispatch = {dispatch}
         logs = {logs}
-        config = {config}/>
+        config = {config}
+        providers = {providers}/>
     </Provider>);
 
   const collectionsWrapper = providerWrapper.find('CollectionList').dive();


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2270: Add provider drop down filter to Collections Overview page](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2270)

## Changes

* Add provider drop down filter to Collections Overview page

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Adhoc testing
- [x] Integration tests