### PR TITLE
Migrate to Cypress 6.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Continuous integration moved to earthdata bamboo.
   - CircleCI configuration removed from project.
 
+- **CUMULUS-2325**
+  - Updates Cypress test software to 6.2.1.
+
 ## [v3.0.0]
 
 ### Fixed

--- a/cypress.json
+++ b/cypress.json
@@ -9,6 +9,5 @@
   },
   "nodeVersion": "system",
   "viewportWidth": 1300,
-  "viewportHeight": 1000,
-  "experimentalNetworkStubbing": true
+  "viewportHeight": 1000
 }

--- a/cypress/integration/auth_spec.js
+++ b/cypress/integration/auth_spec.js
@@ -53,13 +53,10 @@ describe('Dashboard authentication', () => {
   });
 
   it('should logout user on failed token refresh', () => {
-    cy.server();
-    cy.intercept({
-      method: 'POST',
-      url: `${Cypress.env('APIROOT')}/refresh`,
-      status: 500,
-      response: {}
-    });
+    cy.intercept(
+      { method: 'POST', url: `${Cypress.env('APIROOT')}/refresh` },
+      { body: {}, statusCode: 500 }
+    );
 
     cy.window().its('appStore').then((store) => {
       const expirationTime = (new Date(Date.now() - 24 * 3600 * 1000)).valueOf() / 1000.0;

--- a/cypress/integration/auth_spec.js
+++ b/cypress/integration/auth_spec.js
@@ -54,7 +54,7 @@ describe('Dashboard authentication', () => {
 
   it('should logout user on failed token refresh', () => {
     cy.server();
-    cy.route({
+    cy.intercept({
       method: 'POST',
       url: `${Cypress.env('APIROOT')}/refresh`,
       status: 500,

--- a/cypress/integration/bulk_granules_spec.js
+++ b/cypress/integration/bulk_granules_spec.js
@@ -25,10 +25,7 @@ describe('Dashboard Bulk Granules', () => {
     it('handles a successful bulk granule operation request', () => {
       const asyncOperationId = Math.random().toString(36).substring(2, 15);
 
-      cy.server();
-      cy.route('POST', '/granules/bulk', {
-        id: asyncOperationId
-      }).as('postBulkGranules');
+      cy.intercept('POST', '/granules/bulk', { id: asyncOperationId }).as('postBulkGranules');
 
       cy.visit('/granules');
       cy.contains('button', 'Granule Actions').click();
@@ -53,8 +50,7 @@ describe('Dashboard Bulk Granules', () => {
     it('appends correct query params after bulk granule operation request', () => {
       const asyncOperationId = Math.random().toString(36).substring(2, 15);
 
-      cy.server();
-      cy.route('POST', '/granules/bulk', {
+      cy.intercept('POST', '/granules/bulk', {
         id: asyncOperationId
       }).as('postBulkGranules');
 
@@ -84,8 +80,7 @@ describe('Dashboard Bulk Granules', () => {
     it('handles successful bulk granule deletion request', () => {
       const asyncOperationId = Math.random().toString(36).substring(2, 15);
 
-      cy.server();
-      cy.route('POST', '/granules/bulkDelete', {
+      cy.intercept('POST', '/granules/bulkDelete', {
         id: asyncOperationId
       }).as('postBulkDelete');
 
@@ -113,8 +108,7 @@ describe('Dashboard Bulk Granules', () => {
     it('handles successful bulk granule reingest request', () => {
       const asyncOperationId = Math.random().toString(36).substring(2, 15);
 
-      cy.server();
-      cy.route('POST', '/granules/bulkReingest', {
+      cy.intercept('POST', '/granules/bulkReingest', {
         id: asyncOperationId
       }).as('postBulkReingest');
 
@@ -143,15 +137,10 @@ describe('Dashboard Bulk Granules', () => {
       const errorMessage = 'bulk operations failure';
 
       beforeEach(() => {
-        cy.server();
-        cy.route({
-          method: 'POST',
-          status: 400,
-          url: '/granules/bulk',
-          response: {
-            message: errorMessage
-          }
-        }).as('postBulkGranules');
+        cy.intercept(
+          { method: 'POST', url: '/granules/bulk' },
+          { statusCode: 400, body: { message: errorMessage } }
+        ).as('postBulkGranules');
 
         cy.visit('/granules');
         cy.contains('button', 'Granule Actions').click();
@@ -193,15 +182,10 @@ describe('Dashboard Bulk Granules', () => {
       const errorMessage = 'bulk delete failure';
 
       beforeEach(() => {
-        cy.server();
-        cy.route({
-          method: 'POST',
-          status: 400,
-          url: '/granules/bulkDelete',
-          response: {
-            message: errorMessage
-          }
-        }).as('postBulkDelete');
+        cy.intercept(
+          { method: 'POST', url: '/granules/bulkDelete' },
+          { statusCode: 400, body: { message: errorMessage } }
+        ).as('postBulkDelete');
 
         cy.visit('/granules');
         cy.contains('button', 'Granule Actions').click();
@@ -243,15 +227,10 @@ describe('Dashboard Bulk Granules', () => {
       const errorMessage = 'bulk reingest failure';
 
       beforeEach(() => {
-        cy.server();
-        cy.route({
-          method: 'POST',
-          status: 400,
-          url: '/granules/bulkReingest',
-          response: {
-            message: errorMessage
-          }
-        }).as('postBulkReingest');
+        cy.intercept(
+          { method: 'POST', url: '/granules/bulkReingest' },
+          { statusCode: 400, body: { message: errorMessage } }
+        ).as('postBulkReingest');
 
         cy.visit('/granules');
         cy.contains('button', 'Granule Actions').click();

--- a/cypress/integration/executions_spec.js
+++ b/cypress/integration/executions_spec.js
@@ -77,14 +77,11 @@ describe('Dashboard Executions Page', () => {
       const executionArn = 'arn:aws:states:us-east-1:012345678901:execution:test-stack-HelloWorldWorkflow:8e21ca0f-79d3-4782-8247-cacd42a595ea';
       const stateMachine = 'arn:aws:states:us-east-1:012345678901:stateMachine:test-stack-HelloWorldWorkflow';
 
-      cy.server();
       cy.visit('/executions');
-      cy.route({
-        method: 'GET',
-        url: `http://localhost:5001/executions/status/${executionArn}`,
-        response: 'fixture:valid-execution.json',
-        status: 200
-      });
+      cy.intercept(
+        { method: 'GET', url: `http://localhost:5001/executions/status/${executionArn}` },
+        { fixture: 'valid-execution.json', statusCode: 200 }
+      );
 
       cy.contains('nav li a', 'Executions').as('executions');
       cy.get('@executions').should('have.attr', 'href', '/executions');
@@ -113,19 +110,14 @@ describe('Dashboard Executions Page', () => {
       const executionName = '8e21ca0f-79d3-4782-8247-cacd42a595ea';
       const executionArn = 'arn:aws:states:us-east-1:012345678901:execution:test-stack-HelloWorldWorkflow:8e21ca0f-79d3-4782-8247-cacd42a595ea';
 
-      cy.server();
-      cy.route({
-        method: 'GET',
-        url: `http://localhost:5001/executions/status/${executionArn}`,
-        response: 'fixture:valid-execution.json',
-        status: 200
-      });
-      cy.route({
-        method: 'GET',
-        url: `http://localhost:5001/logs/${executionName}`,
-        response: 'fixture:execution-logs.json',
-        status: 200
-      });
+      cy.intercept(
+        { method: 'GET', url: `http://localhost:5001/executions/status/${executionArn}` },
+        { fixture: 'valid-execution.json', statusCode: 200 }
+      );
+      cy.intercept(
+        { method: 'GET', url: `http://localhost:5001/logs/${executionName}` },
+        { fixture: 'execution-logs.json', statusCode: 200 }
+      );
 
       cy.visit(`/executions/execution/${executionArn}`);
       cy.contains('.heading--large', 'Execution');
@@ -162,13 +154,10 @@ describe('Dashboard Executions Page', () => {
       const executionName = '8e21ca0f-79d3-4782-8247-cacd42a595ea';
       const executionArn = 'arn:aws:states:us-east-1:012345678901:execution:test-stack-HelloWorldWorkflow:8e21ca0f-79d3-4782-8247-cacd42a595ea';
 
-      cy.server();
-      cy.route({
-        method: 'GET',
-        url: `http://localhost:5001/executions/status/${executionArn}`,
-        response: 'fixture:valid-execution.json',
-        status: 200
-      });
+      cy.intercept(
+        { method: 'GET', url: `http://localhost:5001/executions/status/${executionArn}` },
+        { fixture: 'valid-execution.json', statusCode: 200 }
+      );
 
       cy.visit(`/executions/execution/${executionArn}`);
       cy.contains('.heading--large', 'Execution');
@@ -217,13 +206,10 @@ describe('Dashboard Executions Page', () => {
       const executionArn = 'arn:aws:states:us-east-1:123456789012:execution:TestSourceIntegrationIngestAndPublishGranuleStateMachine-yCAhWOss5Xgo:b313e777-d28a-435b-a0dd-f1fad08116t1';
       const stateMachine = 'arn:aws:states:us-east-1:123456789012:stateMachine:TestSourceIntegrationIngestAndPublishGranuleStateMachine-yCAhWOss5Xgo';
 
-      cy.server();
-      cy.route({
-        method: 'GET',
-        url: `http://localhost:5001/logs/${executionName}`,
-        response: 'fixture:limited-execution.json',
-        status: 200
-      });
+      cy.intercept(
+        { method: 'GET', url: `http://localhost:5001/logs/${executionName}` },
+        { fixture: 'limited-execution.json', statusCode: 200 }
+      );
 
       cy.visit(`/executions/execution/${executionArn}`);
 
@@ -267,13 +253,10 @@ describe('Dashboard Executions Page', () => {
     it('should show an execution graph for a single execution', () => {
       const executionArn = 'arn:aws:states:us-east-1:012345678901:execution:test-stack-HelloWorldWorkflow:8e21ca0f-79d3-4782-8247-cacd42a595ea';
 
-      cy.server();
-      cy.route({
-        method: 'GET',
-        url: `http://localhost:5001/executions/status/${executionArn}`,
-        response: 'fixture:valid-execution.json',
-        status: 200
-      });
+      cy.intercept(
+        { method: 'GET', url: `http://localhost:5001/executions/status/${executionArn}` },
+        { fixture: 'valid-execution.json', statusCode: 200 }
+      );
 
       cy.visit(`/executions/execution/${executionArn}`);
 

--- a/cypress/integration/granules_spec.js
+++ b/cypress/integration/granules_spec.js
@@ -391,8 +391,8 @@ describe('Dashboard Granules Page', () => {
     it('Should have a Granule Lists page', () => {
       const listName = 'GranuleList100220';
       const url = `**/reconciliationReports/${listName}`;
-      cy.route2({ url: '**/reconciliationReports?limit=*', method: 'GET' }).as('getLists');
-      cy.route2({ url, method: 'GET' }).as('getList');
+      cy.intercept({ url: '**/reconciliationReports?limit=*', method: 'GET' }).as('getLists');
+      cy.intercept({ url, method: 'GET' }).as('getList');
       cy.visit('/granules');
       cy.contains('.sidebar li a', 'Lists').click();
       cy.wait('@getLists');
@@ -416,7 +416,7 @@ describe('Dashboard Granules Page', () => {
         'MOD09GQ.A1657416.CbyoRi.006.9697917818587'
       ];
 
-      cy.route2({
+      cy.intercept({
         url: '/reconciliationReports',
         method: 'POST'
       }, (req) => {
@@ -634,7 +634,7 @@ describe('Dashboard Granules Page', () => {
       cy.contains('button', 'Delete').click();
       cy.contains('.button--submit', 'Confirm').click();
 
-      cy.route2({
+      cy.intercept({
         url: '/granules',
         method: 'PUT'
       }, (req) => {

--- a/cypress/integration/granules_spec.js
+++ b/cypress/integration/granules_spec.js
@@ -38,88 +38,93 @@ describe('Dashboard Granules Page', () => {
       // shows a list of granules
       cy.getFakeApiFixture('granules').as('granulesListFixture');
 
+      const numGranulesToTest = 4;
+      let granuleNum = 0;
       cy.get('@granulesListFixture').its('results')
         .each((granule) => {
-          // Wait for this granule to appear before proceeding.
-          cy.contains(granule.granuleId);
-          cy.get(`[data-value="${granule.granuleId}"]`).children().as('columns');
-          cy.get('@columns').should('have.length', 9);
+          granuleNum += 1;
+          if (granuleNum <= numGranulesToTest) {
+            // Wait for this granule to appear before proceeding.
+            cy.contains(granule.granuleId);
+            cy.get(`[data-value="${granule.granuleId}"]`).children().as('columns');
+            cy.get('@columns').should('have.length', 9);
 
-          // Granule Status Column is correct
-          cy.get('@columns').eq(1).invoke('text')
-            .should('be.eq', granule.status.replace(/^\w/, (c) => c.toUpperCase()));
-          // has link to the granule list with the same status
-          cy.get('@columns').eq(1).children('a')
-            .should('have.attr', 'href')
-            .and('be.eq', `/granules/${granule.status}`);
-
-          // granule Name (id) column
-          cy.get('@columns').eq(2).invoke('text')
-            .should('be.eq', granule.granuleId);
-          // has link to the detailed granule page
-          cy.get('@columns').eq(2).find('a')
-            .should('have.attr', 'href')
-            .and('be.eq', `/granules/granule/${granule.granuleId}`);
-          // has popover with copy feature
-          cy.get('@columns').eq(2).find('.hover-wrap').trigger('mouseover');
-          cy.get(`#granuleId-${granule.granuleId.replaceAll('.', '\\.')}-popover`).as('popover');
-          cy.get('@popover').should('be.visible');
-          cy.get('@popover').contains('.popover-body--main', granule.granuleId);
-          cy.get('@popover').contains('button', 'Copy').click();
-          cy.get('@popover').find('span').should('be.visible');
-          cy.get('@columns').eq(2).find('.hover-wrap').trigger('mouseleave');
-
-          // Published column, only public granules have CMR link
-          if (granule.published) {
-            cy.get('@columns').eq(3).invoke('text')
-              .should('be.eq', 'Yes');
-            cy.get('@columns').eq(3).children('a')
+            // Granule Status Column is correct
+            cy.get('@columns').eq(1).invoke('text')
+              .should('be.eq', granule.status.replace(/^\w/, (c) => c.toUpperCase()));
+            // has link to the granule list with the same status
+            cy.get('@columns').eq(1).children('a')
               .should('have.attr', 'href')
-              .and('be.eq', granule.cmrLink);
-          } else {
-            cy.get('@columns').eq(3).invoke('text')
-              .should('be.eq', 'No');
-            cy.get('@columns').eq(3).children('a')
-              .should('not.exist');
+              .and('be.eq', `/granules/${granule.status}`);
+
+            // granule Name (id) column
+            cy.get('@columns').eq(2).invoke('text')
+              .should('be.eq', granule.granuleId);
+            // has link to the detailed granule page
+            cy.get('@columns').eq(2).find('a')
+              .should('have.attr', 'href')
+              .and('be.eq', `/granules/granule/${granule.granuleId}`);
+            // has popover with copy feature
+            cy.get('@columns').eq(2).find('.hover-wrap').trigger('mouseover');
+            cy.get(`#granuleId-${granule.granuleId.replaceAll('.', '\\.')}-popover`).as('popover');
+            cy.get('@popover').should('be.visible');
+            cy.get('@popover').contains('.popover-body--main', granule.granuleId);
+            cy.get('@popover').contains('button', 'Copy').click();
+            cy.get('@popover').find('span').should('be.visible');
+            cy.get('@columns').eq(2).find('.hover-wrap').trigger('mouseleave');
+
+            // Published column, only public granules have CMR link
+            if (granule.published) {
+              cy.get('@columns').eq(3).invoke('text')
+                .should('be.eq', 'Yes');
+              cy.get('@columns').eq(3).children('a')
+                .should('have.attr', 'href')
+                .and('be.eq', granule.cmrLink);
+            } else {
+              cy.get('@columns').eq(3).invoke('text')
+                .should('be.eq', 'No');
+              cy.get('@columns').eq(3).children('a')
+                .should('not.exist');
+            }
+
+            // Collection ID column
+            const formattedCollectionId = granule.collectionId.replace('___', ' / ');
+            cy.get('@columns').eq(4).invoke('text')
+              .should('be.eq', formattedCollectionId);
+            // has popover with copy feature
+            cy.get('@columns').eq(4).find('.hover-wrap').trigger('mouseover');
+            cy.get(`#collectionId-${granule.collectionId}-popover`).as('popover');
+            cy.get('@popover').should('be.visible');
+            cy.get('@popover').contains('.popover-body--main', formattedCollectionId);
+            cy.get('@popover').contains('button', 'Copy').click();
+            cy.get('@popover').find('span').should('be.visible');
+            cy.get('@columns').eq(2).find('.hover-wrap').trigger('mouseleave');
+
+            // has link to the detailed collection page
+            cy.get('@columns').eq(4).find('a')
+              .should('have.attr', 'href')
+              .and('be.eq', `/collections/collection/${granule.collectionId.replace('___', '/')}`);
+
+            // has link to provider
+            cy.get('@columns').eq(5).children('a')
+              .should('have.attr', 'href')
+              .and('be.eq', `/providers/provider/${granule.provider}`);
+
+            // Execution column has link to the detailed execution page
+            cy.get('@columns').eq(6).children('a')
+              .should('have.attr', 'href')
+              .and('be.eq', `/executions/execution/${granule.execution.split('/').pop()}`);
+
+            // Duration column
+            cy.get('@columns').eq(7).invoke('text')
+              .should('be.eq', `${Number(granule.duration).toFixed(2)}s`);
+            // Updated column
+            cy.get('@columns').eq(8).invoke('text')
+              .should('match', /.+ago$/);
+            cy.get('@columns').eq(8).find('span').trigger('mouseover');
+            cy.get('#table-timestamp-tooltip').should('be.visible');
+            cy.get('@columns').eq(8).find('span').trigger('mouseleave');
           }
-
-          // Collection ID column
-          const formattedCollectionId = granule.collectionId.replace('___', ' / ');
-          cy.get('@columns').eq(4).invoke('text')
-            .should('be.eq', formattedCollectionId);
-          // has popover with copy feature
-          cy.get('@columns').eq(4).find('.hover-wrap').trigger('mouseover');
-          cy.get(`#collectionId-${granule.collectionId}-popover`).as('popover');
-          cy.get('@popover').should('be.visible');
-          cy.get('@popover').contains('.popover-body--main', formattedCollectionId);
-          cy.get('@popover').contains('button', 'Copy').click();
-          cy.get('@popover').find('span').should('be.visible');
-          cy.get('@columns').eq(2).find('.hover-wrap').trigger('mouseleave');
-
-          // has link to the detailed collection page
-          cy.get('@columns').eq(4).find('a')
-            .should('have.attr', 'href')
-            .and('be.eq', `/collections/collection/${granule.collectionId.replace('___', '/')}`);
-
-          // has link to provider
-          cy.get('@columns').eq(5).children('a')
-            .should('have.attr', 'href')
-            .and('be.eq', `/providers/provider/${granule.provider}`);
-
-          // Execution column has link to the detailed execution page
-          cy.get('@columns').eq(6).children('a')
-            .should('have.attr', 'href')
-            .and('be.eq', `/executions/execution/${granule.execution.split('/').pop()}`);
-
-          // Duration column
-          cy.get('@columns').eq(7).invoke('text')
-            .should('be.eq', `${Number(granule.duration).toFixed(2)}s`);
-          // Updated column
-          cy.get('@columns').eq(8).invoke('text')
-            .should('match', /.+ago$/);
-          cy.get('@columns').eq(8).find('span').trigger('mouseover');
-          cy.get('#table-timestamp-tooltip').should('be.visible');
-          cy.get('@columns').eq(8).find('span').trigger('mouseleave');
         });
 
       cy.get('.table .tbody .tr').as('list');

--- a/cypress/integration/granules_spec.js
+++ b/cypress/integration/granules_spec.js
@@ -605,9 +605,12 @@ describe('Dashboard Granules Page', () => {
     });
 
     it('Should handle a successful API response from the Remove and Delete granule requests', () => {
+
       cy.intercept(
-        { method: 'PUT', url: new RegExp('/granules/.*')},
-        { body: { message: 'success' }, statusCode: 200 },
+        { method: 'PUT', url: new RegExp('/granules/.*') }, (req) => {
+          expect(req.body).to.have.property('action', 'removeFromCmr');
+          req.reply({ body: { message: 'success' }, statusCode: 200 });
+        }
       );
 
       cy.intercept(
@@ -624,14 +627,6 @@ describe('Dashboard Granules Page', () => {
       cy.contains('button', 'Granule Actions').click();
       cy.contains('button', 'Delete').click();
       cy.contains('.button--submit', 'Confirm').click();
-
-      cy.intercept({
-        url: '/granules',
-        method: 'PUT'
-      }, (req) => {
-        const requestBody = JSON.parse(req.body);
-        expect(requestBody).to.have.property('action', 'removeFromCmr');
-      });
 
       cy.get('.default-modal.batch-async-modal ').as('modal');
       cy.get('@modal').contains('div', 'Success!');

--- a/cypress/integration/granules_spec.js
+++ b/cypress/integration/granules_spec.js
@@ -369,7 +369,7 @@ describe('Dashboard Granules Page', () => {
       ];
       cy.intercept(
         { method: 'PUT', url: new RegExp('/granules/.*') },
-        {body: { message: 'Oopsie' }, statusCode: 500 }
+        { body: { message: 'Oopsie' }, statusCode: 500 }
       );
       cy.visit('/granules');
       cy.get(`[data-value="${granuleIds[0]}"] > .td >input[type="checkbox"]`).click();
@@ -605,7 +605,6 @@ describe('Dashboard Granules Page', () => {
     });
 
     it('Should handle a successful API response from the Remove and Delete granule requests', () => {
-
       cy.intercept(
         { method: 'PUT', url: new RegExp('/granules/.*') }, (req) => {
           expect(req.body).to.have.property('action', 'removeFromCmr');

--- a/cypress/integration/main_page_spec.js
+++ b/cypress/integration/main_page_spec.js
@@ -169,7 +169,7 @@ describe('Dashboard Home Page', () => {
     });
 
     it('modifies the UPDATES section and Granules Errors list as datepicker changes.', () => {
-      cy.route('GET', '/stats?*timestamp__from=1233360000000*').as('stats');
+      cy.intercept('GET', '/stats?*timestamp__from=1233360000000*').as('stats');
 
       cy.get('#Errors').contains('2');
       cy.get('#Collections').contains('1');
@@ -213,7 +213,8 @@ describe('Dashboard Home Page', () => {
       // Cypress only allows one stub per url. We make multiple POST requests to the same
       // elasticsearch endpoint. The fixture here returns a combined response of all the
       // responses for one url, effectively stubbing our elasticsearch searches.
-      cy.route('POST', 'http://example.com/_search/', 'fixture:elasticsearch.json');
+      let fixtureName = 'elasticsearch.json';
+      cy.intercept('POST', 'http://example.com/_search/', (req) => req.reply({ statusCode: 200, fixture: fixtureName }));
       cy.visit('/');
 
       cy.get('.overview-num__wrapper-home > ul#distributionErrors > :nth-child(5)').contains('0');
@@ -228,7 +229,7 @@ describe('Dashboard Home Page', () => {
       cy.get('.overview-num__wrapper-home > ul#distributionSuccesses > :nth-child(2)').contains('9');
       cy.get('.overview-num__wrapper-home > ul#distributionSuccesses > :nth-child(1)').contains('7');
 
-      cy.route('POST', 'http://example.com/_search/', 'fixture:updated_elasticsearch.json');
+      fixtureName = 'updated_elasticsearch.json';
 
       cy.get('[data-cy=startDateTime]').within(() => {
         cy.get('input[name=month]').click().type(1);

--- a/cypress/integration/pdrs_spec.js
+++ b/cypress/integration/pdrs_spec.js
@@ -204,8 +204,6 @@ describe('Dashboard PDRs Page', () => {
       cy.get('.table .tbody .tr').as('list');
       cy.get('@list').should('have.length', 2);
 
-      cy.server();
-
       cy.getFakeApiFixture('granules').its('results')
         .then((granules) => granules.filter((item) => item.pdrName === pdrName))
         .each((granule) => {
@@ -223,12 +221,11 @@ describe('Dashboard PDRs Page', () => {
             .should('have.text', `${Number(granule.duration.toFixed(2))}s`);
           cy.get('@columns').eq(5).invoke('text')
             .should('match', /.+ago$/);
-
-          cy.route('DELETE', `/granules/${granule.granuleId}`).as('deleteGranule');
+          cy.intercept('DELETE', `/granules/${granule.granuleId}`).as(`deleteGranule${granule.granuleId}`);
           cy.get(`[data-value="${granule.granuleId}"] > .td >input[type="checkbox"]`).check();
           cy.get('.list-actions').contains('Delete').click();
           cy.get('.button--submit').click();
-          cy.wait('@deleteGranule');
+          cy.wait(`@deleteGranule${granule.granuleId}`);
           cy.get('.button--cancel').click();
         });
 

--- a/cypress/integration/providers_spec.js
+++ b/cypress/integration/providers_spec.js
@@ -22,10 +22,9 @@ describe('Dashboard Providers Page', () => {
       cy.login();
       cy.task('resetState');
       cy.visit('/');
-      cy.server();
-      cy.route('POST', '/providers').as('postProvider');
-      cy.route('GET', '/providers?limit=*').as('getProviders');
-      cy.route('GET', '/providers/*').as('getProvider');
+      cy.intercept('POST', '/providers').as('postProvider');
+      cy.intercept('GET', '/providers?limit=*').as('getProviders');
+      cy.intercept('GET', '/providers/*').as('getProvider');
     });
 
     it('should display a link to view providers', () => {

--- a/cypress/integration/reconciliation_spec.js
+++ b/cypress/integration/reconciliation_spec.js
@@ -137,7 +137,7 @@ describe('Dashboard Reconciliation Reports Page', () => {
         url: '/reconciliationReports',
         method: 'POST'
       }, (req) => {
-        const requestBody = JSON.parse(req.body);
+        const requestBody = req.body;
         expect(requestBody).to.have.property('reportType', reportType);
         expect(requestBody).to.have.property('reportName', reportName);
         expect(requestBody).to.have.property('startTimestamp', startTimestamp);
@@ -209,7 +209,7 @@ describe('Dashboard Reconciliation Reports Page', () => {
 
           cy.contains('.table .th', filterLabel).should('be.visible');
           cy.contains('.table__filters--filter label', filterLabel).prev().click();
-          cy.contains('.table .th', filterLabel).should('not.be.visible');
+          cy.contains('.table .th', filterLabel).should('not.exist');
 
           cy.get('.table__filters .button__filter').click();
           cy.contains('.table__filters .button__filter', 'Show Column Filters');

--- a/cypress/integration/reconciliation_spec.js
+++ b/cypress/integration/reconciliation_spec.js
@@ -133,7 +133,7 @@ describe('Dashboard Reconciliation Reports Page', () => {
 
       cy.get(`form .form__item .location input[value="${location}"]`).check();
 
-      cy.route2({
+      cy.intercept({
         url: '/reconciliationReports',
         method: 'POST'
       }, (req) => {

--- a/cypress/integration/reconciliation_spec.js
+++ b/cypress/integration/reconciliation_spec.js
@@ -137,13 +137,13 @@ describe('Dashboard Reconciliation Reports Page', () => {
         url: '/reconciliationReports',
         method: 'POST'
       }, (req) => {
-        const requestBody = req.body;
-        expect(requestBody).to.have.property('reportType', reportType);
-        expect(requestBody).to.have.property('reportName', reportName);
-        expect(requestBody).to.have.property('startTimestamp', startTimestamp);
-        expect(requestBody).to.have.property('endTimestamp', endTimestamp);
-        expect(requestBody).to.have.deep.property('collectionId', collectionId);
-        expect(requestBody).to.have.property('location', location);
+        const { body } = req;
+        expect(body).to.have.property('reportType', reportType);
+        expect(body).to.have.property('reportName', reportName);
+        expect(body).to.have.property('startTimestamp', startTimestamp);
+        expect(body).to.have.property('endTimestamp', endTimestamp);
+        expect(body).to.have.deep.property('collectionId', collectionId);
+        expect(body).to.have.property('location', location);
       }).as('createReport');
 
       cy.get('.button--submit').click();

--- a/cypress/integration/rules_spec.js
+++ b/cypress/integration/rules_spec.js
@@ -285,8 +285,7 @@ describe('Rules page', () => {
     });
 
     it('deleting a rule should remove it from the list', () => {
-      cy.server();
-      cy.route('DELETE', '/rules/MOD09GK_TEST_kinesisRule').as('deleteRule');
+      cy.intercept('DELETE', '/rules/MOD09GK_TEST_kinesisRule').as('deleteRule');
       cy.visit('/rules');
       cy.contains('.table .tr', testRuleName)
         .within(() => {
@@ -307,8 +306,7 @@ describe('Rules page', () => {
     });
 
     it('Should trigger workflow when a rule is rerun', () => {
-      cy.server();
-      cy.route('PUT', '/rules/MOD09GK_TEST_kinesisRule', 'fixtures:rule-success.json').as('putRule');
+      cy.intercept('PUT', '/rules/MOD09GK_TEST_kinesisRule', { fixtures: 'rule-success.json' }).as('putRule');
       cy.visit('/rules/rule/MOD09GK_TEST_kinesisRule');
       cy.get('.dropdown__options__btn').click();
       cy.get('.dropdown__menu').contains('Rerun').click();
@@ -319,13 +317,10 @@ describe('Rules page', () => {
     });
 
     it('Should display error when a rule fails to rerun.', () => {
-      cy.server();
-      cy.route({
-        method: 'PUT',
-        url: '/rules/MOD09GK_TEST_kinesisRule',
-        status: 503,
-        response: 'fixture:rule-error.json'
-      }).as('putRule');
+      cy.intercept(
+        { method: 'PUT', url: '/rules/MOD09GK_TEST_kinesisRule' },
+        { fixture: 'rule-error.json', statusCode: 503 }
+      ).as('putRule');
       cy.visit('/rules/rule/MOD09GK_TEST_kinesisRule');
       cy.get('.dropdown__options__btn').click();
       cy.get('.dropdown__menu').contains('Rerun').click();

--- a/cypress/integration/workflows_spec.js
+++ b/cypress/integration/workflows_spec.js
@@ -59,8 +59,7 @@ describe('Dashboard Workflows Page', () => {
     });
 
     it('filters workflows when a user types in the search box', () => {
-      cy.server();
-      cy.route('GET', '/workflows*').as('get-workflows');
+      cy.intercept('GET', '/workflows*').as('get-workflows');
       cy.visit('/workflows');
       cy.get('.table .tbody .tr').should('have.length', 2);
       cy.get('.table .tbody .tr').first().contains('HelloWorldWorkflow');

--- a/localAPI/docker-compose-cypress.yml
+++ b/localAPI/docker-compose-cypress.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
   e2e:
     # must be run in conjunction with the docker-compose stack.
-    image: cypress/included:5.5.0
+    image: cypress/included:6.2.1
     network_mode: "service:shim"
     entrypoint: [ "./localAPI/wait-for-dashboard.sh", "npm", "run", "cypress-ci"]
     working_dir:

--- a/package-lock.json
+++ b/package-lock.json
@@ -7776,12 +7776,6 @@
           "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "optional": true
         },
-        "colors": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
-          "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
-          "optional": true
-        },
         "is-fullwidth-code-point": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -8054,6 +8048,12 @@
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.1.tgz",
       "integrity": "sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==",
       "dev": true
+    },
+    "colors": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+      "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==",
+      "optional": true
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -9058,9 +9058,9 @@
       "dev": true
     },
     "cypress": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-5.5.0.tgz",
-      "integrity": "sha512-UHEiTca8AUTevbT2pWkHQlxoHtXmbq+h6Eiu/Mz8DqpNkF98zjTBLv/HFiKJUU5rQzp9EwSWtms33p5TWCJ8tQ==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-6.2.1.tgz",
+      "integrity": "sha512-OYkSgzA4J4Q7eMjZvNf5qWpBLR4RXrkqjL3UZ1UzGGLAskO0nFTi/RomNTG6TKvL3Zp4tw4zFY1gp5MtmkCZrA==",
       "optional": true,
       "requires": {
         "@cypress/listr-verbose-renderer": "^0.4.1",
@@ -9075,7 +9075,7 @@
         "chalk": "^4.1.0",
         "check-more-types": "^2.24.0",
         "cli-table3": "~0.6.0",
-        "commander": "^4.1.1",
+        "commander": "^5.1.0",
         "common-tags": "^1.8.0",
         "debug": "^4.1.1",
         "eventemitter2": "^6.4.2",
@@ -9144,9 +9144,9 @@
           "optional": true
         },
         "commander": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
+          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
           "optional": true
         },
         "cross-spawn": {
@@ -9161,9 +9161,9 @@
           }
         },
         "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "optional": true,
           "requires": {
             "ms": "2.1.2"
@@ -18871,9 +18871,9 @@
       "dev": true
     },
     "pretty-bytes": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.4.1.tgz",
-      "integrity": "sha512-s1Iam6Gwz3JI5Hweaz4GoCD1WUNUIyzePFy5+Js2hjwGVt2Z79wNN+ZKOZ2vB6C+Xs6njyB84Z1IthQg8d9LxA==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.5.0.tgz",
+      "integrity": "sha512-p+T744ZyjjiaFlMUZZv6YPC5JrkNj8maRmPaQCWFJFplUAzpIUTRaTcS+7wmZtUoFXHtESJb23ISliaWyz3SHA==",
       "optional": true
     },
     "pretty-error": {

--- a/package.json
+++ b/package.json
@@ -203,6 +203,6 @@
     "url": "^0.11.0"
   },
   "optionalDependencies": {
-    "cypress": "^6.2.1"
+    "cypress": "6.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -203,6 +203,6 @@
     "url": "^0.11.0"
   },
   "optionalDependencies": {
-    "cypress": "5.5.0"
+    "cypress": "^6.2.1"
   }
 }


### PR DESCRIPTION

Addresses [CUMULUS-2325: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2325)

## Changes

* Migration to specs that upgrade Cypress tests to use 6.2.1
* Main changes is to replace `cy.route` & `cy.server` with `cy.intercept`.
* Followed the Migration Guide https://docs.cypress.io/guides/references/migration-guide.html#Migrating-cy-route-to-cy-intercept 


## PR Checklist

- [X] Update CHANGELOG
- [X] Unit tests
- [X] Adhoc testing
- [X] Integration tests