### PR TITLE
[CUMULUS 2071] Update card interactions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,13 +37,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **CUMULUS-2251**
   - Add the `Granule Actions` button
 
-  **CUMULUS-2262**
+- **CUMULUS-2262**
   - Revised `Delete Granule` workflow to allow removing from CMR and then deleting in one step
 
-  **CUMULUS-2242**
+- **CUMULUS-2242**
   - Changes underlying Docker files for building dashboard bundle and dashboard image via docker.  The user interface remains the same.
 
-  **CUMULUS-2070**
+- **CUMULUS-2271**
+  - Allow horizontal scrolling in table cells when content doesn't fit in view
+
+- **CUMULUS-2070**
   - Styling changes included a small css refactor.
 
 ## [v3.0.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   **CUMULUS-2242**
   - Changes underlying Docker files for building dashboard bundle and dashboard image via docker.  The user interface remains the same.
 
+  **CUMULUS-2070**
+  - Styling changes included a small css refactor.
+
 ## [v3.0.0]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **CUMULUS-2070**
   - Styling changes included a small css refactor.
 
+- **CUMULUS-2071**
+  - Replace the static "Granule Updates" stats on the home page with clickable cards
+  - Animate the Reconciliation Report > "Bucket Status" cards
+
 ## [v3.0.0]
 
 ### Fixed

--- a/app/src/css/_base.scss
+++ b/app/src/css/_base.scss
@@ -396,28 +396,29 @@ a:active {
   margin-bottom: 1em;
 }
 
-.page__content__nosidebar {
-  margin-top: 2em;
-  flex-direction: column;
-}
-
 .page__content {
   width: 100%;
   @extend .clearfix;
-}
 
-.page__content--shortened {
-  flex: 10;
-  padding: 2em 4em 2em 4em;
-  /*float: left;*/
-  width: 80%;
-}
+  &--nosidebar {
+    margin-top: 2em;
+    flex-direction: column;
+    padding-bottom: 2em;
+  }
 
-.page__content--shortened--centered {
-  width: 70%;
-  margin: 0 auto;
-  padding-top: 2em;
-  padding-bottom: 2em;
+  &--shortened {
+    flex: 10;
+    padding: 2em 4em 2em 4em;
+    /*float: left;*/
+    width: 80%;
+
+    &--centered {
+      width: 70%;
+      margin: 0 auto;
+      padding-top: 2em;
+      padding-bottom: 2em;
+    }
+  }
 }
 
 .page__section {

--- a/app/src/css/modules/_table.scss
+++ b/app/src/css/modules/_table.scss
@@ -362,8 +362,19 @@
   &--color{
     position: relative;
     top: 30px;
-    /*left: 55px;*/
     text-align: center;
+  }
+
+  &--yellow{
+    color: $orange;
+  }
+
+  &--red{
+    color: $error-red;
+  }
+
+  &--blue{
+    color: $midnight-blue;
   }
 }
 

--- a/app/src/css/modules/_table.scss
+++ b/app/src/css/modules/_table.scss
@@ -34,10 +34,25 @@
         padding: 1em 2em;
         vertical-align: middle;
         overflow: hidden;
-        text-overflow: ellipsis;
-        /*&:first-of-type {
-          padding: 1em 0 1em 2em;
-        }*/
+        &:hover {
+          overflow: auto;
+        }
+
+        /*
+         * From https://stackoverflow.com/questions/7492062/css-overflow-scroll-always-show-vertical-scroll-bar/10100209#10100209
+         * The horizontal scrollbar does not always show, depending on the user's OS settings.
+         * This forces a bar to render.
+        */
+        &::-webkit-scrollbar {
+          -webkit-appearance: none;
+          height: 8px;
+        }
+
+        &::-webkit-scrollbar-thumb {
+          border-radius: 4px;
+          background-color: rgba(0, 0, 0, .5);
+          box-shadow: 0 0 1px rgba(255, 255, 255, .5);
+        }
       }
       .table__main-asset {
         font-weight: $base-font-semibold;

--- a/app/src/css/vendor/bootstrap/overrides/_card.scss
+++ b/app/src/css/vendor/bootstrap/overrides/_card.scss
@@ -1,12 +1,17 @@
 .card-wrapper {
   display: flex;
   justify-content: flex-start;
+  max-height: 165px;
+
 }
 
 .card {
   width: 10em;
   cursor: pointer;
   margin: 1em 1em 1em 0;
+  -webkit-transition: all 0.3s;
+  -moz-transition: all 0.3s;
+  transition: all 0.3s ease 0s;
 
   .card-header {
     color: $white;
@@ -18,6 +23,7 @@
   }
 
   &:hover {
+    margin: .5em 1em 1.5em 0;
     box-shadow: $shadow__hover;
   }
 
@@ -36,6 +42,7 @@
 
     &--title-caption {
       font-weight: $base-font-semibold;
+      margin-bottom: 1em;
     }
 
     &:first-child {

--- a/app/src/css/vendor/bootstrap/overrides/_card.scss
+++ b/app/src/css/vendor/bootstrap/overrides/_card.scss
@@ -2,7 +2,6 @@
   display: flex;
   justify-content: flex-start;
   max-height: 165px;
-
 }
 
 .card {

--- a/app/src/js/components/home.js
+++ b/app/src/js/components/home.js
@@ -97,7 +97,7 @@ class Home extends React.Component {
       <section className='page__section'>
         <div className='row'>
           <div className='heading__wrapper'>
-            {header}
+            <h2 className='heading--medium heading--shared-content--right'>{header}</h2>
           </div>
           <div className="overview-num__wrapper overview-num__wrapper-home">
             <ul id={listId}>
@@ -205,22 +205,9 @@ class Home extends React.Component {
             </div>
           </section>
 
-          {this.renderButtonListSection(
-            overview,
-            <h2 className='heading--medium heading--shared-content--right'>Updates</h2>
-          )}
-
-          {this.renderButtonListSection(
-            distErrorStats,
-            <h2 className='heading--medium heading--shared-content--right'>Distribution Errors</h2>,
-            'distributionErrors'
-          )}
-
-          {this.renderButtonListSection(
-            distSuccessStats,
-            <h2 className='heading--medium heading--shared-content--right'>Distribution Successes</h2>,
-            'distributionSuccesses'
-          )}
+          {this.renderButtonListSection(overview, 'Updates')}
+          {this.renderButtonListSection(distErrorStats, 'Distribution Errors', 'distributionErrors')}
+          {this.renderButtonListSection(distSuccessStats, 'Distribution Successes', 'distributionSuccesses')}
 
           <section className='page__section update--granules'>
             <div className='row'>
@@ -232,7 +219,7 @@ class Home extends React.Component {
 
             {this.renderButtonListSection(
               updated,
-              <h2 className='heading--medium heading--shared-content--right'>{strings.granules_updated}<span className='num-title'>{numGranules}</span></h2>
+              <>{strings.granules_updated}<span className='num-title'>{numGranules}</span></>
             )}
 
           </section>

--- a/app/src/js/components/home.js
+++ b/app/src/js/components/home.js
@@ -220,7 +220,9 @@ class Home extends React.Component {
                 <h2 className='heading--medium heading--shared-content--right'>{strings.granules_updated}<span className='num-title'>{numGranules}</span></h2>
               </div>
             </div>
+
             {this.renderButtonListSection(updated, '')}
+
           </section>
           <section className='page__section list--granules'>
             <div className='row'>

--- a/app/src/js/components/home.js
+++ b/app/src/js/components/home.js
@@ -79,6 +79,18 @@ class Home extends React.Component {
     return link && link.match('https?://');
   }
 
+  getCountColor (type, count) {
+    if (type === 'Failed' && count > 0) {
+      if (count > 99) {
+        return 'red';
+      } if (count > 0) {
+        return 'yellow';
+      }
+    } else {
+      return 'blue';
+    }
+  }
+
   renderButtonListSection (items, header, listId) {
     const data = items.filter((d) => d[0] !== nullValue);
     if (!data.length) return null;
@@ -99,11 +111,11 @@ class Home extends React.Component {
                   <li key={d[1]}>
                     {this.isExternalLink(d[2]) ? (
                       <a id={d[1]} href={d[2]} className='overview-num' target='_blank'>
-                        <span className='num--large'>{value}</span> {d[1]}
+                        <span className={`num--large num--large--${this.getCountColor(d[1], value)}`}>{value}</span> {d[1]}
                       </a>
                     ) : (
                       <Link id={d[1]} className='overview-num' to={{ pathname: d[2], search: getPersistentQueryParams(this.props.location) }}>
-                        <span className='num--large'>{value}</span> {d[1]}
+                        <span className={`num--large num--large--${this.getCountColor(d[1], value)}`}>{value}</span> {d[1]}
                       </Link>
                     )}
                   </li>
@@ -114,6 +126,14 @@ class Home extends React.Component {
         </div>
       </section>
     );
+  }
+
+  getCountByKey (counts, key) {
+    const granuleCount = counts.find((c) => c.key === key);
+
+    if (granuleCount) {
+      return granuleCount.count;
+    }
   }
 
   render () {
@@ -149,6 +169,12 @@ class Home extends React.Component {
     const granuleCount = get(count.data, 'granules.meta.count');
     const numGranules = !Number.isNaN(+granuleCount) ? `${tally(granuleCount)}` : 0;
     const granuleStatus = get(count.data, 'granules.count', []);
+
+    const updated = [
+      [tally(this.getCountByKey(granuleStatus, 'running')), 'Running', '/granules/running'],
+      [tally(this.getCountByKey(granuleStatus, 'completed')), 'Completed', '/granules/completed'],
+      [tally(this.getCountByKey(granuleStatus, 'failed')), 'Failed', '/granules/failed'],
+    ];
 
     return (
       <div className='page__home'>
@@ -193,9 +219,8 @@ class Home extends React.Component {
               <div className="heading__wrapper">
                 <h2 className='heading--medium heading--shared-content--right'>{strings.granules_updated}<span className='num-title'>{numGranules}</span></h2>
               </div>
-
-              <GranulesProgress granules={granuleStatus} />
             </div>
+            {this.renderButtonListSection(updated, '')}
           </section>
           <section className='page__section list--granules'>
             <div className='row'>

--- a/app/src/js/components/home.js
+++ b/app/src/js/components/home.js
@@ -212,12 +212,14 @@ class Home extends React.Component {
 
           {this.renderButtonListSection(
             distErrorStats,
-            <h2 className='heading--medium heading--shared-content--right'>Distribution Errors</h2>
+            <h2 className='heading--medium heading--shared-content--right'>Distribution Errors</h2>,
+            'distributionErrors'
           )}
 
           {this.renderButtonListSection(
             distSuccessStats,
-            <h2 className='heading--medium heading--shared-content--right'>Distribution Successes</h2>
+            <h2 className='heading--medium heading--shared-content--right'>Distribution Successes</h2>,
+            'distributionSuccesses'
           )}
 
           <section className='page__section update--granules'>

--- a/app/src/js/components/home.js
+++ b/app/src/js/components/home.js
@@ -158,7 +158,7 @@ class Home extends React.Component {
           </div>
         </div>
 
-        <div className='page__content page__content__nosidebar'>
+        <div className='page__content page__content--nosidebar'>
           <section className='page__section datetime'>
             <div className='row'>
               <div className='heading__wrapper'>

--- a/app/src/js/components/home.js
+++ b/app/src/js/components/home.js
@@ -23,7 +23,6 @@ import {
   seconds
 } from '../utils/format';
 import List from './Table/Table';
-import GranulesProgress from './Granules/progress';
 import { errorTableColumns } from '../utils/table-config/granules';
 import {
   kibanaS3AccessErrorsLink,

--- a/app/src/js/components/home.js
+++ b/app/src/js/components/home.js
@@ -96,11 +96,8 @@ class Home extends React.Component {
     return (
       <section className='page__section'>
         <div className='row'>
-          <Helmet>
-            <title> Cumulus Home  </title>
-          </Helmet>
           <div className='heading__wrapper'>
-            <h2 className='heading--medium heading--shared-content--right'>{header}</h2>
+            {header}
           </div>
           <div className="overview-num__wrapper overview-num__wrapper-home">
             <ul id={listId}>
@@ -177,6 +174,9 @@ class Home extends React.Component {
 
     return (
       <div className='page__home'>
+        <Helmet>
+          <title> Cumulus Home  </title>
+        </Helmet>
         <div className='content__header content__header--lg'>
           <div className='row'>
             <h1 className='heading--xlarge'>{strings.dashboard}</h1>
@@ -205,9 +205,20 @@ class Home extends React.Component {
             </div>
           </section>
 
-          {this.renderButtonListSection(overview, 'Updates')}
-          {this.renderButtonListSection(distErrorStats, 'Distribution Errors', 'distributionErrors')}
-          {this.renderButtonListSection(distSuccessStats, 'Distribution Successes', 'distributionSuccesses')}
+          {this.renderButtonListSection(
+            overview,
+            <h2 className='heading--medium heading--shared-content--right'>Updates</h2>
+          )}
+
+          {this.renderButtonListSection(
+            distErrorStats,
+            <h2 className='heading--medium heading--shared-content--right'>Distribution Errors</h2>
+          )}
+
+          {this.renderButtonListSection(
+            distSuccessStats,
+            <h2 className='heading--medium heading--shared-content--right'>Distribution Successes</h2>
+          )}
 
           <section className='page__section update--granules'>
             <div className='row'>
@@ -215,12 +226,12 @@ class Home extends React.Component {
                 <h2 className='heading--large heading--shared-content--right'>Granules Updates</h2>
                 <Link className='link--secondary link--learn-more' to={{ pathname: '/granules', search: searchString }}>{strings.view_granules_overview}</Link>
               </div>
-              <div className="heading__wrapper">
-                <h2 className='heading--medium heading--shared-content--right'>{strings.granules_updated}<span className='num-title'>{numGranules}</span></h2>
-              </div>
             </div>
 
-            {this.renderButtonListSection(updated, '')}
+            {this.renderButtonListSection(
+              updated,
+              <h2 className='heading--medium heading--shared-content--right'>{strings.granules_updated}<span className='num-title'>{numGranules}</span></h2>
+            )}
 
           </section>
           <section className='page__section list--granules'>


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2071: Dashboard: UI Interaction Fix - Cards](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2071)

## Changes

* Replaces the static Granule Updates stats on the home page with clickable cards
* Animates the Reconciliation Report > Bucket Status cards

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Adhoc testing
- [ ] Integration tests