### PR TITLE
The README file in this repo has a bad link - [404:NotFound] - under "serving the dashboard from CloudFront"

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The compiled dashboard files (dashboard bundle) will be placed in the `./dist` d
 
 #### Build dashboard to be served by CloudFront
 
-If you wish to serve the dashboard from behind [CloudFront](https://aws.amazon.com/cloudfront/).  Build a `dist` with your configuration including `APIROOT` and ensure the `SERVED_BY_CUMULUS_API` variable is unset. Follow the cumulus operator docs on [serving the dashboard from CloudFront](https://nasa.github.io/cumulus/docs/next/operator-docs/serve-dashboard-from-cloudfront).
+If you wish to serve the dashboard from behind [CloudFront](https://aws.amazon.com/cloudfront/).  Build a `dist` with your configuration including `APIROOT` and ensure the `SERVED_BY_CUMULUS_API` variable is unset. Follow the cumulus operator docs on [serving the dashboard from CloudFront](https://nasa.github.io/cumulus/docs/operator-docs/serve-dashboard-from-cloudfront).
 
 #### Build dashboard to be served by the Cumulus API.
 


### PR DESCRIPTION
Hopefully resolves issue #908

The markup version of the readme that is displayed for the main page in this repo contains the following bad link:

"serving the dashboard from CloudFront"
Status code [404:NotFound] - Link: https://nasa.github.io/cumulus/docs/next/operator-docs/serve-dashboard-from-cloudfront

The closes working link I can find is: "https://nasa.github.io/cumulus/docs/operator-docs/serve-dashboard-from-cloudfront"


(The link in the readme’s raw markdown may appear in a different relative format to the link above)


**Extra**



This bad link was found by a tool I recently created as part of an new experimental hobby project: https://github.com/MrCull/GitHub-Repo-ReadMe-Dead-Link-Finder

I (a human) verified that this link is broken and have manually logged this Issue (i.e. this Issue has not been created by a bot).
If this has been in any way helpful then please consider giving the above Repo a Star.

If you have any feedback on the information provided here, or on the tool itself, then please feel free to share your thoughts here, or log an “Issue” in the repo.

--

Re-check this Repo via: http://githubreadmechecker.com/Home/Search?SingleRepoUri=https%3a%2f%2fgithub.com%2fnasa%2fcumulus-dashboard
Check all Repos for this GitHub account: http://githubreadmechecker.com/Home/Search?User=nasa

**Summary:** Summary of changes

Addresses [CUMULUS-XX: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-XXX)

## Changes

* Detailed list or prose of changes
* ...

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests