### PR TITLE
[CUMULUS-2297] Add table column toggle to all tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - **CUMULUS-2297**
-  - Add abilitiy to toggle column filters on all tables
+  - Add ability to show/hide columns on all tables
 
 ## [v4.0.0] - 2021-01-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **CUMULUS-bugfix**
   - replaced deprecated node-sass with sass
 
+### Added
+
+- **CUMULUS-2297**
+  - Add abilitiy to toggle column filters on all tables
+
 ## [v4.0.0] - 2021-01-13
 
 ## Breaking Changes

--- a/app/src/css/modules/_table.scss
+++ b/app/src/css/modules/_table.scss
@@ -148,8 +148,7 @@
     background: $white;
     padding: 2em;
     margin: 1em 0;
-    box-shadow: 0px 1px 3px rgba(0, 0, 0, 0.08);
-    border-radius: 8px;
+    box-shadow: $shadow__default;
   }
 
   &--filter {
@@ -167,9 +166,8 @@
   padding: 1em 1em .4em 1em;
   border: 1px solid $border-grey;
   box-shadow: $shadow__default;
-  width: 100%;
 
-  h {
+  h4 {
     font-size: .86em;
   }
 
@@ -182,7 +180,10 @@
 .list-action-wrapper {
   display: flex;
   flex-wrap: wrap;
-  align-items: flex-start;
+
+  &:not(.no-actions) {
+    align-items: flex-start;
+  }
 
   &.no-actions {
     .filters {
@@ -193,12 +194,14 @@
 
 .list-actions {
   display: flex;
+  align-items: flex-start;
   justify-content: space-around;
   flex-grow: 1;
   margin-top: 3em;
 
   .form--controls {
     flex-grow: 1;
+    margin-bottom: 1em;
   }
 }
 

--- a/app/src/css/modules/_table.scss
+++ b/app/src/css/modules/_table.scss
@@ -115,14 +115,11 @@
 }
 
 .list__filters {
-  margin: 1.5em 0 2em;
+  margin: 1.5em 0 .5em;
+  display: flex;
   @extend .clearfix;
   label {
     font-size: .86em;
-  }
-
-  &--flex {
-    display: flex;
   }
 
   &--item {
@@ -183,14 +180,11 @@
 }
 
 .list-action-wrapper {
-  padding-top: 1.5em;
   display: flex;
   flex-wrap: wrap;
-  align-items: flex-end;
+  align-items: flex-start;
 
   &.no-actions {
-    align-items: center;
-
     .filters {
       margin: 1em 0;
     }
@@ -201,6 +195,7 @@
   display: flex;
   justify-content: space-around;
   flex-grow: 1;
+  margin-top: 3em;
 
   .form--controls {
     flex-grow: 1;

--- a/app/src/js/components/Form/_form.scss
+++ b/app/src/js/components/Form/_form.scss
@@ -180,6 +180,9 @@ select option{
 
 .form__element__updateToggle {
   padding-right: .1em;
+  margin-left: auto;
+  align-self: flex-end;
+  margin-top: 1em;
   .metadata__updated {
     display: block;
     &:hover {

--- a/app/src/js/components/ListActions/ListActions.js
+++ b/app/src/js/components/ListActions/ListActions.js
@@ -62,33 +62,35 @@ const ListActions = ({
   function renderGroupActions() {
     return (
       <>
-        <div className={'list-actions'}>
-          <div className='form--controls'>
-            <button
-              aria-expanded={actionsExpanded}
-              className={`button button--small form-group__element button--group-action${actionsExpanded ? '--collapsed' : ''}`}
-              onClick={() => setFiltersExpanded(!actionsExpanded)}
-            >
-              {groupAction.title}
-            </button>
-          </div>
-          <Timer
-            noheader={!hasActions}
-            dispatch={dispatch}
-            action={action}
-            config={queryConfig}
-            reload={completedBulkActions}
-          />
-        </div>
-        <Collapse in={actionsExpanded}>
-          <div className='group-action--wrapper'>
-            <h4>{groupAction.title}</h4>
-            <p>{groupAction.description}</p>
+        <div>
+          <div className={'list-actions'}>
             <div className='form--controls'>
-              {listBulkActions()}
+              <button
+                aria-expanded={actionsExpanded}
+                className={`button button--small form-group__element button--group-action${actionsExpanded ? '--collapsed' : ''}`}
+                onClick={() => setFiltersExpanded(!actionsExpanded)}
+              >
+                {groupAction.title}
+              </button>
             </div>
           </div>
-        </Collapse>
+          <Collapse in={actionsExpanded}>
+            <div className='group-action--wrapper'>
+              <h4>{groupAction.title}</h4>
+              <p>{groupAction.description}</p>
+              <div className='form--controls'>
+                {listBulkActions()}
+              </div>
+            </div>
+          </Collapse>
+        </div>
+        <Timer
+          noheader={!hasActions}
+          dispatch={dispatch}
+          action={action}
+          config={queryConfig}
+          reload={completedBulkActions}
+        />
       </>
     );
   }

--- a/app/src/js/components/SortableTable/SortableTable.js
+++ b/app/src/js/components/SortableTable/SortableTable.js
@@ -53,9 +53,9 @@ IndeterminateCheckbox.propTypes = {
 const SortableTable = ({
   canSelect,
   changeSortProps,
-  children,
   clearSelected,
   data = [],
+  getToggleColumnOptions,
   initialHiddenColumns = [],
   initialSortId,
   legend,
@@ -139,7 +139,6 @@ const SortableTable = ({
   );
 
   const tableRows = page || rows;
-  const includeFilters = initialHiddenColumns.length > 0;
 
   useEffect(() => {
     if (clearSelected) {
@@ -166,6 +165,15 @@ const SortableTable = ({
     }
   }, [changeSortProps, sortBy]);
 
+  useEffect(() => {
+    if (typeof getToggleColumnOptions === 'function') {
+      getToggleColumnOptions({
+        onChange: toggleHideColumn,
+        hiddenColumns
+      });
+    }
+  }, [getToggleColumnOptions, hiddenColumns, toggleHideColumn]);
+
   function handleDoubleClick(id, header, originalWidth) {
     setFitColumn({
       ...fitColumn,
@@ -183,14 +191,11 @@ const SortableTable = ({
 
   return (
     <div className='table--wrapper'>
-      {(includeFilters || legend) &&
-        <ListFilters className="list__filters--flex">
-          {includeFilters &&
-            <TableFilters columns={tableColumns} onChange={toggleHideColumn} hiddenColumns={hiddenColumns} />
-          }
-          {legend}
-        </ListFilters>
-      }
+      {(typeof getToggleColumnOptions !== 'function') &&
+      <ListFilters>
+        <TableFilters columns={tableColumns} onChange={toggleHideColumn} hiddenColumns={hiddenColumns} />
+        {legend}
+      </ListFilters>}
       <div className='table' {...getTableProps()}>
         <div className='thead'>
           <div className='tr'>
@@ -303,9 +308,9 @@ const SortableTable = ({
 SortableTable.propTypes = {
   canSelect: PropTypes.bool,
   changeSortProps: PropTypes.func,
-  children: PropTypes.node,
   clearSelected: PropTypes.bool,
   data: PropTypes.array,
+  getToggleColumnOptions: PropTypes.func,
   initialHiddenColumns: PropTypes.array,
   initialSortId: PropTypes.string,
   legend: PropTypes.node,

--- a/app/src/js/components/SortableTable/SortableTable.js
+++ b/app/src/js/components/SortableTable/SortableTable.js
@@ -139,6 +139,7 @@ const SortableTable = ({
   );
 
   const tableRows = page || rows;
+  const includeFilters = typeof getToggleColumnOptions !== 'function';
 
   useEffect(() => {
     if (clearSelected) {
@@ -191,9 +192,11 @@ const SortableTable = ({
 
   return (
     <div className='table--wrapper'>
-      {(typeof getToggleColumnOptions !== 'function') &&
+      {(includeFilters || legend) &&
       <ListFilters>
-        <TableFilters columns={tableColumns} onChange={toggleHideColumn} hiddenColumns={hiddenColumns} />
+        {includeFilters &&
+            <TableFilters columns={tableColumns} onChange={toggleHideColumn} hiddenColumns={hiddenColumns} />
+        }
         {legend}
       </ListFilters>}
       <div className='table' {...getTableProps()}>

--- a/app/src/js/components/Table/Table.js
+++ b/app/src/js/components/Table/Table.js
@@ -1,16 +1,19 @@
-import React, { useState, useEffect, lazy, Suspense } from 'react';
+import React, { useState, useEffect, lazy, Suspense, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import withQueryParams from 'react-router-query-params';
 import isNil from 'lodash/isNil';
 import isEqual from 'lodash/isEqual';
 import omitBy from 'lodash/omitBy';
+import noop from 'lodash/noop';
 import ErrorReport from '../Errors/report';
 import Loading from '../LoadingIndicator/loading-indicator';
 import Pagination from '../Pagination/pagination';
 // Lodash
 import ListActions from '../ListActions/ListActions';
 import TableHeader from '../TableHeader/table-header';
+import ListFilters from '../ListActions/ListFilters';
+import TableFilters from './TableFilters';
 
 const SortableTable = lazy(() => import('../SortableTable/SortableTable'));
 
@@ -52,6 +55,10 @@ const List = ({
   const [bulkActionMeta, setBulkActionMeta] = useState({
     completedBulkActions: 0,
     bulkActionError: null,
+  });
+  const [toggleColumnOptions, setToggleColumnOptions] = useState({
+    onChange: noop,
+    hiddenColumns: [],
   });
 
   const { bulkActionError, completedBulkActions } = bulkActionMeta;
@@ -154,6 +161,10 @@ const List = ({
     );
   }
 
+  const getToggleColumnOptions = useCallback((newOptions) => {
+    setToggleColumnOptions(newOptions);
+  }, []);
+
   return (
     <>
       <ListActions
@@ -168,6 +179,9 @@ const List = ({
         selected={selected}
       >
         {children}
+        <ListFilters>
+          <TableFilters columns={tableColumns} {...toggleColumnOptions} />
+        </ListFilters>
       </ListActions>
       <div className="list-view">
         {listInflight && <Loading />}
@@ -198,6 +212,7 @@ const List = ({
               // if there's an initialSortId, it means the first fetch request for the list should be sorted
               // according to that id, and therefore we are using sever-side/manual sorting
               shouldManualSort={!!initialSortId}
+              getToggleColumnOptions={getToggleColumnOptions}
             />
           </Suspense>
           <Pagination

--- a/app/src/js/components/Table/TableFilters.js
+++ b/app/src/js/components/Table/TableFilters.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Collapse } from 'react-bootstrap';
 
-const TableFilters = ({ columns, onChange, hiddenColumns = [] }) => {
+const TableFilters = ({ columns = [], onChange, hiddenColumns = [] }) => {
   const [filtersExpanded, setFiltersExpanded] = useState(false);
 
   function handleChange(id) {

--- a/cypress/integration/reconciliation_spec.js
+++ b/cypress/integration/reconciliation_spec.js
@@ -1,6 +1,9 @@
 import moment from 'moment';
 import { shouldBeRedirectedToLogin } from '../support/assertions';
 import { dateTimeFormat } from '../../app/src/js/utils/datepicker';
+import { tableColumns } from '../../app/src/js/utils/table-config/reconciliation-reports';
+
+const tableColumnHeaders = tableColumns({ isGranules: false }).map((column) => column.Header);
 
 describe('Dashboard Reconciliation Reports Page', () => {
   describe('When not logged in', () => {
@@ -42,6 +45,25 @@ describe('Dashboard Reconciliation Reports Page', () => {
       cy.get('.table .tbody .tr').should('have.length', 5);
       cy.get('[data-value="inventoryReport-2020/01/14T202529026"] > .table__main-asset > a').should('have.attr', 'href', '/reconciliation-reports/report/inventoryReport-2020%2F01%2F14T202529026');
       cy.get('[data-value="inventoryReport-20200114T205238781"] > .table__main-asset > a').should('have.attr', 'href', '/reconciliation-reports/report/inventoryReport-20200114T205238781');
+    });
+
+    it('has a column toggle on the report list page', () => {
+      cy.visit('/reconciliation-reports');
+
+      cy.contains('.table__filters .button__filter', 'Show Column Filters').click();
+      cy.get('.table__filters--collapse').should('be.visible');
+
+      tableColumnHeaders.forEach((header) => {
+        cy.contains('.table .th', header).should('be.visible');
+        cy.contains('.table__filters--filter label', header).prev().click();
+        cy.contains('.table .th', header).should('not.exist');
+        cy.contains('.table__filters--filter label', header).prev().click();
+        cy.contains('.table .th', header).should('be.visible');
+      });
+
+      cy.contains('.table__filters .button__filter', 'Hide Column Filters').click();
+      cy.get('.table__filters--collapse').should('not.be.visible');
+      cy.contains('.table__filters .button__filter', 'Show Column Filters');
     });
 
     it('should update dropdown with label when visiting bookmarkable URL', () => {
@@ -211,9 +233,9 @@ describe('Dashboard Reconciliation Reports Page', () => {
           cy.contains('.table__filters--filter label', filterLabel).prev().click();
           cy.contains('.table .th', filterLabel).should('not.exist');
 
-          cy.get('.table__filters .button__filter').click();
-          cy.contains('.table__filters .button__filter', 'Show Column Filters');
+          cy.contains('.table__filters .button__filter', 'Hide Column Filters').click();
           cy.get('.table__filters--collapse').should('not.be.visible');
+          cy.contains('.table__filters .button__filter', 'Show Column Filters');
         });
 
       /** Pagination */


### PR DESCRIPTION
**Summary:** Add ability to show/hide columns on all tables

Addresses [CUMULUS-2297: Dashboard: Tables - Show/Hide Columns Feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2297)

## Changes

* Added `TableFilters` to `List` component
* Update handling of `TableFilters` in `SortableTable` component
* Various styling changes to display column toggle in line with other buttons/actions in the `List` components


## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Adhoc testing
- [x] Integration tests