### PR TITLE
[CUMULUS-2176] Update GNF Report Styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Update status on execution details page to be displayed as a badge
   - Other styling tweaks on execution details page
 
+- **CUMULUS-2176**
+  - Update styles for Granule Not Found Reports
+  - Add tooltips to indicators on GNF reports
+
 - **CUMULUS-2242**
   - Changes underlying Docker files for building dashboard bundle and dashboard image via docker.  The user interface remains the same.
 

--- a/app/src/css/_base.scss
+++ b/app/src/css/_base.scss
@@ -441,6 +441,12 @@ a:active {
   margin-bottom: 1em;
 }
 
+.page__section__header--shared-content {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
 .page_section.metrics--overview .heading__wrapper--border {
   margin-top: 0em;
 }

--- a/app/src/css/_buttons.scss
+++ b/app/src/css/_buttons.scss
@@ -647,7 +647,6 @@ $delete-btn-hover-bg-color: darken($error-red, 10%);
 
     &__filter {
       background-color: $light-green;
-      position: relative;
 
       &:before {
         color: $white;
@@ -662,6 +661,10 @@ $delete-btn-hover-bg-color: darken($error-red, 10%);
       &:hover {
         background-color: $light-green;
       }
+    }
+
+    &__legend {
+      background-color: $orange;
     }
 
     &__row {

--- a/app/src/css/_legend.scss
+++ b/app/src/css/_legend.scss
@@ -3,6 +3,8 @@
   padding: 2em;
   border-radius: 4px;
   box-shadow: $shadow__default;
+  margin-top: 1em;
+  font-size: .9em;
 
   &--title {
     font-size: 1.3em;

--- a/app/src/css/_legend.scss
+++ b/app/src/css/_legend.scss
@@ -1,7 +1,6 @@
 .legend {
   background-color: $white;
   padding: 2em;
-  width: 50%;
   border-radius: 4px;
   box-shadow: $shadow__default;
 

--- a/app/src/css/_typography.scss
+++ b/app/src/css/_typography.scss
@@ -35,6 +35,10 @@ h1, h2, h3, h4, h5, h6 {
   font-weight: $base-font-bold;
 }
 
+.heading--date-range {
+  font-size: .8em;
+}
+
 .heading--shared-content {
   display: inline-block;
 }

--- a/app/src/css/_typography.scss
+++ b/app/src/css/_typography.scss
@@ -35,8 +35,8 @@ h1, h2, h3, h4, h5, h6 {
   font-weight: $base-font-bold;
 }
 
-.heading--date-range {
-  font-size: .8em;
+.heading--description {
+  font-size: .86em;
 }
 
 .heading--shared-content {

--- a/app/src/css/modules/_table.scss
+++ b/app/src/css/modules/_table.scss
@@ -140,7 +140,6 @@
   &--filter {
     display: flex;
     align-items: center;
-    width: 20%;
 
     label {
       margin: 0 .5em;

--- a/app/src/css/modules/_table.scss
+++ b/app/src/css/modules/_table.scss
@@ -130,6 +130,7 @@
 .table__filters {
   &--wrapper {
     display: flex;
+    flex-direction: column;
     background: $white;
     padding: 2em;
     margin: 1em 0;

--- a/app/src/css/modules/_table.scss
+++ b/app/src/css/modules/_table.scss
@@ -89,7 +89,7 @@
     align-items: center;
   }
 
-  .filter__item {
+  .list__filters--item {
     margin: 0 .3em;
   }
 
@@ -109,12 +109,25 @@
   text-align: right;
 }
 
-.table__filters {
-
-  .button__filter {
-    margin-bottom: 1em;
+.list__filters {
+  margin: 1.5em 0 2em;
+  @extend .clearfix;
+  label {
+    font-size: .86em;
   }
 
+  &--flex {
+    display: flex;
+  }
+
+  &--item {
+    display: inline-block;
+    vertical-align: bottom;
+    position: relative;
+  }
+}
+
+.table__filters {
   &--wrapper {
     display: flex;
     background: $white;

--- a/app/src/js/components/DropDown/dropdown.js
+++ b/app/src/js/components/DropDown/dropdown.js
@@ -118,7 +118,7 @@ const Dropdown = ({
   }
 
   return (
-    <div className={`filter__item form-group__element filter-${paramKey.includes('.') ? paramKey.split('.')[0] : paramKey}`}>
+    <div className={`list__filters--item form-group__element filter-${paramKey.includes('.') ? paramKey.split('.')[0] : paramKey}`}>
       {label && <label htmlFor={paramKey}>{label}</label>}
       <Typeahead
         allowNew={allowNew}

--- a/app/src/js/components/Executions/execution-events.js
+++ b/app/src/js/components/Executions/execution-events.js
@@ -20,6 +20,7 @@ import Search from '../Search/search';
 
 import { getEventDetails } from './execution-graph-utils';
 import SortableTable from '../SortableTable/SortableTable';
+import ListFilters from '../ListActions/ListFilters';
 
 const ExecutionEvents = ({
   dispatch,
@@ -97,7 +98,7 @@ const ExecutionEvents = ({
               target='_blank'
             ><FontAwesomeIcon icon={faExternalLinkSquareAlt} /> View Workflows</a>
           </div>
-          <div className='filters'>
+          <ListFilters>
             <Search
               action={searchExecutionEvents}
               clear={clearExecutionEventsSearch}
@@ -109,7 +110,7 @@ const ExecutionEvents = ({
               placeholder="Search Type"
               searchKey="executions"
             />
-          </div>
+          </ListFilters>
 
           <SortableTable
             data={mutableEvents.sort((a, b) => (a.id > b.id ? 1 : -1))}

--- a/app/src/js/components/Form/_form.scss
+++ b/app/src/js/components/Form/_form.scss
@@ -62,62 +62,6 @@ select option{
     background-color: $ocean-blue;
     box-shadow: inset 2px 2px $ocean-blue;
     color: $white;
-}
-}
-
-
-.filters {
-  margin: 1.5em 0 2em;
-  @extend .clearfix;
-  label {
-    font-size: .86em;
-  }
-}
-
-.filter__item {
-  display: inline-block;
-  vertical-align: bottom;
-  position: relative;
-}
-
-.filter__icon{
-  &:after {
-    color: $ocean-blue;
-    position: absolute;
-    font-family: 'FontAwesome';
-    content: '\f0d7';
-    font-weight: 900;
-    width: 14px;
-    height: 14px;
-    background-size: 14px 14px;
-    display: block;
-    right: .8em;
-    top: .5em;
-  }
-}
-
-.filters.filters__wlabels ul{
-  display: flex;
-  align-items: baseline;
-}
-
-.filters.filters__wlabels .run_bulk{
-  margin-left: auto;
-}
-
-.filter-action-wrapper {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: flex-end;
-}
-
-.filter-actions {
-  display: flex;
-  justify-content: space-around;
-  flex-grow: 1;
-
-  .form--controls {
-    flex-grow: 1;
   }
 }
 

--- a/app/src/js/components/ListActions/ListFilters.js
+++ b/app/src/js/components/ListActions/ListFilters.js
@@ -5,7 +5,7 @@ const ListFilters = ({
   children,
   className = ''
 }) => (
-  <div className={`filters ${className}`} >
+  <div className={`list__filters ${className}`} >
     {children}
   </div>
 );

--- a/app/src/js/components/ReconciliationReports/gnf-report.js
+++ b/app/src/js/components/ReconciliationReports/gnf-report.js
@@ -15,6 +15,7 @@ import { getCollectionId } from '../../utils/format';
 
 const GnfReport = ({
   filterString,
+  legend,
   recordData,
   reportName,
 }) => {
@@ -71,9 +72,10 @@ const GnfReport = ({
   }
 
   function calculateMissingGranules(totalMissing, currentGranuleData) {
-    const missingS3 = currentGranuleData.s3 === 'notFound' || currentGranuleData.s3 === false ? 1 : 0;
-    const missingCumulus = currentGranuleData.cumulus === 'notFound' || currentGranuleData.cumulus === false ? 1 : 0;
-    const missingCmr = currentGranuleData.cmr === 'notFound' || currentGranuleData.cmr === false ? 1 : 0;
+    const { s3, cumulus, cmr } = currentGranuleData;
+    const missingS3 = s3 === false || (typeof s3 === 'string' && s3.match(/^(notFound|missing)$/)) ? 1 : 0;
+    const missingCumulus = cumulus === false || (typeof cumulus === 'string' && cumulus.match(/^(notFound|missing)$/)) ? 1 : 0;
+    const missingCmr = cmr === false || (typeof cmr === 'string' && cmr.match(/^(notFound|missing)$/)) ? 1 : 0;
 
     return totalMissing + missingS3 + missingCumulus + missingCmr;
   }
@@ -88,24 +90,24 @@ const GnfReport = ({
 
   return (
     <div className="page__component">
-      <div className="heading__wrapper">
-        <ReportHeading
-          endTime={createEndTime}
-          error={error}
-          name={reportName}
-          onDownloadClick={handleDownloadClick}
-          reportState={reportState}
-          startTime={createStartTime}
-          type='Granule Not Found'
-        />
-      </div>
+      <ReportHeading
+        conflictComparisons={totalMissingGranules}
+        endTime={createEndTime}
+        error={error}
+        name={reportName}
+        onDownloadClick={handleDownloadClick}
+        reportState={reportState}
+        startTime={createStartTime}
+        type='Granule Not Found'
+      />
       <section className="page__section">
-        <div className="title-count">
-          <h2 className="heading--medium heading--shared-content with-description">
-            Granules Not Found <span className="num-title">{totalMissingGranules}</span>
-          </h2>
-        </div>
-        <div className="filters">
+        <SortableTable
+          data={combinedGranules}
+          tableColumns={tableColumnsGnf}
+          shouldUsePagination={true}
+          initialHiddenColumns={['']}
+          legend={legend}
+        >
           <Search
             action={searchReconciliationReport}
             clear={clearReconciliationSearch}
@@ -117,14 +119,7 @@ const GnfReport = ({
             options={combinedGranules}
             placeholder="Search"
           />
-        </div>
-
-        <SortableTable
-          data={combinedGranules}
-          tableColumns={tableColumnsGnf}
-          shouldUsePagination={true}
-          initialHiddenColumns={['']}
-        />
+        </SortableTable>
       </section>
     </div>
   );
@@ -132,6 +127,7 @@ const GnfReport = ({
 
 GnfReport.propTypes = {
   filterString: PropTypes.string,
+  legend: PropTypes.node,
   recordData: PropTypes.object,
   reportName: PropTypes.string,
 };

--- a/app/src/js/components/ReconciliationReports/gnf-report.js
+++ b/app/src/js/components/ReconciliationReports/gnf-report.js
@@ -82,8 +82,6 @@ const GnfReport = ({
 
   const totalMissingGranules = combinedGranules.reduce(calculateMissingGranules, 0);
 
-  const reportState = combinedGranules.length > 0 ? 'CONFLICT' : 'PASSED';
-
   function handleDownloadClick(e) {
     handleDownloadJsonClick(e, { data: recordData, reportName });
   }
@@ -96,7 +94,6 @@ const GnfReport = ({
         error={error}
         name={reportName}
         onDownloadClick={handleDownloadClick}
-        reportState={reportState}
         startTime={createStartTime}
         type='Granule Not Found'
       />

--- a/app/src/js/components/ReconciliationReports/gnf-report.js
+++ b/app/src/js/components/ReconciliationReports/gnf-report.js
@@ -101,13 +101,7 @@ const GnfReport = ({
         type='Granule Not Found'
       />
       <section className="page__section">
-        <SortableTable
-          data={combinedGranules}
-          tableColumns={tableColumnsGnf}
-          shouldUsePagination={true}
-          initialHiddenColumns={['']}
-          legend={legend}
-        >
+        <div className="list-action-wrapper">
           <Search
             action={searchReconciliationReport}
             clear={clearReconciliationSearch}
@@ -116,7 +110,14 @@ const GnfReport = ({
             options={combinedGranules}
             placeholder="Search"
           />
-        </SortableTable>
+        </div>
+        <SortableTable
+          data={combinedGranules}
+          tableColumns={tableColumnsGnf}
+          shouldUsePagination={true}
+          initialHiddenColumns={['']}
+          legend={legend}
+        />
       </section>
     </div>
   );

--- a/app/src/js/components/ReconciliationReports/index.js
+++ b/app/src/js/components/ReconciliationReports/index.js
@@ -11,7 +11,6 @@ import CreateReconciliationReport from './create';
 import ReconciliationReportList from './list';
 import ReconciliationReport from './reconciliation-report';
 import DatePickerHeader from '../DatePickerHeader/DatePickerHeader';
-import Legend from './legend';
 import { filterQueryParams } from '../../utils/url-helper';
 
 const ReconciliationReports = ({
@@ -53,13 +52,6 @@ const ReconciliationReports = ({
               <Route path="/reconciliation-reports/create" component={CreateReconciliationReport} />
               <Route path='/reconciliation-reports/report/:reconciliationReportName' component={ReconciliationReport} />
             </Switch>
-            {showSidebar
-              ? (
-                <section className='page__section'>
-                  <Legend />
-                </section>
-              )
-              : null}
           </div>
         </div>
       </div>

--- a/app/src/js/components/ReconciliationReports/inventory-report.js
+++ b/app/src/js/components/ReconciliationReports/inventory-report.js
@@ -19,15 +19,6 @@ import Dropdown from '../DropDown/dropdown';
 import ReportHeading from './report-heading';
 import ListFilters from '../ListActions/ListFilters';
 
-/**
- * returns PASSED or CONFLICT based on reconcilation report data.
- * @param {Object} dataList - list of reconcilation report objects.
- */
-const reportState = (dataList) => {
-  const anyBad = dataList.some((item) => item.tables.some((table) => table.data.length));
-  return anyBad ? 'CONFLICT' : 'PASSED';
-};
-
 const bucketsForFilter = (allBuckets) => {
   const uniqueBuckets = [...new Set(allBuckets)];
   return uniqueBuckets.map((bucket) => ({
@@ -52,7 +43,6 @@ const InventoryReport = ({
     allBuckets,
   } = reshapeReport(recordData, filterString, filterBucket);
   const reportComparisons = [...internalComparison, ...cumulusVsCmrComparison];
-  const theReportState = reportState(reportComparisons);
   const activeCardTables = reportComparisons.find(
     (displayObj) => displayObj.id === activeId
   ).tables;
@@ -123,7 +113,6 @@ const InventoryReport = ({
         endTime={reportEndTime}
         error={error}
         name={reportName}
-        reportState={theReportState}
         startTime={reportStartTime}
         type='Inventory'
       />

--- a/app/src/js/components/ReconciliationReports/inventory-report.js
+++ b/app/src/js/components/ReconciliationReports/inventory-report.js
@@ -39,6 +39,7 @@ const bucketsForFilter = (allBuckets) => {
 const InventoryReport = ({
   filterBucket,
   filterString,
+  legend,
   recordData,
   reportName,
 }) => {
@@ -217,6 +218,7 @@ const InventoryReport = ({
                     <div id={item.id}>
                       <SortableTable
                         data={item.data}
+                        legend={legend}
                         tableColumns={item.columns}
                         shouldUsePagination={true}
                         initialHiddenColumns={['']}
@@ -235,6 +237,7 @@ const InventoryReport = ({
 InventoryReport.propTypes = {
   filterBucket: PropTypes.string,
   filterString: PropTypes.string,
+  legend: PropTypes.node,
   recordData: PropTypes.object,
   reportName: PropTypes.string,
 };

--- a/app/src/js/components/ReconciliationReports/legend.js
+++ b/app/src/js/components/ReconciliationReports/legend.js
@@ -1,15 +1,42 @@
-import React from 'react';
+import React, { useState } from 'react';
+import { Collapse } from 'react-bootstrap';
 
-const Legend = () => (
-  <div className='legend'>
-    <h3 className='legend--title'>Legend</h3>
-    <p>When reviewing the reports, you may see the following indicators:</p>
-    <ul className='legend-items'>
-      <li className='legend-items--item'><span className='status-indicator status-indicator--failed'></span>Granule not found</li>
-      <li className='legend-items--item'><span className='status-indicator status-indicator--orange'></span>Missing image file</li>
-      <li className='legend-items--item'><span className='status-indicator status-indicator--success'></span>No issues/conflicts</li>
-    </ul>
-  </div>
-);
+const Legend = () => {
+  const [legendExpanded, setLegendExpanded] = useState(false);
+  return (
+    <div className="table__legend">
+      <div className="label">Table Legend</div>
+      <button
+        aria-expanded={legendExpanded}
+        aria-controls="table__legend--collapse"
+        className="button button--small button--no-left-padding button__legend"
+        onClick={() => setLegendExpanded(!legendExpanded)}
+      >
+        {`${legendExpanded ? 'Hide' : 'Show'} Table Legend`}
+      </button>
+      <Collapse in={legendExpanded}>
+        <div className="legend">
+          <p>
+            When reviewing the reports, you may see the following indicators:
+          </p>
+          <ul className="legend-items">
+            <li className="legend-items--item">
+              <span className="status-indicator status-indicator--failed"></span>
+              Granule not found
+            </li>
+            <li className="legend-items--item">
+              <span className="status-indicator status-indicator--orange"></span>
+              Missing image file
+            </li>
+            <li className="legend-items--item">
+              <span className="status-indicator status-indicator--success"></span>
+              No issues/conflicts
+            </li>
+          </ul>
+        </div>
+      </Collapse>
+    </div>
+  );
+};
 
 export default Legend;

--- a/app/src/js/components/ReconciliationReports/reconciliation-report.js
+++ b/app/src/js/components/ReconciliationReports/reconciliation-report.js
@@ -6,6 +6,7 @@ import { getReconciliationReport } from '../../actions';
 import Loading from '../LoadingIndicator/loading-indicator';
 import InventoryReport from './inventory-report';
 import GnfReport from './gnf-report';
+import Legend from './legend';
 
 const ReconciliationReport = ({
   dispatch,
@@ -39,6 +40,7 @@ const ReconciliationReport = ({
           />,
           'Granule Not Found': <GnfReport
             filterString={filterString}
+            legend={<Legend />}
             recordData={recordData}
             reportName={reconciliationReportName}
           />

--- a/app/src/js/components/ReconciliationReports/reconciliation-report.js
+++ b/app/src/js/components/ReconciliationReports/reconciliation-report.js
@@ -47,7 +47,6 @@ const ReconciliationReport = ({
           />
         }[reportType]
       }
-
     </>
   );
 };

--- a/app/src/js/components/ReconciliationReports/reconciliation-report.js
+++ b/app/src/js/components/ReconciliationReports/reconciliation-report.js
@@ -35,6 +35,7 @@ const ReconciliationReport = ({
           Inventory: <InventoryReport
             filterBucket={filterBucket}
             filterString={filterString}
+            legend={<Legend />}
             recordData={recordData}
             reportName={reconciliationReportName}
           />,

--- a/app/src/js/components/ReconciliationReports/report-heading.js
+++ b/app/src/js/components/ReconciliationReports/report-heading.js
@@ -64,7 +64,7 @@ const ReportHeading = ({
             {formattedStartTime} to {formattedEndTime}
           </div>
         </div>
-        <div div className="heading--shared-content">
+        <div className="heading--shared-content">
           {conflictComparisons && (
             <h2 className="heading--medium heading--shared-content">
               Total Conflict Comparisons

--- a/app/src/js/components/ReconciliationReports/report-heading.js
+++ b/app/src/js/components/ReconciliationReports/report-heading.js
@@ -17,7 +17,6 @@ const ReportHeading = ({
   error,
   name,
   onDownloadClick,
-  reportState,
   startTime,
   type,
 }) => {
@@ -56,24 +55,33 @@ const ReportHeading = ({
       </section>
       <section className="page__section page__section__header-wrapper">
         <div className="page__section__header page__section__header--shared-content heading__wrapper--border">
-          <h1 className="heading--large with-description">
-            {type && `${type} Report: `}{name}
+          <h1 className="heading--large">
+            {type && `${type} Report: `}
+            {name}
           </h1>
-          <div className="heading--date-range">
-            <span className="font-weight-bold">Date Range:</span> {formattedStartTime} to {formattedEndTime}
-            {/* <dt>State:</dt>
-              <dd
-                className={`status__badge status__badge--${
-                  reportState === 'PASSED' ? 'passed' : 'conflict'
-                }`}
-              >
-                {reportState}
-              </dd> */}
+          <div className="heading--description">
+            <span className="font-weight-bold">Date Range:</span>{' '}
+            {formattedStartTime} to {formattedEndTime}
           </div>
         </div>
-        {conflictComparisons && <h2 className="heading--medium heading--shared-content with-description">
-          Total Conflict Comparisons <span className="num-title">{conflictComparisons}</span>
-        </h2>}
+        <div div className="heading--shared-content">
+          {conflictComparisons && (
+            <h2 className="heading--medium heading--shared-content">
+              Total Conflict Comparisons
+              <span className="num-title">{conflictComparisons}</span>
+            </h2>
+          )}
+          <div className="heading--description">
+            {
+              {
+                Inventory:
+                  'The reports below compare datasets and display the conflicts in each data location.',
+                'Granule Not Found':
+                  'The report below shows a comparison across each data bucket/repository for granule issues.',
+              }[type]
+            }
+          </div>
+        </div>
         {downloadOptions && (
           <DropdownBootstrap className="form-group__element--right">
             <DropdownBootstrap.Toggle
@@ -127,7 +135,6 @@ ReportHeading.propTypes = {
    * Create button for single download
    */
   onDownloadClick: PropTypes.func,
-  reportState: PropTypes.string,
   startTime: PropTypes.string,
   type: PropTypes.string,
 };

--- a/app/src/js/components/ReconciliationReports/report-heading.js
+++ b/app/src/js/components/ReconciliationReports/report-heading.js
@@ -12,6 +12,7 @@ import ErrorReport from '../Errors/report';
 
 const ReportHeading = ({
   downloadOptions,
+  conflictComparisons,
   endTime,
   error,
   name,
@@ -36,11 +37,11 @@ const ReportHeading = ({
   ];
 
   const formattedStartTime = startTime
-    ? moment(startTime).utc().format('YYYY-MM-DD H:mm:ss UTC')
+    ? moment(startTime).utc().format('YYYY-MM-DD H:mm:ss')
     : 'missing';
 
   const formattedEndTime = endTime
-    ? moment(endTime).utc().format('YYYY-MM-DD H:mm:ss UTC')
+    ? moment(endTime).utc().format('YYYY-MM-DD H:mm:ss')
     : 'missing';
   return (
     <>
@@ -54,63 +55,62 @@ const ReportHeading = ({
         </div>
       </section>
       <section className="page__section page__section__header-wrapper">
-        <div className="page__section__header">
-          <div>
-            <h1 className="heading--large heading--shared-content with-description ">
-              {type && `${type} Report: `}{name}
-            </h1>
-          </div>
-          <div className="status--process">
-            <dl className="status--process--report">
-              <dt>Date Range:</dt>
-              <dd>{`${formattedStartTime} to ${formattedEndTime}`}</dd>
-              <dt>State:</dt>
+        <div className="page__section__header page__section__header--shared-content heading__wrapper--border">
+          <h1 className="heading--large with-description">
+            {type && `${type} Report: `}{name}
+          </h1>
+          <div className="heading--date-range">
+            <span className="font-weight-bold">Date Range:</span> {formattedStartTime} to {formattedEndTime}
+            {/* <dt>State:</dt>
               <dd
                 className={`status__badge status__badge--${
                   reportState === 'PASSED' ? 'passed' : 'conflict'
                 }`}
               >
                 {reportState}
-              </dd>
-            </dl>
-            {downloadOptions && (
-              <DropdownBootstrap className="form-group__element--right">
-                <DropdownBootstrap.Toggle
-                  className="button button--small button--download"
-                  id="download-report-dropdown"
-                >
-                  Download Report
-                </DropdownBootstrap.Toggle>
-                <DropdownBootstrap.Menu>
-                  {downloadOptions.map(({ label, onClick }, index) => (
-                    <DropdownBootstrap.Item
-                      key={index}
-                      as="button"
-                      onClick={onClick}
-                    >
-                      {label}
-                    </DropdownBootstrap.Item>
-                  ))}
-                </DropdownBootstrap.Menu>
-              </DropdownBootstrap>
-            )}
-            {onDownloadClick && (
-              <button
-                className="form-group__element--right button button--small button--download"
-                onClick={onDownloadClick}
-              >
-                Download Report
-              </button>
-            )}
+              </dd> */}
           </div>
-          {error && <ErrorReport report={error} />}
         </div>
+        {conflictComparisons && <h2 className="heading--medium heading--shared-content with-description">
+          Total Conflict Comparisons <span className="num-title">{conflictComparisons}</span>
+        </h2>}
+        {downloadOptions && (
+          <DropdownBootstrap className="form-group__element--right">
+            <DropdownBootstrap.Toggle
+              className="button button--small button--download"
+              id="download-report-dropdown"
+            >
+              Download Report
+            </DropdownBootstrap.Toggle>
+            <DropdownBootstrap.Menu>
+              {downloadOptions.map(({ label, onClick }, index) => (
+                <DropdownBootstrap.Item
+                  key={index}
+                  as="button"
+                  onClick={onClick}
+                >
+                  {label}
+                </DropdownBootstrap.Item>
+              ))}
+            </DropdownBootstrap.Menu>
+          </DropdownBootstrap>
+        )}
+        {onDownloadClick && (
+          <button
+            className="form-group__element--right button button--small button--download"
+            onClick={onDownloadClick}
+          >
+            Download Report
+          </button>
+        )}
+        {error && <ErrorReport report={error} />}
       </section>
     </>
   );
 };
 
 ReportHeading.propTypes = {
+  conflictComparisons: PropTypes.number,
   /**
    * Create dropdown for downloading multiple tables using these options
    */

--- a/app/src/js/components/Search/search.js
+++ b/app/src/js/components/Search/search.js
@@ -87,7 +87,7 @@ const Search = ({
   }
 
   return (
-    <div className="filter__item">
+    <div className="list__filters--item">
       {label && <label htmlFor="search" form={formID}>{label}</label>}
       <form className="search__wrapper form-group__element">
         <AsyncTypeahead

--- a/app/src/js/components/SortableTable/SortableTable.js
+++ b/app/src/js/components/SortableTable/SortableTable.js
@@ -181,26 +181,16 @@ const SortableTable = ({
     onMouseDown(e);
   }
 
-  function renderFilters() {
-    const tableFilters =
-    <>{includeFilters &&
-      <TableFilters columns={tableColumns} onChange={toggleHideColumn} hiddenColumns={hiddenColumns} />
-    }</>;
-    if (children || legend) {
-      return (
-        <ListFilters className="list__filters--flex">
-          {children}
-          {tableFilters}
-          {legend}
-        </ListFilters>
-      );
-    }
-    return tableFilters;
-  }
-
   return (
     <div className='table--wrapper'>
-      {renderFilters()}
+      {(includeFilters || legend) &&
+        <ListFilters className="list__filters--flex">
+          {includeFilters &&
+            <TableFilters columns={tableColumns} onChange={toggleHideColumn} hiddenColumns={hiddenColumns} />
+          }
+          {legend}
+        </ListFilters>
+      }
       <div className='table' {...getTableProps()}>
         <div className='thead'>
           <div className='tr'>

--- a/app/src/js/components/SortableTable/SortableTable.js
+++ b/app/src/js/components/SortableTable/SortableTable.js
@@ -11,6 +11,7 @@ import omit from 'lodash/omit';
 import { useTable, useResizeColumns, useFlexLayout, useSortBy, useRowSelect, usePagination } from 'react-table';
 import SimplePagination from '../Pagination/simple-pagination';
 import TableFilters from '../Table/TableFilters';
+import ListFilters from '../ListActions/ListFilters';
 
 const getColumnWidth = (rows, accessor, headerText, originalWidth) => {
   const maxWidth = 400;
@@ -52,10 +53,12 @@ IndeterminateCheckbox.propTypes = {
 const SortableTable = ({
   canSelect,
   changeSortProps,
+  children,
   clearSelected,
   data = [],
   initialHiddenColumns = [],
   initialSortId,
+  legend,
   onSelect,
   rowId,
   shouldManualSort = false,
@@ -178,11 +181,26 @@ const SortableTable = ({
     onMouseDown(e);
   }
 
+  function renderFilters() {
+    const tableFilters =
+    <>{includeFilters &&
+      <TableFilters columns={tableColumns} onChange={toggleHideColumn} hiddenColumns={hiddenColumns} />
+    }</>;
+    if (children || legend) {
+      return (
+        <ListFilters className="list__filters--flex">
+          {children}
+          {tableFilters}
+          {legend}
+        </ListFilters>
+      );
+    }
+    return tableFilters;
+  }
+
   return (
     <div className='table--wrapper'>
-      {includeFilters &&
-        <TableFilters columns={tableColumns} onChange={toggleHideColumn} hiddenColumns={hiddenColumns} />
-      }
+      {renderFilters()}
       <div className='table' {...getTableProps()}>
         <div className='thead'>
           <div className='tr'>
@@ -294,10 +312,12 @@ const SortableTable = ({
 SortableTable.propTypes = {
   canSelect: PropTypes.bool,
   changeSortProps: PropTypes.func,
+  children: PropTypes.node,
   clearSelected: PropTypes.bool,
   data: PropTypes.array,
   initialHiddenColumns: PropTypes.array,
   initialSortId: PropTypes.string,
+  legend: PropTypes.node,
   onSelect: PropTypes.func,
   rowId: PropTypes.any,
   shouldManualSort: PropTypes.bool,

--- a/app/src/js/components/Table/TableFilters.js
+++ b/app/src/js/components/Table/TableFilters.js
@@ -2,40 +2,41 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Collapse } from 'react-bootstrap';
 
-const TableFilters = ({
-  columns,
-  onChange,
-  hiddenColumns = []
-}) => {
+const TableFilters = ({ columns, onChange, hiddenColumns = [] }) => {
   const [filtersExpanded, setFiltersExpanded] = useState(false);
 
-  function handleChange (id) {
+  function handleChange(id) {
     if (typeof onChange === 'function') {
       onChange(id);
     }
   }
 
   return (
-    <div className='table__filters'>
+    <div className="table__filters form-group__element">
+      <div className="label">Column Filters</div>
       <button
         aria-expanded={filtersExpanded}
         aria-controls="table__filters--collapse"
-        className='button button--small button__filter'
+        className="button button--small button__filter"
         onClick={() => setFiltersExpanded(!filtersExpanded)}
       >
         {`${filtersExpanded ? 'Hide' : 'Show'} Column Filters`}
       </button>
       <Collapse in={filtersExpanded}>
-        <div className='table__filters--collapse'>
-          <h3>Table Column Filters</h3>
-          <div className='table__filters--wrapper'>
+        <div className="table__filters--collapse">
+          <div className="table__filters--wrapper">
             {columns.map((column, index) => {
               const { Header, id, accessor } = column;
               const columnId = id || accessor;
               const isChecked = !hiddenColumns.includes(columnId);
               return (
-                <div className='table__filters--filter' key={index}>
-                  <input id={columnId} type='checkbox' checked={isChecked} onChange={() => handleChange(columnId)} />
+                <div className="table__filters--filter" key={index}>
+                  <input
+                    id={columnId}
+                    type="checkbox"
+                    checked={isChecked}
+                    onChange={() => handleChange(columnId)}
+                  />
                   <label htmlFor={columnId}>{Header}</label>
                 </div>
               );
@@ -50,7 +51,7 @@ const TableFilters = ({
 TableFilters.propTypes = {
   columns: PropTypes.array,
   onChange: PropTypes.func,
-  hiddenColumns: PropTypes.array
+  hiddenColumns: PropTypes.array,
 };
 
 export default TableFilters;

--- a/app/src/js/utils/format.js
+++ b/app/src/js/utils/format.js
@@ -97,6 +97,53 @@ export const fromNowWithTooltip = (timestamp) => (
   />
 );
 
+const getIndicator = (prop) => {
+  const indicator = {};
+  switch (prop) {
+    case 'missing':
+      indicator.color = 'orange';
+      indicator.text = 'Granule missing';
+      break;
+    case 'notFound':
+      indicator.color = 'failed';
+      indicator.text = 'Granule not found';
+      break;
+    case false:
+      indicator.color = 'failed';
+      indicator.text = 'Granule not found';
+      break;
+    default:
+      indicator.color = 'success';
+      indicator.text = 'Granule found';
+      break;
+  }
+  return indicator;
+};
+
+export const IndicatorWithTooltip = ({
+  granuleId,
+  repo,
+  value,
+}) => {
+  const indicator = getIndicator(value);
+  const { color, text } = indicator;
+  return (
+    <Tooltip
+      className="tooltip--blue"
+      id={`${granuleId}-${repo}-indicator-tooltip`}
+      placement="right"
+      target={<span className={`status-indicator status-indicator--${color}`}></span>}
+      tip={text}
+    />
+  );
+};
+
+IndicatorWithTooltip.propTypes = {
+  granuleId: PropTypes.string,
+  repo: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
+};
+
 export const CopyCellPopover = ({ cellContent, id, popoverContent, value }) => {
   const [copyStatus, setCopyStatus] = useState('');
 

--- a/app/src/js/utils/table-config/reconciliation-reports.js
+++ b/app/src/js/utils/table-config/reconciliation-reports.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-import { nullValue, dateOnly, collectionNameVersion } from '../format';
+import { nullValue, dateOnly, collectionNameVersion, IndicatorWithTooltip } from '../format';
 import { getReconciliationReport, deleteReconciliationReport, listReconciliationReports } from '../../actions';
 import { getPersistentQueryParams } from '../url-helper';
 import { downloadFile } from '../download-file';
@@ -183,25 +183,6 @@ export const tableColumnsGranules = [
   }
 ];
 
-const getIndicatorColor = (prop) => {
-  let indicatorColor = '';
-  switch (prop) {
-    case 'missing':
-      indicatorColor = 'orange';
-      break;
-    case 'notFound':
-      indicatorColor = 'failed';
-      break;
-    case false:
-      indicatorColor = 'failed';
-      break;
-    default:
-      indicatorColor = 'success';
-      break;
-  }
-  return indicatorColor;
-};
-
 export const tableColumnsGnf = [
   {
     Header: 'Collection ID',
@@ -224,8 +205,8 @@ export const tableColumnsGnf = [
   {
     Header: 'S3',
     id: 's3',
-    Cell: ({ row: { original: { s3 } } }) => ( // eslint-disable-line react/prop-types
-      <span className={`status-indicator status-indicator--${getIndicatorColor(s3)}`}></span>
+    Cell: ({ row: { original: { s3 }, values: { granuleId } } }) => ( // eslint-disable-line react/prop-types
+      <IndicatorWithTooltip granuleId={granuleId} repo='s3' value={s3} />
     ),
     width: 50,
   },
@@ -236,17 +217,17 @@ export const tableColumnsGnf = [
   // },
   {
     Header: 'Cumulus',
-    id: 'Cumulus',
-    Cell: ({ row: { original: { cumulus } } }) => ( // eslint-disable-line react/prop-types
-      <span className={`status-indicator status-indicator--${getIndicatorColor(cumulus)}`}></span>
+    id: 'cumulus',
+    Cell: ({ row: { original: { cumulus }, values: { granuleId } } }) => ( // eslint-disable-line react/prop-types
+      <IndicatorWithTooltip granuleId={granuleId} repo='cumulus' value={cumulus} />
     ),
     width: 50,
   },
   {
     Header: 'CMR',
     id: 'cmr',
-    Cell: ({ row: { original: { cmr } } }) => ( // eslint-disable-line react/prop-types
-      <span className={`status-indicator status-indicator--${getIndicatorColor(cmr)}`}></span>
+    Cell: ({ row: { original: { cmr }, values: { granuleId } } }) => ( // eslint-disable-line react/prop-types
+      <IndicatorWithTooltip granuleId={granuleId} repo='cmr' value={cmr} />
     ),
     width: 50,
   },

--- a/cypress/integration/reconciliation_spec.js
+++ b/cypress/integration/reconciliation_spec.js
@@ -220,6 +220,13 @@ describe('Dashboard Reconciliation Reports Page', () => {
       cy.contains('.simple-pagination .pagination__link--active', '1');
       cy.contains('.simple-pagination button', 'Next').click();
       cy.contains('.simple-pagination .pagination__link--active', '2');
+
+      /** Legend */
+      cy.get('.legend').should('have.length', 1);
+      cy.get('.legend-items--item').should('have.length', 3);
+      cy.get('.legend-items--item').eq(0).should('contain', 'Granule not found');
+      cy.get('.legend-items--item').eq(1).should('contain', 'Missing image file');
+      cy.get('.legend-items--item').eq(2).should('contain', 'No issues/conflicts');
     });
 
     it('Has a way to expand/collapse all tables', () => {
@@ -260,8 +267,8 @@ describe('Dashboard Reconciliation Reports Page', () => {
       cy.visit(path);
       cy.contains('.heading--large', `Granule Not Found Report: ${reportName}`);
 
-      cy.contains('.heading--medium', 'Granules Not Found');
-      cy.contains('.num-title', '7');
+      cy.contains('.heading--medium', 'Total Conflict Comparisons');
+      cy.contains('.num-title', '11');
 
       cy.get('.table .th').eq(0).should('contain', 'Collection ID');
       cy.get('.table .th').eq(1).should('contain', 'Granule ID');
@@ -274,22 +281,19 @@ describe('Dashboard Reconciliation Reports Page', () => {
       cy.get('.table .tr[data-value="4"] .td').eq(2).find('span').should('have.class', 'status-indicator--failed');
       cy.get('.table .tr[data-value="4"] .td').eq(3).find('span').should('have.class', 'status-indicator--failed');
       cy.get('.table .tr[data-value="4"] .td').eq(4).find('span').should('have.class', 'status-indicator--success');
+
+      /** Legend */
+      cy.get('.legend').should('have.length', 1);
+      cy.get('.legend-items--item').should('have.length', 3);
+      cy.get('.legend-items--item').eq(0).should('contain', 'Granule not found');
+      cy.get('.legend-items--item').eq(1).should('contain', 'Missing image file');
+      cy.get('.legend-items--item').eq(2).should('contain', 'No issues/conflicts');
     });
 
     it('should download the Internal report with the report link', () => {
       const reportName = 'InternalReport092020';
       cy.visit('/reconciliation-reports');
       cy.get(`[data-value="${reportName}"]`).find('.button__row--download').should('have.length', 1);
-    });
-
-    it('should include legend on list page', () => {
-      cy.visit('/reconciliation-reports');
-
-      cy.get('.legend').should('have.length', 1);
-      cy.get('.legend-items--item').should('have.length', 3);
-      cy.get('.legend-items--item').eq(0).should('contain', 'Granule not found');
-      cy.get('.legend-items--item').eq(1).should('contain', 'Missing image file');
-      cy.get('.legend-items--item').eq(2).should('contain', 'No issues/conflicts');
     });
 
     it('should have the option to search the report', () => {

--- a/cypress/integration/reconciliation_spec.js
+++ b/cypress/integration/reconciliation_spec.js
@@ -221,12 +221,13 @@ describe('Dashboard Reconciliation Reports Page', () => {
       cy.contains('.simple-pagination button', 'Next').click();
       cy.contains('.simple-pagination .pagination__link--active', '2');
 
-      /** Legend */
-      cy.get('.legend').should('have.length', 1);
-      cy.get('.legend-items--item').should('have.length', 3);
-      cy.get('.legend-items--item').eq(0).should('contain', 'Granule not found');
-      cy.get('.legend-items--item').eq(1).should('contain', 'Missing image file');
-      cy.get('.legend-items--item').eq(2).should('contain', 'No issues/conflicts');
+      /** Legend - there should be one for each table */
+      cy.get('.legend').should('have.length', 3);
+      cy.get('.legend').eq(0).as('legend1');
+      cy.get('@legend1').find('.legend-items--item').should('have.length', 3);
+      cy.get('@legend1').find('.legend-items--item').eq(0).should('contain', 'Granule not found');
+      cy.get('@legend1').find('.legend-items--item').eq(1).should('contain', 'Missing image file');
+      cy.get('@legend1').find('.legend-items--item').eq(2).should('contain', 'No issues/conflicts');
     });
 
     it('Has a way to expand/collapse all tables', () => {

--- a/test/components/reconciliation-reports/reconciliation-report.js
+++ b/test/components/reconciliation-reports/reconciliation-report.js
@@ -183,7 +183,6 @@ test('correctly renders the heading', function (t) {
     endTime: '2018-06-11T18:52:39.893Z',
     error: null,
     name: 'exampleInventoryReport',
-    reportState: 'CONFLICT',
     startTime: '2018-06-11T18:52:37.710Z',
     type: 'Inventory'
   };


### PR DESCRIPTION
Date range moved to same line as header
Added Total Conflict Comparisons
Download report below border
Table legend moved to Collapse component above table

**Summary:** Summary of changes

Addresses [CUMULUS-2176: Reports: GNF View - Update Style & Interaction](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2176)

## Changes

* Added Total Conflict Comparison section w/ description (for both GNF and Inventory)
* Removed report status
* Moved date range to be in line with header
* Made Legend collapsible and added it next to the column filters collapsible button
* Added tooltips for the colored indicators

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Adhoc testing
- [ ] Integration tests