### PR TITLE
[CUMULUS-1885] Expand columns on double click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Update Pagination input to show possible page options in dropdown
 
 ### Added
+- **CUMULUS-1885**
+  - Expand columns to fit full content width when separator is double clicked
+
 - **CUMULUS-1895**
   - Update execution events to display more details in modal
 

--- a/app/src/css/modules/_table.scss
+++ b/app/src/css/modules/_table.scss
@@ -20,11 +20,13 @@
     max-width: 500px;
   }
 
+  .thead, .tbody {
+    width: fit-content;
+    min-width: 100%;
+  }
+
   .thead {
     background-color: $ocean-blue;
-    &, .tbody {
-      width: fit-content;
-    }
     .th {
       color: $white;
       font-weight: $base-font-semibold;

--- a/app/src/css/modules/_table.scss
+++ b/app/src/css/modules/_table.scss
@@ -199,7 +199,9 @@
 
 .resizer {
   display: inline-block;
-  background: $lightest-grey;
+  background-color: $lightest-grey;
+  background-clip: content-box;
+  padding: 0 10px;
   width: 2px;
   height: 100%;
   position: absolute;
@@ -210,7 +212,7 @@
   touch-action:none;
 
   &.isResizing {
-    background: red;
+    background-color: $grey;
   }
 }
 

--- a/app/src/css/modules/_table.scss
+++ b/app/src/css/modules/_table.scss
@@ -12,17 +12,29 @@
   overflow-x: scroll;
   border-radius: 8px 8px 0px 0px;
 
+  .content-fit {
+    width: fit-content!important;
+  }
+
   .Collapsible {
     max-width: 500px;
   }
 
   .thead {
     background-color: $ocean-blue;
+    &, .tbody {
+      width: fit-content;
+    }
     .th {
       color: $white;
       font-weight: $base-font-semibold;
       padding: 1em 2em;
       font-size: .86em;
+
+      &.no-resize {
+        border-right: 2px solid $lightest-grey;
+        padding: 1em 1.5em;
+      }
     }
   }
 
@@ -186,7 +198,7 @@
 .resizer {
   display: inline-block;
   background: $lightest-grey;
-  width: 1px;
+  width: 2px;
   height: 100%;
   position: absolute;
   right: 0;

--- a/app/src/js/components/SortableTable/SortableTable.js
+++ b/app/src/js/components/SortableTable/SortableTable.js
@@ -8,7 +8,7 @@ import React, {
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import omit from 'lodash/omit';
-import { useTable, useResizeColumns, useBlockLayout, useSortBy, useRowSelect, usePagination } from 'react-table';
+import { useTable, useResizeColumns, useFlexLayout, useSortBy, useRowSelect, usePagination } from 'react-table';
 import SimplePagination from '../Pagination/simple-pagination';
 import TableFilters from '../Table/TableFilters';
 
@@ -65,9 +65,8 @@ const SortableTable = ({
     () => ({
       Cell: ({ value = '' }) => value,
       // When using the useFlexLayout:
-      // minWidth: 30, // minWidth is only used as a limit for resizing
-      // width: 125, // width is used for both the flex-basis and flex-grow
-      // maxWidth: 350, // maxWidth is only used as a limit for resizing
+      minWidth: 30, // minWidth is only used as a limit for resizing
+      width: 125, // width is used for both the flex-basis and flex-grow
     }),
     []
   );
@@ -109,7 +108,7 @@ const SortableTable = ({
         hiddenColumns: initialHiddenColumns
       },
     },
-    useBlockLayout, // this allows table to have dynamic layouts outside of standard table markup
+    useFlexLayout, // this allows table to have dynamic layouts outside of standard table markup
     useResizeColumns, // this allows for resizing columns
     useSortBy, // this allows for sorting
     usePagination,

--- a/app/src/js/components/SortableTable/SortableTable.js
+++ b/app/src/js/components/SortableTable/SortableTable.js
@@ -2,12 +2,26 @@ import React, {
   useMemo,
   useEffect,
   forwardRef,
-  useRef
+  useRef,
+  useState
 } from 'react';
 import PropTypes from 'prop-types';
-import { useTable, useResizeColumns, useFlexLayout, useSortBy, useRowSelect, usePagination } from 'react-table';
+import classNames from 'classnames';
+import omit from 'lodash/omit';
+import { useTable, useResizeColumns, useBlockLayout, useSortBy, useRowSelect, usePagination } from 'react-table';
 import SimplePagination from '../Pagination/simple-pagination';
 import TableFilters from '../Table/TableFilters';
+
+const getColumnWidth = (rows, accessor, headerText, originalWidth) => {
+  const maxWidth = 400;
+  const magicSpacing = 10;
+  const cellLength = Math.max(
+    ...rows.map((row) => (`${row.values[accessor]}` || '').length * magicSpacing),
+    headerText.length * magicSpacing,
+    originalWidth,
+  );
+  return Math.min(maxWidth, cellLength);
+};
 
 /**
  * IndeterminateCheckbox
@@ -51,12 +65,13 @@ const SortableTable = ({
     () => ({
       Cell: ({ value = '' }) => value,
       // When using the useFlexLayout:
-      minWidth: 30, // minWidth is only used as a limit for resizing
-      width: 125, // width is used for both the flex-basis and flex-grow
-      maxWidth: 350, // maxWidth is only used as a limit for resizing
+      // minWidth: 30, // minWidth is only used as a limit for resizing
+      // width: 125, // width is used for both the flex-basis and flex-grow
+      // maxWidth: 350, // maxWidth is only used as a limit for resizing
     }),
     []
   );
+  const [fitColumn, setFitColumn] = useState({});
 
   const {
     getTableProps,
@@ -67,7 +82,7 @@ const SortableTable = ({
       selectedRowIds,
       sortBy,
       pageIndex,
-      hiddenColumns
+      hiddenColumns,
     },
     toggleAllRowsSelected,
     page,
@@ -92,9 +107,9 @@ const SortableTable = ({
       manualPagination: !shouldUsePagination,
       initialState: {
         hiddenColumns: initialHiddenColumns
-      }
+      },
     },
-    useFlexLayout, // this allows table to have dynamic layouts outside of standard table markup
+    useBlockLayout, // this allows table to have dynamic layouts outside of standard table markup
     useResizeColumns, // this allows for resizing columns
     useSortBy, // this allows for sorting
     usePagination,
@@ -104,15 +119,14 @@ const SortableTable = ({
         hooks.visibleColumns.push((columns) => [
           {
             id: 'selection',
+            disableResizing: true,
+            width: 50,
             Header: ({ getToggleAllRowsSelectedProps }) => ( // eslint-disable-line react/prop-types
               <IndeterminateCheckbox {...getToggleAllRowsSelectedProps()} />
             ),
             Cell: ({ row }) => ( // eslint-disable-line react/prop-types
               <IndeterminateCheckbox {...row.getToggleRowSelectedProps()} /> // eslint-disable-line react/prop-types
             ),
-            minWidth: 61,
-            width: 61,
-            maxWidth: 61
           },
           ...columns
         ]);
@@ -148,6 +162,21 @@ const SortableTable = ({
     }
   }, [changeSortProps, sortBy]);
 
+  function handleDoubleClick(id, header, originalWidth) {
+    setFitColumn({
+      ...fitColumn,
+      [id]: getColumnWidth(tableRows, id, header, originalWidth)
+    });
+  }
+
+  function handleMouseDown(e, id, onMouseDown) {
+    if (fitColumn[id]) {
+      const newFitColumn = omit(fitColumn, [id]);
+      setFitColumn(newFitColumn);
+    }
+    onMouseDown(e);
+  }
+
   return (
     <div className='table--wrapper'>
       {includeFilters &&
@@ -174,15 +203,36 @@ const SortableTable = ({
 
                       columnClassName = `table__sort${columnClassNameSuffix}`;
                     }
+
+                    const wrapperClassNames = classNames(
+                      'th',
+                      {
+                        'no-resize': !column.canResize,
+                      }
+                    );
+
+                    const { style, ...restHeaderProps } = column.getHeaderProps();
+                    const columnWidth = fitColumn[column.id];
+                    if (columnWidth) style.width = `${columnWidth}px`;
+
+                    const {
+                      onMouseDown,
+                      role,
+                      ...restResizerProps
+                    } = column.getResizerProps ? column.getResizerProps() : {};
+
                     return (
-                      <div {...column.getHeaderProps()} className='th'>
-                        <div {...column.getSortByToggleProps()} className={columnClassName}>
+                      <div {...restHeaderProps} className={wrapperClassNames} style={style}>
+                        <span {...column.getSortByToggleProps()} className={columnClassName}>
                           {column.render('Header')}
-                        </div>
-                        <div
-                          {...column.getResizerProps()}
+                        </span>
+                        {column.canResize && <div
+                          {...restResizerProps}
+                          role={role}
+                          onMouseDown={(e) => handleMouseDown(e, column.id, onMouseDown)}
+                          onDoubleClick={() => handleDoubleClick(column.id, column.Header, column.originalWidth)}
                           className={`resizer ${column.isResizing ? 'isResizing' : ''}`}
-                        />
+                        />}
                       </div>
                     );
                   })}
@@ -197,16 +247,26 @@ const SortableTable = ({
                 <div className='tr' data-value={row.id} {...row.getRowProps()} key={i}>
                   {row.cells.map((cell, cellIndex) => {
                     const primaryIdx = canSelect ? 1 : 0;
+                    const wrapperClassNames = classNames(
+                      'td',
+                      {
+                        'table__main-asset': cellIndex === primaryIdx,
+                      }
+                    );
+
+                    const { style, ...restCellProps } = cell.getCellProps();
+                    const columnWidth = fitColumn[cell.column.id];
+                    if (columnWidth) style.width = `${columnWidth}px`;
+
                     return (
-                      <React.Fragment key={cellIndex}>
-                        <div
-                          className={`td ${cellIndex === primaryIdx ? 'table__main-asset' : ''}`}
-                          {...cell.getCellProps()}
-                          key={cellIndex}
-                        >
-                          {cell.render('Cell')}
-                        </div>
-                      </React.Fragment>
+                      <div
+                        className={wrapperClassNames}
+                        {...restCellProps}
+                        style={style}
+                        key={cellIndex}
+                      >
+                        {cell.render('Cell')}
+                      </div>
                     );
                   })}
                 </div>

--- a/app/src/js/components/SortableTable/SortableTable.js
+++ b/app/src/js/components/SortableTable/SortableTable.js
@@ -228,6 +228,7 @@ const SortableTable = ({
                         {column.canResize && <div
                           {...restResizerProps}
                           role={role}
+                          title='Double click to expand'
                           onMouseDown={(e) => handleMouseDown(e, column.id, onMouseDown)}
                           onDoubleClick={() => handleDoubleClick(column.id, column.Header, column.originalWidth)}
                           className={`resizer ${column.isResizing ? 'isResizing' : ''}`}

--- a/cypress/integration/granules_spec.js
+++ b/cypress/integration/granules_spec.js
@@ -111,10 +111,9 @@ describe('Dashboard Granules Page', () => {
 
       cy.get('.table .thead .tr .th').contains('.table__sort', 'Collection ID').dblclick();
       cy.get('.table .thead .tr .th').contains('.table__sort--desc', 'Collection ID');
-      cy.get('.table .thead .tr .th').eq(0).type('{shift}', { release: false });
-      cy.get('.table .thead .tr .th').contains('.table__sort', 'Status').click();
+      cy.get('.table .thead .tr .th').contains('.table__sort', 'Status').click({ shiftKey: true });
       cy.get('.table .thead .tr .th').contains('.table__sort--asc', 'Status');
-      cy.get('.table .thead .tr .th').contains('.table__sort', 'Name').click();
+      cy.get('.table .thead .tr .th').contains('.table__sort', 'Name').click({ shiftKey: true });
       cy.get('.table .thead .tr .th').contains('.table__sort--asc', 'Name');
 
       // wait until the selected fields of granules are in sorted order

--- a/cypress/integration/granules_spec.js
+++ b/cypress/integration/granules_spec.js
@@ -144,6 +144,14 @@ describe('Dashboard Granules Page', () => {
       );
     });
 
+    it('Should resize column to fit content on double click', () => {
+      cy.visit('/granules');
+      cy.contains('.table .thead .tr .th', 'Name').as('nameColumn');
+      cy.get('@nameColumn').invoke('outerWidth').should('eq', 225);
+      cy.get('@nameColumn').find('.resizer').dblclick();
+      cy.get('@nameColumn').invoke('outerWidth').should('eq', 400);
+    });
+
     it('Should update dropdown with label when visiting bookmarkable URL', () => {
       cy.visit('/granules?status=running');
       cy.get('.filter-status .rbt-input-main').as('status-input');


### PR DESCRIPTION
**Summary:** Expand table columns

Addresses [CUMULUS-1885: Expand table columns on double click](https://bugs.earthdata.nasa.gov/browse/CUMULUS-1885)

## Changes

* Column expands to fit content when double clicking the separator/resizer, which is the same behavior that is seen in excel.
* Some style tweaks. Made resizer bigger/easier to click

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Adhoc testing
- [x] Integration tests