### PR TITLE
CUMULUS-2321: Updated reconciliation report to work with the API endpoint changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ This version of the dashboard requires Cumulus API v5.0.2-alpha.0
   - replaced deprecated node-sass with sass
 
 - **CUMULUS-2321**
-  - Updated reconcilation report to work with the API endpoint changes
+  - Updated reconciliation report to work with the API endpoint changes
   - Requires @cumulus/api@5.0.2-alpha.0
 
 ## [v4.0.0] - 2021-01-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## Breaking Changes
+
+This version of the dashboard requires Cumulus API v5.0.2-alpha.0
+
 ### Fixed
 
 - **CUMULUS-2310**
@@ -20,6 +24,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - **CUMULUS-bugfix**
   - replaced deprecated node-sass with sass
+
+- **CUMULUS-2321**
+  - Updated reconcilation report to work with the API endpoint changes
+  - Requires @cumulus/api@5.0.2-alpha.0
 
 ## [v4.0.0] - 2021-01-13
 

--- a/app/src/js/components/ReconciliationReports/gnf-report.js
+++ b/app/src/js/components/ReconciliationReports/gnf-report.js
@@ -83,7 +83,7 @@ const GnfReport = ({
   const totalMissingGranules = combinedGranules.reduce(calculateMissingGranules, 0);
 
   function handleDownloadClick(e) {
-    handleDownloadJsonClick(e, { data: recordData, reportName });
+    handleDownloadUrlClick(e, { url: reportUrl });
   }
 
   return (

--- a/app/src/js/components/ReconciliationReports/gnf-report.js
+++ b/app/src/js/components/ReconciliationReports/gnf-report.js
@@ -8,7 +8,7 @@ import {
 import SortableTable from '../SortableTable/SortableTable';
 import Search from '../Search/search';
 import ReportHeading from './report-heading';
-import { handleDownloadJsonClick } from '../../utils/download-file';
+import { handleDownloadUrlClick } from '../../utils/download-file';
 import { tableColumnsGnf } from '../../utils/table-config/reconciliation-reports';
 import { getFilesSummary, getGranuleFilesSummary } from './reshape-report';
 import { getCollectionId } from '../../utils/format';
@@ -18,6 +18,7 @@ const GnfReport = ({
   legend,
   recordData,
   reportName,
+  reportUrl,
 }) => {
   const {
     filesInCumulus,
@@ -125,6 +126,7 @@ GnfReport.propTypes = {
   legend: PropTypes.node,
   recordData: PropTypes.object,
   reportName: PropTypes.string,
+  reportUrl: PropTypes.string,
 };
 
 export default GnfReport;

--- a/app/src/js/components/ReconciliationReports/inventory-report.js
+++ b/app/src/js/components/ReconciliationReports/inventory-report.js
@@ -13,7 +13,7 @@ import {
 } from '../../actions';
 import SortableTable from '../SortableTable/SortableTable';
 import { reshapeReport } from './reshape-report';
-import { handleDownloadJsonClick, handleDownloadCsvClick } from '../../utils/download-file';
+import { handleDownloadUrlClick, handleDownloadCsvClick } from '../../utils/download-file';
 import Search from '../Search/search';
 import Dropdown from '../DropDown/dropdown';
 import ReportHeading from './report-heading';
@@ -33,6 +33,7 @@ const InventoryReport = ({
   legend,
   recordData,
   reportName,
+  reportUrl,
 }) => {
   const [activeId, setActiveId] = useState('dynamo');
   const { reportStartTime = null, reportEndTime = null, error = null } =
@@ -50,7 +51,7 @@ const InventoryReport = ({
   const downloadOptions = [
     {
       label: 'JSON - Full Report',
-      onClick: (e) => handleDownloadJsonClick(e, { data: recordData, reportName })
+      onClick: (e) => handleDownloadUrlClick(e, { url: reportUrl })
     },
     ...activeCardTables.map((table) => ({
       label: `CSV - ${table.name}`,
@@ -229,6 +230,7 @@ InventoryReport.propTypes = {
   legend: PropTypes.node,
   recordData: PropTypes.object,
   reportName: PropTypes.string,
+  reportUrl: PropTypes.string,
 };
 
 export default InventoryReport;

--- a/app/src/js/components/ReconciliationReports/reconciliation-report.js
+++ b/app/src/js/components/ReconciliationReports/reconciliation-report.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
+import get from 'lodash/get';
 import { getReconciliationReport } from '../../actions';
 import Loading from '../LoadingIndicator/loading-indicator';
 import InventoryReport from './inventory-report';
@@ -18,7 +19,8 @@ const ReconciliationReport = ({
   const { list, map, searchString: filterString } = reconciliationReports;
   const record = map[reconciliationReportName];
 
-  let { error, data: reportData } = record.data || {};
+  let error = get(record, 'data.error');
+  let reportData = get(record, 'data.data', {});
 
   // report data is an error message
   if (typeof reportData === 'string' && reportData.startsWith('Error')) {

--- a/app/src/js/components/ReconciliationReports/reconciliation-report.js
+++ b/app/src/js/components/ReconciliationReports/reconciliation-report.js
@@ -21,6 +21,7 @@ const ReconciliationReport = ({
 
   let error = get(record, 'data.error');
   let reportData = get(record, 'data.data', {});
+  const reportUrl = get(record, 'data.presignedS3Url');
 
   // report data is an error message
   if (typeof reportData === 'string' && reportData.startsWith('Error')) {
@@ -51,12 +52,14 @@ const ReconciliationReport = ({
             legend={<Legend />}
             recordData={recordData}
             reportName={reconciliationReportName}
+            reportUrl={reportUrl}
           />,
           'Granule Not Found': <GnfReport
             filterString={filterString}
             legend={<Legend />}
             recordData={recordData}
             reportName={reconciliationReportName}
+            reportUrl={reportUrl}
           />
         }[reportType]
       }

--- a/app/src/js/components/ReconciliationReports/reconciliation-report.js
+++ b/app/src/js/components/ReconciliationReports/reconciliation-report.js
@@ -2,11 +2,13 @@ import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
+import get from 'lodash/get';
 import { getReconciliationReport } from '../../actions';
 import Loading from '../LoadingIndicator/loading-indicator';
 import InventoryReport from './inventory-report';
 import GnfReport from './gnf-report';
 import Legend from './legend';
+import ErrorReport from '../Errors/report';
 
 const ReconciliationReport = ({
   dispatch,
@@ -17,7 +19,8 @@ const ReconciliationReport = ({
   const reconciliationReportName = decodeURIComponent(encodedReportName);
   const { list, map, searchString: filterString } = reconciliationReports;
   const record = map[reconciliationReportName];
-  const { data: recordData } = record || {};
+
+  const recordData = get(record, 'data.data', {});
   const { reportType = 'Inventory' } = recordData || {};
   const filterBucket = list.params.bucket;
 
@@ -27,6 +30,11 @@ const ReconciliationReport = ({
 
   if (!record || (record.inflight && !record.data)) {
     return <Loading />;
+  }
+
+  if (typeof recordData === 'string' && recordData.startsWith('Error')) {
+    const error = `${recordData}, please download the report instead`;
+    return <ErrorReport report={error} />;
   }
 
   return (

--- a/app/src/js/components/ReconciliationReports/reconciliation-report.js
+++ b/app/src/js/components/ReconciliationReports/reconciliation-report.js
@@ -2,13 +2,11 @@ import PropTypes from 'prop-types';
 import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import get from 'lodash/get';
 import { getReconciliationReport } from '../../actions';
 import Loading from '../LoadingIndicator/loading-indicator';
 import InventoryReport from './inventory-report';
 import GnfReport from './gnf-report';
 import Legend from './legend';
-import ErrorReport from '../Errors/report';
 
 const ReconciliationReport = ({
   dispatch,
@@ -20,7 +18,16 @@ const ReconciliationReport = ({
   const { list, map, searchString: filterString } = reconciliationReports;
   const record = map[reconciliationReportName];
 
-  const recordData = get(record, 'data.data', {});
+  let { error, data: reportData } = record.data || {};
+
+  // report data is an error message
+  if (typeof reportData === 'string' && reportData.startsWith('Error')) {
+    const reportError = `${reportData}, please download the report instead`;
+    error = error || reportError;
+    reportData = {};
+  }
+
+  const recordData = { ...reportData, error };
   const { reportType = 'Inventory' } = recordData || {};
   const filterBucket = list.params.bucket;
 
@@ -30,11 +37,6 @@ const ReconciliationReport = ({
 
   if (!record || (record.inflight && !record.data)) {
     return <Loading />;
-  }
-
-  if (typeof recordData === 'string' && recordData.startsWith('Error')) {
-    const error = `${recordData}, please download the report instead`;
-    return <ErrorReport report={error} />;
   }
 
   return (

--- a/app/src/js/utils/download-file.js
+++ b/app/src/js/utils/download-file.js
@@ -32,14 +32,6 @@ const convertToCSV = (data, columns) => {
   return `${csvHeader}\r\n${csvData}`;
 };
 
-export function handleDownloadJsonClick(e, { data, reportName }) {
-  e.preventDefault();
-  const jsonHref = `data:text/json;charset=utf-8,${encodeURIComponent(
-    JSON.stringify(data)
-  )}`;
-  downloadFile(jsonHref, `${reportName}.json`);
-}
-
 export function handleDownloadUrlClick(e, { url }) {
   e.preventDefault();
   if (url && window && !window.Cypress) window.open(url);

--- a/app/src/js/utils/download-file.js
+++ b/app/src/js/utils/download-file.js
@@ -40,6 +40,11 @@ export function handleDownloadJsonClick(e, { data, reportName }) {
   downloadFile(jsonHref, `${reportName}.json`);
 }
 
+export function handleDownloadUrlClick(e, { url }) {
+  e.preventDefault();
+  if (url && window && !window.Cypress) window.open(url);
+}
+
 export function handleDownloadCsvClick(e, { reportName, table }) {
   e.preventDefault();
   const { name: tableName, data: tableData, columns: tableColumns } = table;

--- a/cypress/fixtures/TESTCOLLECTION___006.json
+++ b/cypress/fixtures/TESTCOLLECTION___006.json
@@ -10,23 +10,27 @@
         {
             "bucket": "protected",
             "regex": "^TESTCOLLECTION\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf$",
+            "reportToEms": true,
             "sampleFileName": "TESTCOLLECTION.A2017025.h21v00.006.2017034065104.hdf",
             "url_path": "{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{extractYear(cmrMetadata.Granule.Temporal.RangeDateTime.BeginningDateTime)}/{substring(file.name, 0, 3)}"
         },
         {
             "bucket": "private",
             "sampleFileName": "TESTCOLLECTION.A2017025.h21v00.006.2017034065104.hdf.met",
-            "regex": "^TESTCOLLECTION\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf\\.met$"
+            "regex": "^TESTCOLLECTION\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.hdf\\.met$",
+            "reportToEms": true
         },
         {
             "bucket": "protected-2",
             "sampleFileName": "TESTCOLLECTION.A2017025.h21v00.006.2017034065104.cmr.xml",
-            "regex": "^TESTCOLLECTION\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.cmr\\.xml$"
+            "regex": "^TESTCOLLECTION\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}\\.cmr\\.xml$",
+            "reportToEms": true
         },
         {
             "bucket": "public",
             "sampleFileName": "TESTCOLLECTION.A2017025.h21v00.006.2017034065104_ndvi.jpg",
-            "regex": "^TESTCOLLECTION\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}_ndvi\\.jpg$"
+            "regex": "^TESTCOLLECTION\\.A[\\d]{7}\\.[\\S]{6}\\.006\\.[\\d]{13}_ndvi\\.jpg$",
+            "reportToEms": true
         }
     ],
     "updatedAt": 1537830419503,

--- a/cypress/integration/granules_spec.js
+++ b/cypress/integration/granules_spec.js
@@ -399,7 +399,7 @@ describe('Dashboard Granules Page', () => {
         .should('be.visible')
         .click({ force: true });
 
-      cy.wait('@getList').its('response.body.url').should('exist');
+      cy.wait('@getList').its('response.body.presignedS3Url').should('exist');
     });
 
     it('Should open modal to create granule inventory report', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3759,24 +3759,24 @@
       "dev": true
     },
     "@cumulus/api": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/api/-/api-5.0.0.tgz",
-      "integrity": "sha512-kyj1vh9jGi21w/sb82MT8PSqzYEaOkRGqGe5ZaBvJ6Igltr6VmDi99Oh/qta8oT2yDZLGLYI3UfG7bxg8e+bVQ==",
+      "version": "5.0.2-alpha.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/api/-/api-5.0.2-alpha.0.tgz",
+      "integrity": "sha512-xIqxgyHSaErEsHEmftxJ45NoOWM2GrImIx3gHhylH4Yqrv/B3Q34pxCNvbSfcnuYGAx6XT/4N+8DZLskfsSJEQ==",
       "dev": true,
       "requires": {
-        "@cumulus/aws-client": "5.0.0",
-        "@cumulus/cmr-client": "5.0.0",
-        "@cumulus/cmrjs": "5.0.0",
-        "@cumulus/collection-config-store": "5.0.0",
-        "@cumulus/common": "5.0.0",
-        "@cumulus/earthdata-login-client": "5.0.0",
-        "@cumulus/errors": "5.0.0",
-        "@cumulus/ingest": "5.0.0",
-        "@cumulus/launchpad-auth": "5.0.0",
-        "@cumulus/logger": "5.0.0",
-        "@cumulus/message": "5.0.0",
-        "@cumulus/pvl": "5.0.0",
-        "@cumulus/sftp-client": "5.0.0",
+        "@cumulus/aws-client": "5.0.1",
+        "@cumulus/cmr-client": "5.0.1",
+        "@cumulus/cmrjs": "5.0.1",
+        "@cumulus/collection-config-store": "5.0.1",
+        "@cumulus/common": "5.0.1",
+        "@cumulus/earthdata-login-client": "5.0.1",
+        "@cumulus/errors": "5.0.1",
+        "@cumulus/ingest": "5.0.1",
+        "@cumulus/launchpad-auth": "5.0.1",
+        "@cumulus/logger": "5.0.1",
+        "@cumulus/message": "5.0.1",
+        "@cumulus/pvl": "5.0.1",
+        "@cumulus/sftp-client": "5.0.1",
         "@elastic/elasticsearch": "^5.6.20",
         "@mapbox/dyno": "^1.4.2",
         "aggregate-error": "^3.0.1",
@@ -3818,14 +3818,14 @@
       },
       "dependencies": {
         "@cumulus/aws-client": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-5.0.0.tgz",
-          "integrity": "sha512-H+rGIr/GACpN/a7G8CkGqBjcxVUJYMzhwu5FTGyoXQI69Yye1Prlzbt64HqsdoG2WHG6K4jS7BBxb61vp2H4uA==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-5.0.1.tgz",
+          "integrity": "sha512-wFzmxbc+GmRAzMy7zG0HC/vxlq+G6aEJ/Gv69ivG6gTQ6lT2mC8l/PwNmVwllCjhdtYn5ZvDSwvj8a+BbBXj2Q==",
           "dev": true,
           "requires": {
-            "@cumulus/checksum": "5.0.0",
-            "@cumulus/errors": "5.0.0",
-            "@cumulus/logger": "5.0.0",
+            "@cumulus/checksum": "5.0.1",
+            "@cumulus/errors": "5.0.1",
+            "@cumulus/logger": "5.0.1",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.20",
@@ -3842,9 +3842,9 @@
               "dev": true
             },
             "p-retry": {
-              "version": "4.2.0",
-              "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.2.0.tgz",
-              "integrity": "sha512-jPH38/MRh263KKcq0wBNOGFJbm+U6784RilTmHjB/HM9kH9V8WlCpVUcdOmip9cjXOh6MxZ5yk1z2SjDUJfWmA==",
+              "version": "4.3.0",
+              "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.3.0.tgz",
+              "integrity": "sha512-Pow4yaHpOiJou1QcpGcBJhGHiS4782LdDa6GhU91hlaNh3ExOOupjSJcxPQZYmUSZk3Pl2ARz/LRvW8Qu0+3mQ==",
               "dev": true,
               "requires": {
                 "@types/retry": "^0.12.0",
@@ -3863,24 +3863,24 @@
           }
         },
         "@cumulus/checksum": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-5.0.0.tgz",
-          "integrity": "sha512-wuwQFVS8UazHgbhgNPfacHOMvDDNdgdUNjkS+r/JsR1JpsNAnmxtMCVZz2fqUd1EFgCaNZbqhL2njbWdDVA0Pg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-5.0.1.tgz",
+          "integrity": "sha512-0Nb89tF/ZswMRlRSGxG1i2LLpDrD1b7bdhJqTF5YsqvC3z0NKXG6ECNfmWFC3x8XnSW+FydLu550lddZgmaMFQ==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-5.0.0.tgz",
-          "integrity": "sha512-hAJGLzR2C4BoZ98jQkOC8y4qxVW30leIyIgWbD9woQfJeYtKWZgp1pno9HnRozw+WaDwb3QNsYpJRPrpz4td1A==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-5.0.1.tgz",
+          "integrity": "sha512-gNHxTBqZE7ManuMxl5dxBwf0BcpMcJYTCpqulNUSaASGlHFHCV7lHq7Rc7k3Y9VdBOAtyJZbOF1WDOUljn32uw==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-5.0.0.tgz",
-          "integrity": "sha512-Ox8CCztwXDUNGuDgYDO98/RPQbYOQC8K2AKf5tVUzXEIwObwmABfWe9VeS2qkZn9Fm/3CeoJfXFZj5PJFlY/FA==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-5.0.1.tgz",
+          "integrity": "sha512-bLOYdO0iiYgNf6Ex/wY8/uqOzziTbyrsM9XbHedZCUxFClC1SEA3/rFgB3PPLNiF2mxZkF6qbTDWDe9eg+/CCg==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
@@ -3975,13 +3975,13 @@
       }
     },
     "@cumulus/cmr-client": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/cmr-client/-/cmr-client-5.0.0.tgz",
-      "integrity": "sha512-uV4em62gwTXK/2kPfSZ8RdJVobb13WpRFUbwpc2f3MB99AtBbuKIWZAfb6ZrEs/nCnnExVlHic5f+kVC2+QXpQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@cumulus/cmr-client/-/cmr-client-5.0.1.tgz",
+      "integrity": "sha512-wHBRAiYJ4BMiUF48G9l46aJxBWyH20S/arkGXKdIOGEYYVmnYWpAk+yjbBPZYEF6fIQPVhqGbFRWnIHQARTZLA==",
       "dev": true,
       "requires": {
-        "@cumulus/aws-client": "5.0.0",
-        "@cumulus/logger": "5.0.0",
+        "@cumulus/aws-client": "5.0.1",
+        "@cumulus/logger": "5.0.1",
         "got": "^11.7.0",
         "lodash": "^4.17.20",
         "public-ip": "^3.0.0",
@@ -3989,14 +3989,14 @@
       },
       "dependencies": {
         "@cumulus/aws-client": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-5.0.0.tgz",
-          "integrity": "sha512-H+rGIr/GACpN/a7G8CkGqBjcxVUJYMzhwu5FTGyoXQI69Yye1Prlzbt64HqsdoG2WHG6K4jS7BBxb61vp2H4uA==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-5.0.1.tgz",
+          "integrity": "sha512-wFzmxbc+GmRAzMy7zG0HC/vxlq+G6aEJ/Gv69ivG6gTQ6lT2mC8l/PwNmVwllCjhdtYn5ZvDSwvj8a+BbBXj2Q==",
           "dev": true,
           "requires": {
-            "@cumulus/checksum": "5.0.0",
-            "@cumulus/errors": "5.0.0",
-            "@cumulus/logger": "5.0.0",
+            "@cumulus/checksum": "5.0.1",
+            "@cumulus/errors": "5.0.1",
+            "@cumulus/logger": "5.0.1",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.20",
@@ -4007,24 +4007,24 @@
           }
         },
         "@cumulus/checksum": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-5.0.0.tgz",
-          "integrity": "sha512-wuwQFVS8UazHgbhgNPfacHOMvDDNdgdUNjkS+r/JsR1JpsNAnmxtMCVZz2fqUd1EFgCaNZbqhL2njbWdDVA0Pg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-5.0.1.tgz",
+          "integrity": "sha512-0Nb89tF/ZswMRlRSGxG1i2LLpDrD1b7bdhJqTF5YsqvC3z0NKXG6ECNfmWFC3x8XnSW+FydLu550lddZgmaMFQ==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-5.0.0.tgz",
-          "integrity": "sha512-hAJGLzR2C4BoZ98jQkOC8y4qxVW30leIyIgWbD9woQfJeYtKWZgp1pno9HnRozw+WaDwb3QNsYpJRPrpz4td1A==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-5.0.1.tgz",
+          "integrity": "sha512-gNHxTBqZE7ManuMxl5dxBwf0BcpMcJYTCpqulNUSaASGlHFHCV7lHq7Rc7k3Y9VdBOAtyJZbOF1WDOUljn32uw==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-5.0.0.tgz",
-          "integrity": "sha512-Ox8CCztwXDUNGuDgYDO98/RPQbYOQC8K2AKf5tVUzXEIwObwmABfWe9VeS2qkZn9Fm/3CeoJfXFZj5PJFlY/FA==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-5.0.1.tgz",
+          "integrity": "sha512-bLOYdO0iiYgNf6Ex/wY8/uqOzziTbyrsM9XbHedZCUxFClC1SEA3/rFgB3PPLNiF2mxZkF6qbTDWDe9eg+/CCg==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
@@ -4037,9 +4037,9 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.2.0.tgz",
-          "integrity": "sha512-jPH38/MRh263KKcq0wBNOGFJbm+U6784RilTmHjB/HM9kH9V8WlCpVUcdOmip9cjXOh6MxZ5yk1z2SjDUJfWmA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.3.0.tgz",
+          "integrity": "sha512-Pow4yaHpOiJou1QcpGcBJhGHiS4782LdDa6GhU91hlaNh3ExOOupjSJcxPQZYmUSZk3Pl2ARz/LRvW8Qu0+3mQ==",
           "dev": true,
           "requires": {
             "@types/retry": "^0.12.0",
@@ -4058,16 +4058,16 @@
       }
     },
     "@cumulus/cmrjs": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/cmrjs/-/cmrjs-5.0.0.tgz",
-      "integrity": "sha512-O1WnzbXYomddAGTwH/NdSJPjQIbDHYy8Y8suSiq5vd/cvRb/G4/j6iINgpk3FzPzzjUB1FuKxAOVvzY2t22OKQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@cumulus/cmrjs/-/cmrjs-5.0.1.tgz",
+      "integrity": "sha512-fwO5oCfrxvr8MukbRn0N/IapLv1CtQnTCb1wRmpGTLTGrdNX/Q2yquNNeGL1Hm7imcaHiP7whkVNcfnQpdMo1Q==",
       "dev": true,
       "requires": {
-        "@cumulus/aws-client": "5.0.0",
-        "@cumulus/cmr-client": "5.0.0",
-        "@cumulus/common": "5.0.0",
-        "@cumulus/errors": "5.0.0",
-        "@cumulus/launchpad-auth": "5.0.0",
+        "@cumulus/aws-client": "5.0.1",
+        "@cumulus/cmr-client": "5.0.1",
+        "@cumulus/common": "5.0.1",
+        "@cumulus/errors": "5.0.1",
+        "@cumulus/launchpad-auth": "5.0.1",
         "js2xmlparser": "^4.0.0",
         "lodash": "^4.17.20",
         "public-ip": "^3.0.0",
@@ -4076,14 +4076,14 @@
       },
       "dependencies": {
         "@cumulus/aws-client": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-5.0.0.tgz",
-          "integrity": "sha512-H+rGIr/GACpN/a7G8CkGqBjcxVUJYMzhwu5FTGyoXQI69Yye1Prlzbt64HqsdoG2WHG6K4jS7BBxb61vp2H4uA==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-5.0.1.tgz",
+          "integrity": "sha512-wFzmxbc+GmRAzMy7zG0HC/vxlq+G6aEJ/Gv69ivG6gTQ6lT2mC8l/PwNmVwllCjhdtYn5ZvDSwvj8a+BbBXj2Q==",
           "dev": true,
           "requires": {
-            "@cumulus/checksum": "5.0.0",
-            "@cumulus/errors": "5.0.0",
-            "@cumulus/logger": "5.0.0",
+            "@cumulus/checksum": "5.0.1",
+            "@cumulus/errors": "5.0.1",
+            "@cumulus/logger": "5.0.1",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.20",
@@ -4094,24 +4094,24 @@
           }
         },
         "@cumulus/checksum": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-5.0.0.tgz",
-          "integrity": "sha512-wuwQFVS8UazHgbhgNPfacHOMvDDNdgdUNjkS+r/JsR1JpsNAnmxtMCVZz2fqUd1EFgCaNZbqhL2njbWdDVA0Pg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-5.0.1.tgz",
+          "integrity": "sha512-0Nb89tF/ZswMRlRSGxG1i2LLpDrD1b7bdhJqTF5YsqvC3z0NKXG6ECNfmWFC3x8XnSW+FydLu550lddZgmaMFQ==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-5.0.0.tgz",
-          "integrity": "sha512-hAJGLzR2C4BoZ98jQkOC8y4qxVW30leIyIgWbD9woQfJeYtKWZgp1pno9HnRozw+WaDwb3QNsYpJRPrpz4td1A==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-5.0.1.tgz",
+          "integrity": "sha512-gNHxTBqZE7ManuMxl5dxBwf0BcpMcJYTCpqulNUSaASGlHFHCV7lHq7Rc7k3Y9VdBOAtyJZbOF1WDOUljn32uw==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-5.0.0.tgz",
-          "integrity": "sha512-Ox8CCztwXDUNGuDgYDO98/RPQbYOQC8K2AKf5tVUzXEIwObwmABfWe9VeS2qkZn9Fm/3CeoJfXFZj5PJFlY/FA==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-5.0.1.tgz",
+          "integrity": "sha512-bLOYdO0iiYgNf6Ex/wY8/uqOzziTbyrsM9XbHedZCUxFClC1SEA3/rFgB3PPLNiF2mxZkF6qbTDWDe9eg+/CCg==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
@@ -4124,9 +4124,9 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.2.0.tgz",
-          "integrity": "sha512-jPH38/MRh263KKcq0wBNOGFJbm+U6784RilTmHjB/HM9kH9V8WlCpVUcdOmip9cjXOh6MxZ5yk1z2SjDUJfWmA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.3.0.tgz",
+          "integrity": "sha512-Pow4yaHpOiJou1QcpGcBJhGHiS4782LdDa6GhU91hlaNh3ExOOupjSJcxPQZYmUSZk3Pl2ARz/LRvW8Qu0+3mQ==",
           "dev": true,
           "requires": {
             "@types/retry": "^0.12.0",
@@ -4151,25 +4151,25 @@
       }
     },
     "@cumulus/collection-config-store": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/collection-config-store/-/collection-config-store-5.0.0.tgz",
-      "integrity": "sha512-9GNvGn25baeTJOICHJFDrQMnTNFLWtD/jnXipZp19NbaEMvu0yYx6pAdNly6JE/RDIwRFgnoUPOCebVoJvJnKw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@cumulus/collection-config-store/-/collection-config-store-5.0.1.tgz",
+      "integrity": "sha512-iMBkSPooD5YdKAyORXjyu7J/boZ94gwOjkb64Qp9bBJ5BxsbQIyzRrKNdBVjkAtPSgNgbAqh0Sq/ap3POAoY9g==",
       "dev": true,
       "requires": {
-        "@cumulus/aws-client": "5.0.0",
-        "@cumulus/common": "5.0.0",
-        "@cumulus/message": "5.0.0"
+        "@cumulus/aws-client": "5.0.1",
+        "@cumulus/common": "5.0.1",
+        "@cumulus/message": "5.0.1"
       },
       "dependencies": {
         "@cumulus/aws-client": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-5.0.0.tgz",
-          "integrity": "sha512-H+rGIr/GACpN/a7G8CkGqBjcxVUJYMzhwu5FTGyoXQI69Yye1Prlzbt64HqsdoG2WHG6K4jS7BBxb61vp2H4uA==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-5.0.1.tgz",
+          "integrity": "sha512-wFzmxbc+GmRAzMy7zG0HC/vxlq+G6aEJ/Gv69ivG6gTQ6lT2mC8l/PwNmVwllCjhdtYn5ZvDSwvj8a+BbBXj2Q==",
           "dev": true,
           "requires": {
-            "@cumulus/checksum": "5.0.0",
-            "@cumulus/errors": "5.0.0",
-            "@cumulus/logger": "5.0.0",
+            "@cumulus/checksum": "5.0.1",
+            "@cumulus/errors": "5.0.1",
+            "@cumulus/logger": "5.0.1",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.20",
@@ -4180,24 +4180,24 @@
           }
         },
         "@cumulus/checksum": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-5.0.0.tgz",
-          "integrity": "sha512-wuwQFVS8UazHgbhgNPfacHOMvDDNdgdUNjkS+r/JsR1JpsNAnmxtMCVZz2fqUd1EFgCaNZbqhL2njbWdDVA0Pg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-5.0.1.tgz",
+          "integrity": "sha512-0Nb89tF/ZswMRlRSGxG1i2LLpDrD1b7bdhJqTF5YsqvC3z0NKXG6ECNfmWFC3x8XnSW+FydLu550lddZgmaMFQ==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-5.0.0.tgz",
-          "integrity": "sha512-hAJGLzR2C4BoZ98jQkOC8y4qxVW30leIyIgWbD9woQfJeYtKWZgp1pno9HnRozw+WaDwb3QNsYpJRPrpz4td1A==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-5.0.1.tgz",
+          "integrity": "sha512-gNHxTBqZE7ManuMxl5dxBwf0BcpMcJYTCpqulNUSaASGlHFHCV7lHq7Rc7k3Y9VdBOAtyJZbOF1WDOUljn32uw==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-5.0.0.tgz",
-          "integrity": "sha512-Ox8CCztwXDUNGuDgYDO98/RPQbYOQC8K2AKf5tVUzXEIwObwmABfWe9VeS2qkZn9Fm/3CeoJfXFZj5PJFlY/FA==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-5.0.1.tgz",
+          "integrity": "sha512-bLOYdO0iiYgNf6Ex/wY8/uqOzziTbyrsM9XbHedZCUxFClC1SEA3/rFgB3PPLNiF2mxZkF6qbTDWDe9eg+/CCg==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
@@ -4210,9 +4210,9 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.2.0.tgz",
-          "integrity": "sha512-jPH38/MRh263KKcq0wBNOGFJbm+U6784RilTmHjB/HM9kH9V8WlCpVUcdOmip9cjXOh6MxZ5yk1z2SjDUJfWmA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.3.0.tgz",
+          "integrity": "sha512-Pow4yaHpOiJou1QcpGcBJhGHiS4782LdDa6GhU91hlaNh3ExOOupjSJcxPQZYmUSZk3Pl2ARz/LRvW8Qu0+3mQ==",
           "dev": true,
           "requires": {
             "@types/retry": "^0.12.0",
@@ -4231,13 +4231,13 @@
       }
     },
     "@cumulus/common": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/common/-/common-5.0.0.tgz",
-      "integrity": "sha512-jL0tMyj6B1oTTpKKhMZ9AuMV2/LPYdvgW9c5e9gd59AuMpMPwCsqRRIaPpVKX6yLVBMOY7sVo5vUq7nZeSSORA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@cumulus/common/-/common-5.0.1.tgz",
+      "integrity": "sha512-QEFSQiLBWT9nh7gR3+W1tpmEuHbvJlY9wzsItsm47tYfifFmrJWBhVopxonhdvVD3+obIj8FI82IF3CFX9OiyA==",
       "dev": true,
       "requires": {
-        "@cumulus/errors": "5.0.0",
-        "@cumulus/logger": "5.0.0",
+        "@cumulus/errors": "5.0.1",
+        "@cumulus/logger": "5.0.1",
         "ajv": "^6.12.3",
         "aws-sdk": "^2.585.0",
         "follow-redirects": "^1.2.4",
@@ -4257,15 +4257,15 @@
       },
       "dependencies": {
         "@cumulus/errors": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-5.0.0.tgz",
-          "integrity": "sha512-hAJGLzR2C4BoZ98jQkOC8y4qxVW30leIyIgWbD9woQfJeYtKWZgp1pno9HnRozw+WaDwb3QNsYpJRPrpz4td1A==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-5.0.1.tgz",
+          "integrity": "sha512-gNHxTBqZE7ManuMxl5dxBwf0BcpMcJYTCpqulNUSaASGlHFHCV7lHq7Rc7k3Y9VdBOAtyJZbOF1WDOUljn32uw==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-5.0.0.tgz",
-          "integrity": "sha512-Ox8CCztwXDUNGuDgYDO98/RPQbYOQC8K2AKf5tVUzXEIwObwmABfWe9VeS2qkZn9Fm/3CeoJfXFZj5PJFlY/FA==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-5.0.1.tgz",
+          "integrity": "sha512-bLOYdO0iiYgNf6Ex/wY8/uqOzziTbyrsM9XbHedZCUxFClC1SEA3/rFgB3PPLNiF2mxZkF6qbTDWDe9eg+/CCg==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
@@ -4284,9 +4284,9 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.2.0.tgz",
-          "integrity": "sha512-jPH38/MRh263KKcq0wBNOGFJbm+U6784RilTmHjB/HM9kH9V8WlCpVUcdOmip9cjXOh6MxZ5yk1z2SjDUJfWmA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.3.0.tgz",
+          "integrity": "sha512-Pow4yaHpOiJou1QcpGcBJhGHiS4782LdDa6GhU91hlaNh3ExOOupjSJcxPQZYmUSZk3Pl2ARz/LRvW8Qu0+3mQ==",
           "dev": true,
           "requires": {
             "@types/retry": "^0.12.0",
@@ -4296,9 +4296,9 @@
       }
     },
     "@cumulus/earthdata-login-client": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/earthdata-login-client/-/earthdata-login-client-5.0.0.tgz",
-      "integrity": "sha512-SaeUr9RRJ0fJHZN7w0FFmRuFNK8ts1Rqa61usll3HObJGJTqqrXwFLsYcAMzW+GpAGkH9NZ5ZzNHtmxyUsEfBA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@cumulus/earthdata-login-client/-/earthdata-login-client-5.0.1.tgz",
+      "integrity": "sha512-dU0ogLocfImO5yEY6OxQADyN30S9/lXI2+ju0mHJubAzzbHtmGPZvJ76ydoDUyliLnNQOjHTijjPWu972V1/8Q==",
       "dev": true,
       "requires": {
         "got": "^11.7.0"
@@ -4311,16 +4311,16 @@
       "dev": true
     },
     "@cumulus/ingest": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/ingest/-/ingest-5.0.0.tgz",
-      "integrity": "sha512-jvC0K1sE24AGMqiQWv3CSBS7L3CBCgguwhtSHbwkFQfhyk6HwTglXEZi+ydJYGf1CrTSYvAlwUC/8TEJjZFWkw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@cumulus/ingest/-/ingest-5.0.1.tgz",
+      "integrity": "sha512-u0oVxcfdqdsDP5/Q0Cf0x9rnvwwfLwPRmxQ832kHe457WUfsCK1NgVVtVKff6yjgr7p+kvZTqFwWunBBOTF6Ug==",
       "dev": true,
       "requires": {
-        "@cumulus/aws-client": "5.0.0",
-        "@cumulus/common": "5.0.0",
-        "@cumulus/errors": "5.0.0",
-        "@cumulus/message": "5.0.0",
-        "@cumulus/sftp-client": "5.0.0",
+        "@cumulus/aws-client": "5.0.1",
+        "@cumulus/common": "5.0.1",
+        "@cumulus/errors": "5.0.1",
+        "@cumulus/message": "5.0.1",
+        "@cumulus/sftp-client": "5.0.1",
         "aws-sdk": "^2.585.0",
         "cksum": "^1.3.0",
         "delay": "^4.3.0",
@@ -4338,14 +4338,14 @@
       },
       "dependencies": {
         "@cumulus/aws-client": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-5.0.0.tgz",
-          "integrity": "sha512-H+rGIr/GACpN/a7G8CkGqBjcxVUJYMzhwu5FTGyoXQI69Yye1Prlzbt64HqsdoG2WHG6K4jS7BBxb61vp2H4uA==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-5.0.1.tgz",
+          "integrity": "sha512-wFzmxbc+GmRAzMy7zG0HC/vxlq+G6aEJ/Gv69ivG6gTQ6lT2mC8l/PwNmVwllCjhdtYn5ZvDSwvj8a+BbBXj2Q==",
           "dev": true,
           "requires": {
-            "@cumulus/checksum": "5.0.0",
-            "@cumulus/errors": "5.0.0",
-            "@cumulus/logger": "5.0.0",
+            "@cumulus/checksum": "5.0.1",
+            "@cumulus/errors": "5.0.1",
+            "@cumulus/logger": "5.0.1",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.20",
@@ -4356,24 +4356,24 @@
           }
         },
         "@cumulus/checksum": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-5.0.0.tgz",
-          "integrity": "sha512-wuwQFVS8UazHgbhgNPfacHOMvDDNdgdUNjkS+r/JsR1JpsNAnmxtMCVZz2fqUd1EFgCaNZbqhL2njbWdDVA0Pg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-5.0.1.tgz",
+          "integrity": "sha512-0Nb89tF/ZswMRlRSGxG1i2LLpDrD1b7bdhJqTF5YsqvC3z0NKXG6ECNfmWFC3x8XnSW+FydLu550lddZgmaMFQ==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-5.0.0.tgz",
-          "integrity": "sha512-hAJGLzR2C4BoZ98jQkOC8y4qxVW30leIyIgWbD9woQfJeYtKWZgp1pno9HnRozw+WaDwb3QNsYpJRPrpz4td1A==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-5.0.1.tgz",
+          "integrity": "sha512-gNHxTBqZE7ManuMxl5dxBwf0BcpMcJYTCpqulNUSaASGlHFHCV7lHq7Rc7k3Y9VdBOAtyJZbOF1WDOUljn32uw==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-5.0.0.tgz",
-          "integrity": "sha512-Ox8CCztwXDUNGuDgYDO98/RPQbYOQC8K2AKf5tVUzXEIwObwmABfWe9VeS2qkZn9Fm/3CeoJfXFZj5PJFlY/FA==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-5.0.1.tgz",
+          "integrity": "sha512-bLOYdO0iiYgNf6Ex/wY8/uqOzziTbyrsM9XbHedZCUxFClC1SEA3/rFgB3PPLNiF2mxZkF6qbTDWDe9eg+/CCg==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
@@ -4401,9 +4401,9 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.2.0.tgz",
-          "integrity": "sha512-jPH38/MRh263KKcq0wBNOGFJbm+U6784RilTmHjB/HM9kH9V8WlCpVUcdOmip9cjXOh6MxZ5yk1z2SjDUJfWmA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.3.0.tgz",
+          "integrity": "sha512-Pow4yaHpOiJou1QcpGcBJhGHiS4782LdDa6GhU91hlaNh3ExOOupjSJcxPQZYmUSZk3Pl2ARz/LRvW8Qu0+3mQ==",
           "dev": true,
           "requires": {
             "@types/retry": "^0.12.0",
@@ -4439,27 +4439,27 @@
       }
     },
     "@cumulus/launchpad-auth": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/launchpad-auth/-/launchpad-auth-5.0.0.tgz",
-      "integrity": "sha512-tH/QhdX2tcFzQEbXf4OT1HLXPSBBD299N6a/nmodflywZtGfioZUWt7TLBAhB3KfbQLb6D9j0dD107RoUYU2VA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@cumulus/launchpad-auth/-/launchpad-auth-5.0.1.tgz",
+      "integrity": "sha512-tRbseqjGKDIQerhfZCIzj9g+/iHPdQ6tVmzposciU0oucF3xiKNtNHjdchJc46kcChKo61ZEV404T4zm4o9rwA==",
       "dev": true,
       "requires": {
-        "@cumulus/aws-client": "5.0.0",
-        "@cumulus/logger": "5.0.0",
+        "@cumulus/aws-client": "5.0.1",
+        "@cumulus/logger": "5.0.1",
         "got": "^11.7.0",
         "lodash": "^4.17.20",
         "uuid": "^3.2.1"
       },
       "dependencies": {
         "@cumulus/aws-client": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-5.0.0.tgz",
-          "integrity": "sha512-H+rGIr/GACpN/a7G8CkGqBjcxVUJYMzhwu5FTGyoXQI69Yye1Prlzbt64HqsdoG2WHG6K4jS7BBxb61vp2H4uA==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-5.0.1.tgz",
+          "integrity": "sha512-wFzmxbc+GmRAzMy7zG0HC/vxlq+G6aEJ/Gv69ivG6gTQ6lT2mC8l/PwNmVwllCjhdtYn5ZvDSwvj8a+BbBXj2Q==",
           "dev": true,
           "requires": {
-            "@cumulus/checksum": "5.0.0",
-            "@cumulus/errors": "5.0.0",
-            "@cumulus/logger": "5.0.0",
+            "@cumulus/checksum": "5.0.1",
+            "@cumulus/errors": "5.0.1",
+            "@cumulus/logger": "5.0.1",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.20",
@@ -4470,24 +4470,24 @@
           }
         },
         "@cumulus/checksum": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-5.0.0.tgz",
-          "integrity": "sha512-wuwQFVS8UazHgbhgNPfacHOMvDDNdgdUNjkS+r/JsR1JpsNAnmxtMCVZz2fqUd1EFgCaNZbqhL2njbWdDVA0Pg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-5.0.1.tgz",
+          "integrity": "sha512-0Nb89tF/ZswMRlRSGxG1i2LLpDrD1b7bdhJqTF5YsqvC3z0NKXG6ECNfmWFC3x8XnSW+FydLu550lddZgmaMFQ==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-5.0.0.tgz",
-          "integrity": "sha512-hAJGLzR2C4BoZ98jQkOC8y4qxVW30leIyIgWbD9woQfJeYtKWZgp1pno9HnRozw+WaDwb3QNsYpJRPrpz4td1A==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-5.0.1.tgz",
+          "integrity": "sha512-gNHxTBqZE7ManuMxl5dxBwf0BcpMcJYTCpqulNUSaASGlHFHCV7lHq7Rc7k3Y9VdBOAtyJZbOF1WDOUljn32uw==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-5.0.0.tgz",
-          "integrity": "sha512-Ox8CCztwXDUNGuDgYDO98/RPQbYOQC8K2AKf5tVUzXEIwObwmABfWe9VeS2qkZn9Fm/3CeoJfXFZj5PJFlY/FA==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-5.0.1.tgz",
+          "integrity": "sha512-bLOYdO0iiYgNf6Ex/wY8/uqOzziTbyrsM9XbHedZCUxFClC1SEA3/rFgB3PPLNiF2mxZkF6qbTDWDe9eg+/CCg==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
@@ -4500,9 +4500,9 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.2.0.tgz",
-          "integrity": "sha512-jPH38/MRh263KKcq0wBNOGFJbm+U6784RilTmHjB/HM9kH9V8WlCpVUcdOmip9cjXOh6MxZ5yk1z2SjDUJfWmA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.3.0.tgz",
+          "integrity": "sha512-Pow4yaHpOiJou1QcpGcBJhGHiS4782LdDa6GhU91hlaNh3ExOOupjSJcxPQZYmUSZk3Pl2ARz/LRvW8Qu0+3mQ==",
           "dev": true,
           "requires": {
             "@types/retry": "^0.12.0",
@@ -4530,29 +4530,29 @@
       }
     },
     "@cumulus/message": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/message/-/message-5.0.0.tgz",
-      "integrity": "sha512-s/4d+3AlD2yii3xY9ec4YIesFOH8au/W1a16IeIT7CSxmt7QzJs1cOLmNjIw6+Y1twKesmF2qH+zrhDms4n0Lg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@cumulus/message/-/message-5.0.1.tgz",
+      "integrity": "sha512-ASVgrDIG4+LOxbt4ZKURAeRfY+JDgr5zN6twgSRe76N3VaRruBWq3JyP1ICweWzt7qMrkpu3P6pVO/JTccoQXg==",
       "dev": true,
       "requires": {
-        "@cumulus/aws-client": "5.0.0",
-        "@cumulus/common": "5.0.0",
-        "@cumulus/logger": "5.0.0",
-        "@cumulus/types": "5.0.0",
+        "@cumulus/aws-client": "5.0.1",
+        "@cumulus/common": "5.0.1",
+        "@cumulus/logger": "5.0.1",
+        "@cumulus/types": "5.0.1",
         "jsonpath-plus": "^3.0.0",
         "lodash": "^4.17.20",
         "uuid": "^8.2.0"
       },
       "dependencies": {
         "@cumulus/aws-client": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-5.0.0.tgz",
-          "integrity": "sha512-H+rGIr/GACpN/a7G8CkGqBjcxVUJYMzhwu5FTGyoXQI69Yye1Prlzbt64HqsdoG2WHG6K4jS7BBxb61vp2H4uA==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-5.0.1.tgz",
+          "integrity": "sha512-wFzmxbc+GmRAzMy7zG0HC/vxlq+G6aEJ/Gv69ivG6gTQ6lT2mC8l/PwNmVwllCjhdtYn5ZvDSwvj8a+BbBXj2Q==",
           "dev": true,
           "requires": {
-            "@cumulus/checksum": "5.0.0",
-            "@cumulus/errors": "5.0.0",
-            "@cumulus/logger": "5.0.0",
+            "@cumulus/checksum": "5.0.1",
+            "@cumulus/errors": "5.0.1",
+            "@cumulus/logger": "5.0.1",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.20",
@@ -4571,24 +4571,24 @@
           }
         },
         "@cumulus/checksum": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-5.0.0.tgz",
-          "integrity": "sha512-wuwQFVS8UazHgbhgNPfacHOMvDDNdgdUNjkS+r/JsR1JpsNAnmxtMCVZz2fqUd1EFgCaNZbqhL2njbWdDVA0Pg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-5.0.1.tgz",
+          "integrity": "sha512-0Nb89tF/ZswMRlRSGxG1i2LLpDrD1b7bdhJqTF5YsqvC3z0NKXG6ECNfmWFC3x8XnSW+FydLu550lddZgmaMFQ==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-5.0.0.tgz",
-          "integrity": "sha512-hAJGLzR2C4BoZ98jQkOC8y4qxVW30leIyIgWbD9woQfJeYtKWZgp1pno9HnRozw+WaDwb3QNsYpJRPrpz4td1A==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-5.0.1.tgz",
+          "integrity": "sha512-gNHxTBqZE7ManuMxl5dxBwf0BcpMcJYTCpqulNUSaASGlHFHCV7lHq7Rc7k3Y9VdBOAtyJZbOF1WDOUljn32uw==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-5.0.0.tgz",
-          "integrity": "sha512-Ox8CCztwXDUNGuDgYDO98/RPQbYOQC8K2AKf5tVUzXEIwObwmABfWe9VeS2qkZn9Fm/3CeoJfXFZj5PJFlY/FA==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-5.0.1.tgz",
+          "integrity": "sha512-bLOYdO0iiYgNf6Ex/wY8/uqOzziTbyrsM9XbHedZCUxFClC1SEA3/rFgB3PPLNiF2mxZkF6qbTDWDe9eg+/CCg==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
@@ -4607,9 +4607,9 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.2.0.tgz",
-          "integrity": "sha512-jPH38/MRh263KKcq0wBNOGFJbm+U6784RilTmHjB/HM9kH9V8WlCpVUcdOmip9cjXOh6MxZ5yk1z2SjDUJfWmA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.3.0.tgz",
+          "integrity": "sha512-Pow4yaHpOiJou1QcpGcBJhGHiS4782LdDa6GhU91hlaNh3ExOOupjSJcxPQZYmUSZk3Pl2ARz/LRvW8Qu0+3mQ==",
           "dev": true,
           "requires": {
             "@types/retry": "^0.12.0",
@@ -4634,36 +4634,36 @@
       }
     },
     "@cumulus/pvl": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/pvl/-/pvl-5.0.0.tgz",
-      "integrity": "sha512-or/H8CiHb+cS3SNnjgs0i57zTmt8bC7qVwW19F8UD4KrVPtagX5cOBwOJFL9uE0b3bajt2hn7WccDkJS2RjdYg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@cumulus/pvl/-/pvl-5.0.1.tgz",
+      "integrity": "sha512-AKKQMiQFoDYqfbMCxoy6FQu92isOIAuMf+7Gft1UU84AUDFMMrzTtCKNjZ5Bb5z/WLcbNyrehCEgUF4yWJTgZw==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.20"
       }
     },
     "@cumulus/sftp-client": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/sftp-client/-/sftp-client-5.0.0.tgz",
-      "integrity": "sha512-hZ++E6tGwHsz3aus2/7Nph3YGF0yPglmvtmIU6lWGCDgUvL7Hp3a+ua/hemurfuFXtPF2CTJMXhEK010NYXDGg==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@cumulus/sftp-client/-/sftp-client-5.0.1.tgz",
+      "integrity": "sha512-4CjNp7SIMVOmfVCasVZdSA0NPqo9gd7E7YBPk/shbeIe4NzjeokFXAaEiXBsvyYYeCiorPaHqB0hdT2Xw8PO6w==",
       "dev": true,
       "requires": {
-        "@cumulus/aws-client": "5.0.0",
-        "@cumulus/common": "5.0.0",
+        "@cumulus/aws-client": "5.0.1",
+        "@cumulus/common": "5.0.1",
         "lodash": "^4.17.20",
         "mime-types": "^2.1.27",
         "ssh2-sftp-client": "^5.2.1"
       },
       "dependencies": {
         "@cumulus/aws-client": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-5.0.0.tgz",
-          "integrity": "sha512-H+rGIr/GACpN/a7G8CkGqBjcxVUJYMzhwu5FTGyoXQI69Yye1Prlzbt64HqsdoG2WHG6K4jS7BBxb61vp2H4uA==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-5.0.1.tgz",
+          "integrity": "sha512-wFzmxbc+GmRAzMy7zG0HC/vxlq+G6aEJ/Gv69ivG6gTQ6lT2mC8l/PwNmVwllCjhdtYn5ZvDSwvj8a+BbBXj2Q==",
           "dev": true,
           "requires": {
-            "@cumulus/checksum": "5.0.0",
-            "@cumulus/errors": "5.0.0",
-            "@cumulus/logger": "5.0.0",
+            "@cumulus/checksum": "5.0.1",
+            "@cumulus/errors": "5.0.1",
+            "@cumulus/logger": "5.0.1",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.20",
@@ -4674,24 +4674,24 @@
           }
         },
         "@cumulus/checksum": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-5.0.0.tgz",
-          "integrity": "sha512-wuwQFVS8UazHgbhgNPfacHOMvDDNdgdUNjkS+r/JsR1JpsNAnmxtMCVZz2fqUd1EFgCaNZbqhL2njbWdDVA0Pg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-5.0.1.tgz",
+          "integrity": "sha512-0Nb89tF/ZswMRlRSGxG1i2LLpDrD1b7bdhJqTF5YsqvC3z0NKXG6ECNfmWFC3x8XnSW+FydLu550lddZgmaMFQ==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-5.0.0.tgz",
-          "integrity": "sha512-hAJGLzR2C4BoZ98jQkOC8y4qxVW30leIyIgWbD9woQfJeYtKWZgp1pno9HnRozw+WaDwb3QNsYpJRPrpz4td1A==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-5.0.1.tgz",
+          "integrity": "sha512-gNHxTBqZE7ManuMxl5dxBwf0BcpMcJYTCpqulNUSaASGlHFHCV7lHq7Rc7k3Y9VdBOAtyJZbOF1WDOUljn32uw==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-5.0.0.tgz",
-          "integrity": "sha512-Ox8CCztwXDUNGuDgYDO98/RPQbYOQC8K2AKf5tVUzXEIwObwmABfWe9VeS2qkZn9Fm/3CeoJfXFZj5PJFlY/FA==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-5.0.1.tgz",
+          "integrity": "sha512-bLOYdO0iiYgNf6Ex/wY8/uqOzziTbyrsM9XbHedZCUxFClC1SEA3/rFgB3PPLNiF2mxZkF6qbTDWDe9eg+/CCg==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
@@ -4719,9 +4719,9 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.2.0.tgz",
-          "integrity": "sha512-jPH38/MRh263KKcq0wBNOGFJbm+U6784RilTmHjB/HM9kH9V8WlCpVUcdOmip9cjXOh6MxZ5yk1z2SjDUJfWmA==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.3.0.tgz",
+          "integrity": "sha512-Pow4yaHpOiJou1QcpGcBJhGHiS4782LdDa6GhU91hlaNh3ExOOupjSJcxPQZYmUSZk3Pl2ARz/LRvW8Qu0+3mQ==",
           "dev": true,
           "requires": {
             "@types/retry": "^0.12.0",
@@ -4740,9 +4740,9 @@
       }
     },
     "@cumulus/types": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/types/-/types-5.0.0.tgz",
-      "integrity": "sha512-acVhb/1MfxtxsqY2qcrzoA+p85u9f762dpYT26pR7bhwRAtR2XZesPVt/2bsIsTFuhx0MaPmWYq2RjnaFsbdGw==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@cumulus/types/-/types-5.0.1.tgz",
+      "integrity": "sha512-A8tJYiOc3BUMsyk/kqafs1sYlv+xuIvZJXnLsPSX9MwRuFcK1c5YDP6sccIiSunECib84FhmjbApdAo6VZyMzQ==",
       "dev": true
     },
     "@cypress/listr-verbose-renderer": {
@@ -5123,6 +5123,42 @@
           "dev": true
         }
       }
+    },
+    "@oozcitak/dom": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-1.15.8.tgz",
+      "integrity": "sha512-MoOnLBNsF+ok0HjpAvxYxR4piUhRDCEWK0ot3upwOOHYudJd30j6M+LNcE8RKpwfnclAX9T66nXXzkytd29XSw==",
+      "dev": true,
+      "requires": {
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/url": "1.0.4",
+        "@oozcitak/util": "8.3.8"
+      }
+    },
+    "@oozcitak/infra": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@oozcitak/infra/-/infra-1.0.8.tgz",
+      "integrity": "sha512-JRAUc9VR6IGHOL7OGF+yrvs0LO8SlqGnPAMqyzOuFZPSZSXI7Xf2O9+awQPSMXgIWGtgUf/dA6Hs6X6ySEaWTg==",
+      "dev": true,
+      "requires": {
+        "@oozcitak/util": "8.3.8"
+      }
+    },
+    "@oozcitak/url": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@oozcitak/url/-/url-1.0.4.tgz",
+      "integrity": "sha512-kDcD8y+y3FCSOvnBI6HJgl00viO/nGbQoCINmQ0h98OhnGITrWR3bOGfwYCthgcrV8AnTJz8MzslTQbC3SOAmw==",
+      "dev": true,
+      "requires": {
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/util": "8.3.8"
+      }
+    },
+    "@oozcitak/util": {
+      "version": "8.3.8",
+      "resolved": "https://registry.npmjs.org/@oozcitak/util/-/util-8.3.8.tgz",
+      "integrity": "sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==",
+      "dev": true
     },
     "@popperjs/core": {
       "version": "2.5.4",
@@ -10407,9 +10443,9 @@
       }
     },
     "delay": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/delay/-/delay-4.4.0.tgz",
-      "integrity": "sha512-txgOrJu3OdtOfTiEOT2e76dJVfG/1dz2NZ4F0Pyt4UGZJryssMRp5vdM5wQoLwSOBNdrJv3F9PAhp/heqd7vrA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/delay/-/delay-4.4.1.tgz",
+      "integrity": "sha512-aL3AhqtfhOlT/3ai6sWXeqwnw63ATNpnUiN4HL7x9q+My5QtHlO3OIkasmug9LKzpheLdmUKGRKnYXYAS7FQkQ==",
       "dev": true
     },
     "delayed-stream": {
@@ -13124,9 +13160,9 @@
       }
     },
     "google-auth-library": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.4.tgz",
-      "integrity": "sha512-q0kYtGWnDd9XquwiQGAZeI2Jnglk7NDi0cChE4tWp6Kpo/kbqnt9scJb0HP+/xqt03Beqw/xQah1OPrci+pOxw==",
+      "version": "6.1.6",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.6.tgz",
+      "integrity": "sha512-Q+ZjUEvLQj/lrVHF/IQwRo6p3s8Nc44Zk/DALsN+ac3T4HY/g/3rrufkgtl+nZ1TW7DNAw5cTChdVp4apUXVgQ==",
       "dev": true,
       "requires": {
         "arrify": "^2.0.0",
@@ -13160,21 +13196,6 @@
             "jwa": "^2.0.0",
             "safe-buffer": "^5.0.1"
           }
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-          "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-          "dev": true
         }
       }
     },
@@ -13350,15 +13371,14 @@
       }
     },
     "gtoken": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.1.0.tgz",
-      "integrity": "sha512-4d8N6Lk8TEAHl9vVoRVMh9BNOKWVgl2DdNtr3428O75r3QFrF/a5MMu851VmK0AA8+iSvbwRv69k5XnMLURGhg==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.2.1.tgz",
+      "integrity": "sha512-OY0BfPKe3QnMsY9MzTHTSKn+Vl2l1CcLe6BwDEQj00mbbkl5nyQ/7EUREstg4fQNZ8iYE7br4JJ7TdKeDOPWmw==",
       "dev": true,
       "requires": {
         "gaxios": "^4.0.0",
         "google-p12-pem": "^3.0.3",
-        "jws": "^4.0.0",
-        "mime": "^2.2.0"
+        "jws": "^4.0.0"
       },
       "dependencies": {
         "jwa": {
@@ -13381,12 +13401,6 @@
             "jwa": "^2.0.0",
             "safe-buffer": "^5.0.1"
           }
-        },
-        "mime": {
-          "version": "2.4.7",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.7.tgz",
-          "integrity": "sha512-dhNd1uA2u397uQk3Nv5LM4lm93WYDUXFn3Fu291FJerns4jyTudqhIWe4W04YLy7Uk1tm1Ore04NpjRvQp/NPA==",
-          "dev": true
         }
       }
     },
@@ -14701,9 +14715,9 @@
       },
       "dependencies": {
         "ip-regex": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.2.0.tgz",
-          "integrity": "sha512-n5cDDeTWWRwK1EBoWwRti+8nP4NbytBBY0pldmnIkq6Z55KNFmWofh4rl9dPZpj+U/nVq7gweR3ylrvMt4YZ5A==",
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.3.0.tgz",
+          "integrity": "sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==",
           "dev": true
         }
       }
@@ -15624,12 +15638,6 @@
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.15.tgz",
       "integrity": "sha512-rlrc3yU3+JNOpZ9zj5pQtxnx2THmvRykwL4Xlxoa8I9lHBlVbbyPhgyPMioxVZ4NqyxaVVtaJnzsyOidQIhyyQ=="
-    },
-    "lodash-node": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/lodash-node/-/lodash-node-2.4.1.tgz",
-      "integrity": "sha1-6oL3sQDHM9GkKvdoAeUGEF4qgOw=",
-      "dev": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",
@@ -20700,59 +20708,35 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "saml2-js": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/saml2-js/-/saml2-js-2.0.6.tgz",
-      "integrity": "sha512-fWGlF0vMpx0MtOgXYWZ5EoHOy2yIEzVkCk28vlNeXOPcvNMH9FQqxWjHCUm+E7aBSLBugB7FeNSx0tYdkQe72Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/saml2-js/-/saml2-js-2.1.0.tgz",
+      "integrity": "sha512-VY97pu1lpXKXjrHU61VfiD23+VtlqCCYf18zohu9zF5YR+fRVoEMttce8AQQAO2IIuX6z9+nTkuf80XUEQRaGg==",
       "dev": true,
       "requires": {
-        "async": "^2.5.0",
-        "debug": "^2.6.0",
+        "async": "^3.2.0",
+        "debug": "^4.3.0",
         "underscore": "^1.8.0",
         "xml-crypto": "^0.10.0",
         "xml-encryption": "^1.2.1",
         "xml2js": "^0.4.0",
-        "xmlbuilder": "~2.2.0",
-        "xmldom": "^0.1.0"
+        "xmlbuilder2": "^2.4.0",
+        "xmldom": "^0.4.0"
       },
       "dependencies": {
-        "async": {
-          "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
-          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
-          "dev": true,
-          "requires": {
-            "lodash": "^4.17.14"
-          }
-        },
         "debug": {
-          "version": "2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-          "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
-            "ms": "2.0.0"
+            "ms": "2.1.2"
           }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
         },
         "underscore": {
           "version": "1.12.0",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.0.tgz",
           "integrity": "sha512-21rQzss/XPMjolTiIezSu3JAjgagXKROtNrYFEOWK109qY1Uv2tVjPTZ1ci2HgvQDA16gHYSthQIJfB+XId/rQ==",
           "dev": true
-        },
-        "xmlbuilder": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-2.2.1.tgz",
-          "integrity": "sha1-kyZDDxMNh0NdTECGZDqikm4QWjI=",
-          "dev": true,
-          "requires": {
-            "lodash-node": "~2.4.1"
-          }
         }
       }
     },
@@ -20941,9 +20925,9 @@
       "dev": true
     },
     "secure-json-parse": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.2.0.tgz",
-      "integrity": "sha512-OYpk8nU1g9+5u6HZ+OOMZVpD037Jo5E9QzdDdQRe6b9ZPWOoB85AenHz5Rd90UwG8zdef69dO0axSosdBsDK9Q==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.3.0.tgz",
+      "integrity": "sha512-kEyTf2cpnuqp7Aiem+yz3QWgm58pYbLlYg4TnVWChZkUBQTcolYZIYRQXmXvEtGJGJ532LREyc8d7pbu9utu7A==",
       "dev": true
     },
     "select-hose": {
@@ -25177,6 +25161,14 @@
         "node-forge": "^0.10.0",
         "xmldom": "~0.1.15",
         "xpath": "0.0.27"
+      },
+      "dependencies": {
+        "xmldom": {
+          "version": "0.1.31",
+          "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
+          "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
+          "dev": true
+        }
       }
     },
     "xml-name-validator": {
@@ -25209,6 +25201,37 @@
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
       "dev": true
     },
+    "xmlbuilder2": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-2.4.0.tgz",
+      "integrity": "sha512-KrOVUGD65xTQ7ZA+GMQGdBSpe1Ufu5ylCQSYVk6QostySDkxPmAQ0WWIu7dR3JjLfVbF22RFQX7KyrZ6VTLcQg==",
+      "dev": true,
+      "requires": {
+        "@oozcitak/dom": "1.15.8",
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/util": "8.3.8",
+        "@types/node": "14.6.2",
+        "js-yaml": "3.14.0"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "14.6.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.2.tgz",
+          "integrity": "sha512-onlIwbaeqvZyniGPfdw/TEhKIh79pz66L1q06WUQqJLnAb6wbjvOtepLYTGHTqzdXgBYIE3ZdmqHDGsRsbBz7A==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.14.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+          "integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
+      }
+    },
     "xmlchars": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
@@ -25222,9 +25245,9 @@
       "dev": true
     },
     "xmldom": {
-      "version": "0.1.31",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
-      "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.4.0.tgz",
+      "integrity": "sha512-2E93k08T30Ugs+34HBSTQLVtpi6mCddaY8uO+pMNk1pqSjV5vElzn4mmh6KLxN3hki8rNcHSYzILoh3TEWORvA==",
       "dev": true
     },
     "xpath": {

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@babel/preset-react": "^7.10.4",
     "@babel/register": "^7.12.0",
     "@babel/runtime": "^7.12.0",
-    "@cumulus/api": "5.0.0",
+    "@cumulus/api": "5.0.2-alpha.0",
     "@cumulus/aws-client": "4.0.0",
     "@cypress/webpack-preprocessor": "^4.1.5",
     "audit-ci": "^3.1.1",

--- a/test/components/reconciliation-reports/reconciliation-report.js
+++ b/test/components/reconciliation-reports/reconciliation-report.js
@@ -238,7 +238,7 @@ test('report with error triggers error message', function (t) {
   t.is(ErrorReport.dive().find('ShowMoreOrLess').props().text, reconciliationReports.map.exampleReportWithError.data.error);
 });
 
-test.only('report which exceeds maximum allowed payload size triggers error message', function (t) {
+test('report which exceeds maximum allowed payload size triggers error message', function (t) {
   const match = { params: { reconciliationReportName: 'exampleReportExceedsPayloadLimit' } };
 
   const dispatch = () => {};

--- a/test/components/reconciliation-reports/reconciliation-report.js
+++ b/test/components/reconciliation-reports/reconciliation-report.js
@@ -13,79 +13,91 @@ const reconciliationReports = {
   map: {
     exampleInventoryReport: {
       data: {
-        reportStartTime: '2018-06-11T18:52:37.710Z',
-        reportEndTime: '2018-06-11T18:52:39.893Z',
-        status: 'SUCCESS',
-        error: null,
-        reportType: 'Inventory',
-        okFileCount: 21,
-        filesInCumulus: {
-          okCount: 129,
-          onlyInS3: [
-            's3://some-bucket/path/to/key-1.hdf',
-            's3://some-bucket/path/to/key-2.hdf'
-          ],
-          onlyInDynamoDb: [
-            {
-              uri: 's3://some-bucket/path/to/key-123.hdf',
-              granuleId: 'g-123'
-            },
-            {
-              uri: 's3://some-bucket/path/to/key-456.hdf',
-              granuleId: 'g-456'
-            }
-          ],
-        },
-        collectionsInCumulusCmr: {
-          okCount: 1
-        },
-        granulesInCumulusCmr: {
-          okCount: 7
-        },
-        filesInCumulusCmr: {
-          okCount: 4
+        presignedS3Url: 'https://example.amazonaws.com/example',
+        data: {
+          reportStartTime: '2018-06-11T18:52:37.710Z',
+          reportEndTime: '2018-06-11T18:52:39.893Z',
+          status: 'SUCCESS',
+          error: null,
+          reportType: 'Inventory',
+          okFileCount: 21,
+          filesInCumulus: {
+            okCount: 129,
+            onlyInS3: [
+              's3://some-bucket/path/to/key-1.hdf',
+              's3://some-bucket/path/to/key-2.hdf'
+            ],
+            onlyInDynamoDb: [
+              {
+                uri: 's3://some-bucket/path/to/key-123.hdf',
+                granuleId: 'g-123'
+              },
+              {
+                uri: 's3://some-bucket/path/to/key-456.hdf',
+                granuleId: 'g-456'
+              }
+            ],
+          },
+          collectionsInCumulusCmr: {
+            okCount: 1
+          },
+          granulesInCumulusCmr: {
+            okCount: 7
+          },
+          filesInCumulusCmr: {
+            okCount: 4
+          }
         }
-      }
+      },
     },
     exampleGranuleNotFoundReport: {
       data: {
-        createStartTime: '2018-06-11T18:52:37.710Z',
-        createEndTime: '2018-06-11T18:52:39.893Z',
-        status: 'SUCCESS',
-        error: null,
-        reportType: 'Granule Not Found',
-        okFileCount: 21,
-        filesInCumulus: {
-          okCount: 129,
-          onlyInS3: [
-            's3://some-bucket/path/to/key-1.hdf',
-            's3://some-bucket/path/to/key-2.hdf'
-          ],
-          onlyInDynamoDb: [
-            {
-              uri: 's3://some-bucket/path/to/key-123.hdf',
-              granuleId: 'g-123'
-            },
-            {
-              uri: 's3://some-bucket/path/to/key-456.hdf',
-              granuleId: 'g-456'
-            }
-          ],
-        },
-        collectionsInCumulusCmr: {
-          okCount: 1
-        },
-        granulesInCumulusCmr: {
-          okCount: 7
-        },
-        filesInCumulusCmr: {
-          okCount: 4
+        presignedS3Url: 'https://example.amazonaws.com/example',
+        data: {
+          createStartTime: '2018-06-11T18:52:37.710Z',
+          createEndTime: '2018-06-11T18:52:39.893Z',
+          status: 'SUCCESS',
+          error: null,
+          reportType: 'Granule Not Found',
+          okFileCount: 21,
+          filesInCumulus: {
+            okCount: 129,
+            onlyInS3: [
+              's3://some-bucket/path/to/key-1.hdf',
+              's3://some-bucket/path/to/key-2.hdf'
+            ],
+            onlyInDynamoDb: [
+              {
+                uri: 's3://some-bucket/path/to/key-123.hdf',
+                granuleId: 'g-123'
+              },
+              {
+                uri: 's3://some-bucket/path/to/key-456.hdf',
+                granuleId: 'g-456'
+              }
+            ],
+          },
+          collectionsInCumulusCmr: {
+            okCount: 1
+          },
+          granulesInCumulusCmr: {
+            okCount: 7
+          },
+          filesInCumulusCmr: {
+            okCount: 4
+          }
         }
-      }
+      },
     },
     exampleReportWithError: {
       data: {
         error: 'error creating report'
+      }
+    },
+    exampleReportExceedsPayloadLimit: {
+      data: {
+        presignedS3Url: 'https://example.amazonaws.com/example',
+        data: 'Error: Report examplereport exceeded maximum allowed payload size',
       }
     }
   },
@@ -224,4 +236,34 @@ test('report with error triggers error message', function (t) {
   const props = ErrorReport.props();
   t.is(props.report, reconciliationReports.map.exampleReportWithError.data.error);
   t.is(ErrorReport.dive().find('ShowMoreOrLess').props().text, reconciliationReports.map.exampleReportWithError.data.error);
+});
+
+test.only('report which exceeds maximum allowed payload size triggers error message', function (t) {
+  const match = { params: { reconciliationReportName: 'exampleReportExceedsPayloadLimit' } };
+
+  const dispatch = () => {};
+
+  const report = shallow(
+    <ReconciliationReport
+      match={match}
+      reconciliationReports={reconciliationReports}
+      dispatch={dispatch}
+    />
+  );
+
+  t.is(report.length, 1);
+
+  const InventoryReport = report.find('InventoryReport');
+  t.is(InventoryReport.length, 1);
+  const inventoryReportWrapper = InventoryReport.dive();
+
+  const ReportHeading = inventoryReportWrapper.find('ReportHeading');
+  t.is(ReportHeading.length, 1);
+  const reportHeadingWrapper = ReportHeading.dive();
+
+  const ErrorReport = reportHeadingWrapper.find('ErrorReport');
+  const props = ErrorReport.props();
+  const errorMessage = reconciliationReports.map.exampleReportExceedsPayloadLimit.data.data;
+  t.true(props.report.includes(errorMessage));
+  t.true(ErrorReport.dive().find('ShowMoreOrLess').props().text.includes(errorMessage));
 });


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2321: reconciliationReport endpoint cannot send an "overlarge" json object](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2321)

## Changes

* reconciliationReport API now returns pre-signed URL and data, so update reconciliation report to work with the API endpoint changes
* If the report data is an error message (payload size exceeds max), Inventory report and GNF pages won't be displayed, instead, the page will display error.

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Adhoc testing
- [x] Integration tests