### PR TITLE
CUMULUS-2419: Fixes log viewer query for cloud metrics log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Breaking Changes
 
-This version of the dashboard requires Cumulus API v5.0.2-alpha.0
+This version of the dashboard requires Cumulus API 7.0.0
 
 ### Fixed
 
@@ -25,6 +25,9 @@ This version of the dashboard requires Cumulus API v5.0.2-alpha.0
 
 - **CUMULUS-2415**
   - Fixes issue with executions not always displaying the graph corresponding to the current execution
+
+- **CUMULUS-2419**
+  - Fixes log viewer query for cloud metrics log
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This version of the dashboard requires Cumulus API 7.0.0
 
 - **CUMULUS-2419**
   - Fixes log viewer query for cloud metrics log
+  - Requires @cumulus/api@7.0.0
 
 ### Changed
 

--- a/app/src/js/components/Granules/granule.js
+++ b/app/src/js/components/Granules/granule.js
@@ -337,7 +337,6 @@ class GranuleOverview extends React.Component {
           <LogViewer
             query={{ q: granuleId }}
             dispatch={this.props.dispatch}
-            logs={this.props.logs}
             notFound={`No recent logs for ${granuleId}`}
           />
         </section>

--- a/app/src/js/components/Granules/list.js
+++ b/app/src/js/components/Granules/list.js
@@ -51,7 +51,7 @@ const AllGranules = ({
   const { dropdowns } = collections;
   const { list } = granules;
   const { count, queriedAt } = list.meta;
-  const logsQuery = { granuleId__exists: 'true' };
+  const logsQuery = { granules__exists: 'true', executions__exists: 'true' };
   const query = generateQuery();
   const view = getView();
   const displayCaseView = displayCase(view);
@@ -247,7 +247,6 @@ const AllGranules = ({
       <LogViewer
         query={logsQuery}
         dispatch={dispatch}
-        logs={logs}
         notFound="No recent logs for granules"
       />
     </div>

--- a/app/src/js/components/Logs/viewer.js
+++ b/app/src/js/components/Logs/viewer.js
@@ -111,9 +111,6 @@ const LogViewer = ({
   }
 
   function searchLogs() {
-    cancelIntervalRef.current();
-    dispatch(clearLogs());
-
     const queryFunction = () => dispatch(getLogs(buildQuery()));
     cancelIntervalRef.current = interval(queryFunction, logsUpdateInterval, true);
   }
@@ -127,6 +124,11 @@ const LogViewer = ({
 
   useEffect(() => {
     searchLogs();
+    return function cleanup() {
+      cancelIntervalRef.current();
+      cancelIntervalRef.current = noop;
+      dispatch(clearLogs());
+    };
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dispatch, JSON.stringify(fetchCurrentTimeFilters(datepicker)), level, searchText]);
 
@@ -136,12 +138,6 @@ const LogViewer = ({
       cancelIntervalRef.current = noop;
     }
   }, [logs]);
-
-  useEffect(() => () => {
-    cancelIntervalRef.current();
-    cancelIntervalRef.current = noop;
-    dispatch(clearLogs());
-  }, [dispatch]);
 
   function render() {
     const { error, inflight, items: logsItems, metricsNotConfigured } = logs || {};

--- a/app/src/js/components/Pdr/pdr.js
+++ b/app/src/js/components/Pdr/pdr.js
@@ -163,7 +163,6 @@ class PDR extends React.Component {
     const { dropdowns } = collections;
     const { list } = granules;
     const { count, queriedAt } = list.meta;
-    const logsQuery = { 'meta.pdrName': pdrName };
     const deleteStatus = get(pdrs.deleted, [pdrName, 'status']);
     const { error } = record;
 
@@ -256,7 +255,7 @@ class PDR extends React.Component {
           </List>
         </section>
         <LogViewer
-          query={logsQuery}
+          query={{ q: pdrName }}
           dispatch={this.props.dispatch}
           logs={this.props.logs}
           notFound={`No recent logs for ${pdrName}`}

--- a/app/src/js/components/Providers/provider.js
+++ b/app/src/js/components/Providers/provider.js
@@ -105,7 +105,6 @@ class ProviderOverview extends React.Component {
       return <ErrorReport report={record.error} truncate={true} />;
     }
     const provider = record.data;
-    const logsQuery = { 'meta.provider': providerId };
     const errors = this.errors();
 
     const deleteStatus = get(this.props.providers.deleted, [providerId, 'status']);
@@ -140,9 +139,8 @@ class ProviderOverview extends React.Component {
 
         <section className='page__section'>
           <LogViewer
-            query={logsQuery}
+            query={{ q: `${providerId}` }}
             dispatch={this.props.dispatch}
-            logs={this.props.logs}
             notFound={`No recent logs for ${providerId}`}
           />
         </section>

--- a/app/src/js/components/Providers/provider.js
+++ b/app/src/js/components/Providers/provider.js
@@ -139,7 +139,7 @@ class ProviderOverview extends React.Component {
 
         <section className='page__section'>
           <LogViewer
-            query={{ q: `${providerId}` }}
+            query={{ q: providerId }}
             dispatch={this.props.dispatch}
             notFound={`No recent logs for ${providerId}`}
           />

--- a/app/src/js/reducers/execution-logs.js
+++ b/app/src/js/reducers/execution-logs.js
@@ -25,7 +25,7 @@ export default createReducer(initialState, {
       state.results = data.results.map(processLog);
     }
 
-    state.details = action.data.meta;
+    state.details = data.meta;
     state.inflight = false;
     state.error = false;
   },

--- a/app/src/js/reducers/execution-logs.js
+++ b/app/src/js/reducers/execution-logs.js
@@ -1,9 +1,13 @@
+import pick from 'lodash/pick';
 import { createReducer } from '@reduxjs/toolkit';
 import {
   EXECUTION_LOGS,
   EXECUTION_LOGS_INFLIGHT,
   EXECUTION_LOGS_ERROR,
 } from '../actions/types';
+
+const fields = ['stackName', 'version', 'executions', 'level', 'version', 'app_message', 'timestamp', 'sender', 'granules', 'logGroup'];
+const processLog = (logEntry) => pick(logEntry, fields);
 
 export const initialState = {
   results: null,
@@ -15,10 +19,15 @@ export const initialState = {
 
 export default createReducer(initialState, {
   [EXECUTION_LOGS]: (state, action) => {
+    const { data } = action;
+
+    if (Array.isArray(data.results) && data.results.length) {
+      state.results = data.results.map(processLog);
+    }
+
+    state.details = action.data.meta;
     state.inflight = false;
     state.error = false;
-    state.details = action.data.meta;
-    state.results = action.data.results;
   },
   [EXECUTION_LOGS_INFLIGHT]: (state) => {
     state.inflight = true;

--- a/app/src/js/reducers/logs.js
+++ b/app/src/js/reducers/logs.js
@@ -1,5 +1,5 @@
 import moment from 'moment';
-import uniqBy from 'lodash/fp';
+import uniqBy from 'lodash/fp/uniqBy';
 import { get } from 'object-path';
 import { createReducer } from '@reduxjs/toolkit';
 import { LOGS, LOGS_ERROR, LOGS_INFLIGHT, CLEAR_LOGS } from '../actions/types';
@@ -11,13 +11,15 @@ const format = 'MM/DD/YY hh:mma ss:SSS[s]';
 const processLog = (logEntry) => ({
   ...logEntry,
   displayTime: moment(logEntry.timestamp).format(format),
-  displayText: logEntry.message || logEntry.msg,
+  displayText: logEntry.inner_message || logEntry.message || logEntry.msg,
   key: `${logEntry.timestamp}-${logEntry.displayText}`,
   searchKey: Object.values(logEntry).join(' '),
 });
 
 export const initialState = {
   items: [],
+  inflight: false,
+  error: false,
 };
 
 export default createReducer(initialState, {
@@ -25,13 +27,11 @@ export default createReducer(initialState, {
     const { data } = action;
 
     if (Array.isArray(data.results) && data.results.length) {
-      state.items = uniqBy(
-        'key',
-        data.results
-          .filter((result) => result.timestamp && result.displayText)
-          .map(processLog)
-          .concat(state.items)
-      );
+      console.log(data.results);
+      state.items = uniqBy((item) => item.key)(data.results
+        .map(processLog)
+        .filter((result) => result.timestamp && result.displayText)
+        .concat(state.items));
     }
 
     state.inflight = false;

--- a/app/src/js/reducers/logs.js
+++ b/app/src/js/reducers/logs.js
@@ -27,11 +27,9 @@ export default createReducer(initialState, {
     const { data } = action;
 
     if (Array.isArray(data.results) && data.results.length) {
-      console.log(data.results);
       state.items = uniqBy((item) => item.key)(data.results
         .map(processLog)
-        .filter((result) => result.timestamp && result.displayText)
-        .concat(state.items));
+        .filter((result) => result.timestamp && result.displayText));
     }
 
     state.inflight = false;

--- a/app/src/js/reducers/logs.js
+++ b/app/src/js/reducers/logs.js
@@ -11,7 +11,7 @@ const format = 'MM/DD/YY hh:mma ss:SSS[s]';
 const processLog = (logEntry) => ({
   ...logEntry,
   displayTime: moment(logEntry.timestamp).format(format),
-  displayText: logEntry.inner_message || logEntry.message || logEntry.msg,
+  displayText: logEntry.inner_message || logEntry.message || logEntry.Message,
   key: `${logEntry.timestamp}-${logEntry.displayText}`,
   searchKey: Object.values(logEntry).join(' '),
 });

--- a/cypress/fixtures/execution-logs.json
+++ b/cypress/fixtures/execution-logs.json
@@ -9,256 +9,441 @@
     },
     "results": [
         {
+            "logStream": "2021/01/07/[$LATEST]8cabe6b8df384f3a812255266a10d45a",
+            "subscriptionFilters": [
+              "test-source-integration-SyncGranuleTaskLogSubscriptionToSharedDestination"
+            ],
+            "stackName": "test-source-integration",
+            "version": "$LATEST",
             "executions": "8e21ca0f-79d3-4782-8247-cacd42a595ea",
-            "level": 20,
-            "message": "SyncGranule Complete. Returning output: {\"granules\":[{\"granuleId\":\"MOD09GQ.A5033248.FyuAeH.006.3234109639725\",\"dataType\":\"MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332\",\"version\":\"006\",\"files\":[{\"path\":\"test-source-integration-IngestGranuleSuccess-1541685563332-test-data/files\",\"fileSize\":17865615,\"name\":\"MOD09GQ.A5033248.FyuAeH.006.3234109639725.hdf\",\"filename\":\"s3://test-source-integration-internal/file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006/MOD09GQ.A5033248.FyuAeH.006.3234109639725.hdf\",\"fileStagingDir\":\"file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006\",\"url_path\":\"{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{extractYear(cmrMetadata.Granule.Temporal.RangeDateTime.BeginningDateTime)}/{substring(file.name, 0, 3)}\",\"bucket\":\"test-source-integration-internal\"},{\"path\":\"test-source-integration-IngestGranuleSuccess-1541685563332-test-data/files\",\"fileSize\":44118,\"name\":\"MOD09GQ.A5033248.FyuAeH.006.3234109639725.hdf.met\",\"filename\":\"s3://test-source-integration-internal/file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006/MOD09GQ.A5033248.FyuAeH.006.3234109639725.hdf.met\",\"fileStagingDir\":\"file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006\",\"url_path\":\"{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{substring(file.name, 0, 3)}\",\"bucket\":\"test-source-integration-internal\"},{\"path\":\"test-source-integration-IngestGranuleSuccess-1541685563332-test-data/files\",\"fileSize\":44118,\"name\":\"MOD09GQ.A5033248.FyuAeH.006.3234109639725_ndvi.jpg\",\"filename\":\"s3://test-source-integration-internal/file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006/MOD09GQ.A5033248.FyuAeH.006.3234109639725_ndvi.jpg\",\"fileStagingDir\":\"file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006\",\"url_path\":\"{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{substring(file.name, 0, 3)}\",\"bucket\":\"test-source-integration-internal\"}]}],\"process\":\"modis\"}",
-            "sender": "test-source-integration-SyncGranuleNoVpc",
-            "timestamp": "2018-11-08T14:01:47.684Z",
-            "version": "23",
-            "RequestId": "642422df-56b6-408c-9d54-820655c93723"
-        },
-        {
+            "level": "debug",
+            "owner": "0123456",
+            "@version": "1",
+            "app_message": "SyncGranule Complete. Returning output: {\"granules\":[{\"granuleId\":\"MOD14A1.A1512064.hpixL1.006.4931121344997\",\"dataType\":\"MOD14A1\",\"version\":\"006\",\"files\":[{\"path\":\"test-source-integration-emsIngestReport-1610051806101-test-data/files\",\"size\":233840,\"type\":\"data\",\"name\":\"MOD14A1.A1512064.hpixL1.006.4931121344997.hdf\",\"filename\":\"s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf\",\"fileStagingDir\":\"file-staging/test-source-integration/MOD14A1___006\",\"url_path\":\"{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{extractYear(cmrMetadata.Granule.Temporal.RangeDateTime.BeginningDateTime)}/{substring(file.name, 0, 3)}\",\"bucket\":\"cumulus-sit-internal\"},{\"path\":\"test-source-integration-emsIngestReport-1610051806101-test-data/files\",\"type\":\"metadata\",\"size\":14297,\"name\":\"MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met\",\"filename\":\"s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met\",\"fileStagingDir\":\"file-staging/test-source-integration/MOD14A1___006\",\"url_path\":\"{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{substring(file.name, 0, 3)}\",\"bucket\":\"cumulus-sit-internal\"},{\"path\":\"test-source-integration-emsIngestReport-1610051806101-test-data/files\",\"size\":5812,\"type\":\"browse\",\"name\":\"BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg\",\"filename\":\"s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg\",\"fileStagingDir\":\"file-staging/test-source-integration/MOD14A1___006\",\"url_path\":\"{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{substring(file.name, 0, 3)}\",\"bucket\":\"cumulus-sit-internal\"}],\"sync_granule_duration\":1643}],\"process\":\"modis\"}",
+            "timestamp": "2021-01-07T20:38:05.462Z",
+            "message": "2021-01-07T20:38:05.462Z\teb31bb65-c95c-4f70-8c5f-1f840ff463e2\tINFO\t{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"message\":\"SyncGranule Complete. Returning output: {\\\"granules\\\":[{\\\"granuleId\\\":\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\",\\\"dataType\\\":\\\"MOD14A1\\\",\\\"version\\\":\\\"006\\\",\\\"files\\\":[{\\\"path\\\":\\\"test-source-integration-emsIngestReport-1610051806101-test-data/files\\\",\\\"size\\\":233840,\\\"type\\\":\\\"data\\\",\\\"name\\\":\\\"MOD14A1.A1512064.hpixL1.006.4931121344997.hdf\\\",\\\"filename\\\":\\\"s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf\\\",\\\"fileStagingDir\\\":\\\"file-staging/test-source-integration/MOD14A1___006\\\",\\\"url_path\\\":\\\"{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{extractYear(cmrMetadata.Granule.Temporal.RangeDateTime.BeginningDateTime)}/{substring(file.name, 0, 3)}\\\",\\\"bucket\\\":\\\"cumulus-sit-internal\\\"},{\\\"path\\\":\\\"test-source-integration-emsIngestReport-1610051806101-test-data/files\\\",\\\"type\\\":\\\"metadata\\\",\\\"size\\\":14297,\\\"name\\\":\\\"MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met\\\",\\\"filename\\\":\\\"s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met\\\",\\\"fileStagingDir\\\":\\\"file-staging/test-source-integration/MOD14A1___006\\\",\\\"url_path\\\":\\\"{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{substring(file.name, 0, 3)}\\\",\\\"bucket\\\":\\\"cumulus-sit-internal\\\"},{\\\"path\\\":\\\"test-source-integration-emsIngestReport-1610051806101-test-data/files\\\",\\\"size\\\":5812,\\\"type\\\":\\\"browse\\\",\\\"name\\\":\\\"BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg\\\",\\\"filename\\\":\\\"s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg\\\",\\\"fileStagingDir\\\":\\\"file-staging/test-source-integration/MOD14A1___006\\\",\\\"url_path\\\":\\\"{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{substring(file.name, 0, 3)}\\\",\\\"bucket\\\":\\\"cumulus-sit-internal\\\"}],\\\"sync_granule_duration\\\":1643}],\\\"process\\\":\\\"modis\\\"}\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:05.462Z\",\"version\":\"$LATEST\"}\n",
+            "logstash_instance_id": "i-077966e2d29b61d76",
+            "inner_message": "{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"app_message\":\"SyncGranule Complete. Returning output: {\\\"granules\\\":[{\\\"granuleId\\\":\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\",\\\"dataType\\\":\\\"MOD14A1\\\",\\\"version\\\":\\\"006\\\",\\\"files\\\":[{\\\"path\\\":\\\"test-source-integration-emsIngestReport-1610051806101-test-data/files\\\",\\\"size\\\":233840,\\\"type\\\":\\\"data\\\",\\\"name\\\":\\\"MOD14A1.A1512064.hpixL1.006.4931121344997.hdf\\\",\\\"filename\\\":\\\"s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf\\\",\\\"fileStagingDir\\\":\\\"file-staging/test-source-integration/MOD14A1___006\\\",\\\"url_path\\\":\\\"{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{extractYear(cmrMetadata.Granule.Temporal.RangeDateTime.BeginningDateTime)}/{substring(file.name, 0, 3)}\\\",\\\"bucket\\\":\\\"cumulus-sit-internal\\\"},{\\\"path\\\":\\\"test-source-integration-emsIngestReport-1610051806101-test-data/files\\\",\\\"type\\\":\\\"metadata\\\",\\\"size\\\":14297,\\\"name\\\":\\\"MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met\\\",\\\"filename\\\":\\\"s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met\\\",\\\"fileStagingDir\\\":\\\"file-staging/test-source-integration/MOD14A1___006\\\",\\\"url_path\\\":\\\"{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{substring(file.name, 0, 3)}\\\",\\\"bucket\\\":\\\"cumulus-sit-internal\\\"},{\\\"path\\\":\\\"test-source-integration-emsIngestReport-1610051806101-test-data/files\\\",\\\"size\\\":5812,\\\"type\\\":\\\"browse\\\",\\\"name\\\":\\\"BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg\\\",\\\"filename\\\":\\\"s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg\\\",\\\"fileStagingDir\\\":\\\"file-staging/test-source-integration/MOD14A1___006\\\",\\\"url_path\\\":\\\"{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{substring(file.name, 0, 3)}\\\",\\\"bucket\\\":\\\"cumulus-sit-internal\\\"}],\\\"sync_granule_duration\\\":1643}],\\\"process\\\":\\\"modis\\\"}\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:05.462Z\",\"version\":\"$LATEST\"}",
+            "sender": "test-source-integration-SyncGranule",
+            "granules": "[\"MOD14A1.A1512064.hpixL1.006.4931121344997\"]",
+            "messageType": "DATA_MESSAGE",
+            "logGroup": "/aws/lambda/test-source-integration-SyncGranule",
+            "id": "35905356854302580009708561802110969479525087823370584083",
+            "@timestamp": "2021-01-07T20:38:05.471Z"
+          },
+          {
+            "logStream": "2021/01/07/[$LATEST]8cabe6b8df384f3a812255266a10d45a",
+            "subscriptionFilters": [
+              "test-source-integration-SyncGranuleTaskLogSubscriptionToSharedDestination"
+            ],
+            "stackName": "test-source-integration",
+            "version": "$LATEST",
             "executions": "8e21ca0f-79d3-4782-8247-cacd42a595ea",
-            "level": 20,
-            "message": "finshed, await lock.removeLock(test-source-integration-internal, s3_provider_test-test-source-integration-IngestGranuleSuccess-1541685563332, MOD09GQ.A5033248.FyuAeH.006.3234109639725)",
-            "sender": "test-source-integration-SyncGranuleNoVpc",
-            "timestamp": "2018-11-08T14:01:47.649Z",
-            "version": "23",
-            "RequestId": "642422df-56b6-408c-9d54-820655c93723"
-        },
-        {
+            "level": "debug",
+            "owner": "0123456",
+            "@version": "1",
+            "app_message": "finished ingest()",
+            "timestamp": "2021-01-07T20:38:05.426Z",
+            "message": "2021-01-07T20:38:05.426Z\teb31bb65-c95c-4f70-8c5f-1f840ff463e2\tINFO\t{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"message\":\"finished ingest()\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:05.426Z\",\"version\":\"$LATEST\"}\n",
+            "logstash_instance_id": "i-077966e2d29b61d76",
+            "inner_message": "{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"app_message\":\"finished ingest()\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:05.426Z\",\"version\":\"$LATEST\"}",
+            "sender": "test-source-integration-SyncGranule",
+            "granules": "[\"MOD14A1.A1512064.hpixL1.006.4931121344997\"]",
+            "messageType": "DATA_MESSAGE",
+            "logGroup": "/aws/lambda/test-source-integration-SyncGranule",
+            "id": "35905356853299046475774683760741862157255911555601465362",
+            "@timestamp": "2021-01-07T20:38:05.426Z"
+          },
+          {
+            "logStream": "2021/01/07/[$LATEST]8cabe6b8df384f3a812255266a10d45a",
+            "subscriptionFilters": [
+              "test-source-integration-SyncGranuleTaskLogSubscriptionToSharedDestination"
+            ],
+            "stackName": "test-source-integration",
+            "version": "$LATEST",
             "executions": "8e21ca0f-79d3-4782-8247-cacd42a595ea",
-            "level": 20,
-            "message": "finished ingest()",
-            "sender": "test-source-integration-SyncGranuleNoVpc",
-            "timestamp": "2018-11-08T14:01:47.649Z",
-            "version": "23",
-            "RequestId": "642422df-56b6-408c-9d54-820655c93723"
-        },
-        {
+            "level": "debug",
+            "owner": "0123456",
+            "@version": "1",
+            "app_message": "returning {\"path\":\"test-source-integration-emsIngestReport-1610051806101-test-data/files\",\"size\":233840,\"type\":\"data\",\"name\":\"MOD14A1.A1512064.hpixL1.006.4931121344997.hdf\",\"filename\":\"s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf\",\"fileStagingDir\":\"file-staging/test-source-integration/MOD14A1___006\",\"url_path\":\"{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{extractYear(cmrMetadata.Granule.Temporal.RangeDateTime.BeginningDateTime)}/{substring(file.name, 0, 3)}\",\"bucket\":\"cumulus-sit-internal\"}",
+            "timestamp": "2021-01-07T20:38:05.425Z",
+            "message": "2021-01-07T20:38:05.425Z\teb31bb65-c95c-4f70-8c5f-1f840ff463e2\tINFO\t{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"message\":\"returning {\\\"path\\\":\\\"test-source-integration-emsIngestReport-1610051806101-test-data/files\\\",\\\"size\\\":233840,\\\"type\\\":\\\"data\\\",\\\"name\\\":\\\"MOD14A1.A1512064.hpixL1.006.4931121344997.hdf\\\",\\\"filename\\\":\\\"s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf\\\",\\\"fileStagingDir\\\":\\\"file-staging/test-source-integration/MOD14A1___006\\\",\\\"url_path\\\":\\\"{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{extractYear(cmrMetadata.Granule.Temporal.RangeDateTime.BeginningDateTime)}/{substring(file.name, 0, 3)}\\\",\\\"bucket\\\":\\\"cumulus-sit-internal\\\"}\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:05.425Z\",\"version\":\"$LATEST\"}\n",
+            "logstash_instance_id": "i-077966e2d29b61d76",
+            "inner_message": "{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"app_message\":\"returning {\\\"path\\\":\\\"test-source-integration-emsIngestReport-1610051806101-test-data/files\\\",\\\"size\\\":233840,\\\"type\\\":\\\"data\\\",\\\"name\\\":\\\"MOD14A1.A1512064.hpixL1.006.4931121344997.hdf\\\",\\\"filename\\\":\\\"s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf\\\",\\\"fileStagingDir\\\":\\\"file-staging/test-source-integration/MOD14A1___006\\\",\\\"url_path\\\":\\\"{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{extractYear(cmrMetadata.Granule.Temporal.RangeDateTime.BeginningDateTime)}/{substring(file.name, 0, 3)}\\\",\\\"bucket\\\":\\\"cumulus-sit-internal\\\"}\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:05.425Z\",\"version\":\"$LATEST\"}",
+            "sender": "test-source-integration-SyncGranule",
+            "granules": "[\"MOD14A1.A1512064.hpixL1.006.4931121344997\"]",
+            "messageType": "DATA_MESSAGE",
+            "logGroup": "/aws/lambda/test-source-integration-SyncGranule",
+            "id": "35905356853299046475774683760741862157255911555601465361",
+            "@timestamp": "2021-01-07T20:38:05.426Z"
+          },
+          {
+            "logStream": "2021/01/07/[$LATEST]8cabe6b8df384f3a812255266a10d45a",
+            "subscriptionFilters": [
+              "test-source-integration-SyncGranuleTaskLogSubscriptionToSharedDestination"
+            ],
+            "stackName": "test-source-integration",
+            "version": "$LATEST",
             "executions": "8e21ca0f-79d3-4782-8247-cacd42a595ea",
-            "level": 20,
-            "message": "await validateChecksum {\"path\":\"test-source-integration-IngestGranuleSuccess-1541685563332-test-data/files\",\"fileSize\":17865615,\"name\":\"MOD09GQ.A5033248.FyuAeH.006.3234109639725.hdf\",\"filename\":\"s3://test-source-integration-internal/file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006/MOD09GQ.A5033248.FyuAeH.006.3234109639725.hdf\",\"fileStagingDir\":\"file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006\",\"url_path\":\"{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{extractYear(cmrMetadata.Granule.Temporal.RangeDateTime.BeginningDateTime)}/{substring(file.name, 0, 3)}\",\"bucket\":\"test-source-integration-internal\"}, test-source-integration-internal, file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006/MOD09GQ.A5033248.FyuAeH.006.3234109639725.hdf",
-            "sender": "test-source-integration-SyncGranuleNoVpc",
-            "timestamp": "2018-11-08T14:01:47.648Z",
-            "version": "23",
-            "RequestId": "642422df-56b6-408c-9d54-820655c93723"
-        },
-        {
+            "level": "warn",
+            "owner": "0123456",
+            "@version": "1",
+            "app_message": "Could not verify MOD14A1.A1512064.hpixL1.006.4931121344997.hdf expected checksum: undefined of type undefined.",
+            "timestamp": "2021-01-07T20:38:05.377Z",
+            "message": "2021-01-07T20:38:05.377Z\teb31bb65-c95c-4f70-8c5f-1f840ff463e2\tINFO\t{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"warn\",\"message\":\"Could not verify MOD14A1.A1512064.hpixL1.006.4931121344997.hdf expected checksum: undefined of type undefined.\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:05.377Z\",\"version\":\"$LATEST\"}\n",
+            "logstash_instance_id": "i-077966e2d29b61d76",
+            "inner_message": "{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"warn\",\"app_message\":\"Could not verify MOD14A1.A1512064.hpixL1.006.4931121344997.hdf expected checksum: undefined of type undefined.\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:05.377Z\",\"version\":\"$LATEST\"}",
+            "sender": "test-source-integration-SyncGranule",
+            "granules": "[\"MOD14A1.A1512064.hpixL1.006.4931121344997\"]",
+            "messageType": "DATA_MESSAGE",
+            "logGroup": "/aws/lambda/test-source-integration-SyncGranule",
+            "id": "35905356852206309961046683226806611961896141841808424976",
+            "@timestamp": "2021-01-07T20:38:05.377Z"
+          },
+          {
+            "logStream": "2021/01/07/[$LATEST]8cabe6b8df384f3a812255266a10d45a",
+            "subscriptionFilters": [
+              "test-source-integration-SyncGranuleTaskLogSubscriptionToSharedDestination"
+            ],
+            "stackName": "test-source-integration",
+            "version": "$LATEST",
             "executions": "8e21ca0f-79d3-4782-8247-cacd42a595ea",
-            "level": 30,
-            "message": "synced 1098034 bytes",
-            "sender": "test-source-integration-SyncGranuleNoVpc",
-            "timestamp": "2018-11-08T14:01:47.648Z",
-            "version": "23",
-            "RequestId": "642422df-56b6-408c-9d54-820655c93723"
-        },
-        {
+            "level": "debug",
+            "owner": "0123456",
+            "@version": "1",
+            "app_message": "await verifyFile {\"path\":\"test-source-integration-emsIngestReport-1610051806101-test-data/files\",\"size\":233840,\"type\":\"data\",\"name\":\"MOD14A1.A1512064.hpixL1.006.4931121344997.hdf\"}, s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf",
+            "timestamp": "2021-01-07T20:38:05.377Z",
+            "message": "2021-01-07T20:38:05.377Z\teb31bb65-c95c-4f70-8c5f-1f840ff463e2\tINFO\t{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"message\":\"await verifyFile {\\\"path\\\":\\\"test-source-integration-emsIngestReport-1610051806101-test-data/files\\\",\\\"size\\\":233840,\\\"type\\\":\\\"data\\\",\\\"name\\\":\\\"MOD14A1.A1512064.hpixL1.006.4931121344997.hdf\\\"}, s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:05.377Z\",\"version\":\"$LATEST\"}\n",
+            "logstash_instance_id": "i-077966e2d29b61d76",
+            "inner_message": "{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"app_message\":\"await verifyFile {\\\"path\\\":\\\"test-source-integration-emsIngestReport-1610051806101-test-data/files\\\",\\\"size\\\":233840,\\\"type\\\":\\\"data\\\",\\\"name\\\":\\\"MOD14A1.A1512064.hpixL1.006.4931121344997.hdf\\\"}, s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:05.377Z\",\"version\":\"$LATEST\"}",
+            "sender": "test-source-integration-SyncGranule",
+            "granules": "[\"MOD14A1.A1512064.hpixL1.006.4931121344997\"]",
+            "messageType": "DATA_MESSAGE",
+            "logGroup": "/aws/lambda/test-source-integration-SyncGranule",
+            "id": "35905356852206309961046683226806611961896141841808424975",
+            "@timestamp": "2021-01-07T20:38:05.377Z"
+          },
+          {
+            "logStream": "2021/01/07/[$LATEST]8cabe6b8df384f3a812255266a10d45a",
+            "subscriptionFilters": [
+              "test-source-integration-SyncGranuleTaskLogSubscriptionToSharedDestination"
+            ],
+            "stackName": "test-source-integration",
+            "version": "$LATEST",
             "executions": "8e21ca0f-79d3-4782-8247-cacd42a595ea",
-            "level": 30,
-            "message": "s3 Upload completed in 0.221 secs s3://test-source-integration-internal/file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006/MOD09GQ.A5033248.FyuAeH.006.3234109639725.hdf",
-            "sender": "test-source-integration-SyncGranuleNoVpc",
-            "timestamp": "2018-11-08T14:01:47.607Z",
-            "version": "23",
-            "RequestId": "642422df-56b6-408c-9d54-820655c93723"
-        },
-        {
+            "level": "debug",
+            "owner": "0123456",
+            "@version": "1",
+            "app_message": "returning {\"path\":\"test-source-integration-emsIngestReport-1610051806101-test-data/files\",\"type\":\"metadata\",\"size\":14297,\"name\":\"MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met\",\"filename\":\"s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met\",\"fileStagingDir\":\"file-staging/test-source-integration/MOD14A1___006\",\"url_path\":\"{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{substring(file.name, 0, 3)}\",\"bucket\":\"cumulus-sit-internal\"}",
+            "timestamp": "2021-01-07T20:38:05.335Z",
+            "message": "2021-01-07T20:38:05.335Z\teb31bb65-c95c-4f70-8c5f-1f840ff463e2\tINFO\t{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"message\":\"returning {\\\"path\\\":\\\"test-source-integration-emsIngestReport-1610051806101-test-data/files\\\",\\\"type\\\":\\\"metadata\\\",\\\"size\\\":14297,\\\"name\\\":\\\"MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met\\\",\\\"filename\\\":\\\"s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met\\\",\\\"fileStagingDir\\\":\\\"file-staging/test-source-integration/MOD14A1___006\\\",\\\"url_path\\\":\\\"{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{substring(file.name, 0, 3)}\\\",\\\"bucket\\\":\\\"cumulus-sit-internal\\\"}\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:05.335Z\",\"version\":\"$LATEST\"}\n",
+            "logstash_instance_id": "i-077966e2d29b61d76",
+            "inner_message": "{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"app_message\":\"returning {\\\"path\\\":\\\"test-source-integration-emsIngestReport-1610051806101-test-data/files\\\",\\\"type\\\":\\\"metadata\\\",\\\"size\\\":14297,\\\"name\\\":\\\"MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met\\\",\\\"filename\\\":\\\"s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met\\\",\\\"fileStagingDir\\\":\\\"file-staging/test-source-integration/MOD14A1___006\\\",\\\"url_path\\\":\\\"{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{substring(file.name, 0, 3)}\\\",\\\"bucket\\\":\\\"cumulus-sit-internal\\\"}\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:05.335Z\",\"version\":\"$LATEST\"}",
+            "sender": "test-source-integration-SyncGranule",
+            "granules": "[\"MOD14A1.A1512064.hpixL1.006.4931121344997\"]",
+            "messageType": "DATA_MESSAGE",
+            "logGroup": "/aws/lambda/test-source-integration-SyncGranule",
+            "id": "35905356851269678662708397054862111794444910658557247502",
+            "@timestamp": "2021-01-07T20:38:05.335Z"
+          },
+          {
+            "logStream": "2021/01/07/[$LATEST]8cabe6b8df384f3a812255266a10d45a",
+            "subscriptionFilters": [
+              "test-source-integration-SyncGranuleTaskLogSubscriptionToSharedDestination"
+            ],
+            "stackName": "test-source-integration",
+            "version": "$LATEST",
             "executions": "8e21ca0f-79d3-4782-8247-cacd42a595ea",
-            "level": 30,
-            "message": "synced 9728 bytes",
-            "sender": "test-source-integration-SyncGranuleNoVpc",
-            "timestamp": "2018-11-08T14:01:47.554Z",
-            "version": "23",
-            "RequestId": "642422df-56b6-408c-9d54-820655c93723"
-        },
-        {
+            "level": "debug",
+            "owner": "0123456",
+            "@version": "1",
+            "app_message": "returning {\"path\":\"test-source-integration-emsIngestReport-1610051806101-test-data/files\",\"size\":5812,\"type\":\"browse\",\"name\":\"BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg\",\"filename\":\"s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg\",\"fileStagingDir\":\"file-staging/test-source-integration/MOD14A1___006\",\"url_path\":\"{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{substring(file.name, 0, 3)}\",\"bucket\":\"cumulus-sit-internal\"}",
+            "timestamp": "2021-01-07T20:38:05.319Z",
+            "message": "2021-01-07T20:38:05.319Z\teb31bb65-c95c-4f70-8c5f-1f840ff463e2\tINFO\t{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"message\":\"returning {\\\"path\\\":\\\"test-source-integration-emsIngestReport-1610051806101-test-data/files\\\",\\\"size\\\":5812,\\\"type\\\":\\\"browse\\\",\\\"name\\\":\\\"BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg\\\",\\\"filename\\\":\\\"s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg\\\",\\\"fileStagingDir\\\":\\\"file-staging/test-source-integration/MOD14A1___006\\\",\\\"url_path\\\":\\\"{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{substring(file.name, 0, 3)}\\\",\\\"bucket\\\":\\\"cumulus-sit-internal\\\"}\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:05.319Z\",\"version\":\"$LATEST\"}\n",
+            "logstash_instance_id": "i-077966e2d29b61d76",
+            "inner_message": "{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"app_message\":\"returning {\\\"path\\\":\\\"test-source-integration-emsIngestReport-1610051806101-test-data/files\\\",\\\"size\\\":5812,\\\"type\\\":\\\"browse\\\",\\\"name\\\":\\\"BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg\\\",\\\"filename\\\":\\\"s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg\\\",\\\"fileStagingDir\\\":\\\"file-staging/test-source-integration/MOD14A1___006\\\",\\\"url_path\\\":\\\"{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{substring(file.name, 0, 3)}\\\",\\\"bucket\\\":\\\"cumulus-sit-internal\\\"}\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:05.319Z\",\"version\":\"$LATEST\"}",
+            "sender": "test-source-integration-SyncGranule",
+            "granules": "[\"MOD14A1.A1512064.hpixL1.006.4931121344997\"]",
+            "messageType": "DATA_MESSAGE",
+            "logGroup": "/aws/lambda/test-source-integration-SyncGranule",
+            "id": "35905356850935167484730437707739076020355185235967541261",
+            "@timestamp": "2021-01-07T20:38:05.320Z"
+          },
+          {
+            "logStream": "2021/01/07/[$LATEST]8cabe6b8df384f3a812255266a10d45a",
+            "subscriptionFilters": [
+              "test-source-integration-SyncGranuleTaskLogSubscriptionToSharedDestination"
+            ],
+            "stackName": "test-source-integration",
+            "version": "$LATEST",
             "executions": "8e21ca0f-79d3-4782-8247-cacd42a595ea",
-            "level": 20,
-            "message": "await validateChecksum {\"path\":\"test-source-integration-IngestGranuleSuccess-1541685563332-test-data/files\",\"fileSize\":44118,\"name\":\"MOD09GQ.A5033248.FyuAeH.006.3234109639725_ndvi.jpg\",\"filename\":\"s3://test-source-integration-internal/file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006/MOD09GQ.A5033248.FyuAeH.006.3234109639725_ndvi.jpg\",\"fileStagingDir\":\"file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006\",\"url_path\":\"{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{substring(file.name, 0, 3)}\",\"bucket\":\"test-source-integration-internal\"}, test-source-integration-internal, file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006/MOD09GQ.A5033248.FyuAeH.006.3234109639725_ndvi.jpg",
-            "sender": "test-source-integration-SyncGranuleNoVpc",
-            "timestamp": "2018-11-08T14:01:47.554Z",
-            "version": "23",
-            "RequestId": "642422df-56b6-408c-9d54-820655c93723"
-        },
-        {
+            "level": "warn",
+            "owner": "0123456",
+            "@version": "1",
+            "app_message": "Could not verify BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg expected checksum: undefined of type undefined.",
+            "timestamp": "2021-01-07T20:38:05.233Z",
+            "message": "2021-01-07T20:38:05.233Z\teb31bb65-c95c-4f70-8c5f-1f840ff463e2\tINFO\t{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"warn\",\"message\":\"Could not verify BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg expected checksum: undefined of type undefined.\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:05.233Z\",\"version\":\"$LATEST\"}\n",
+            "logstash_instance_id": "i-077966e2d29b61d76",
+            "inner_message": "{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"warn\",\"app_message\":\"Could not verify BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg expected checksum: undefined of type undefined.\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:05.233Z\",\"version\":\"$LATEST\"}",
+            "sender": "test-source-integration-SyncGranule",
+            "granules": "[\"MOD14A1.A1512064.hpixL1.006.4931121344997\"]",
+            "messageType": "DATA_MESSAGE",
+            "logGroup": "/aws/lambda/test-source-integration-SyncGranule",
+            "id": "35905356849017303397656804117567004248907426146453225484",
+            "@timestamp": "2021-01-07T20:38:05.234Z"
+          },
+          {
+            "logStream": "2021/01/07/[$LATEST]8cabe6b8df384f3a812255266a10d45a",
+            "subscriptionFilters": [
+              "test-source-integration-SyncGranuleTaskLogSubscriptionToSharedDestination"
+            ],
+            "stackName": "test-source-integration",
+            "version": "$LATEST",
             "executions": "8e21ca0f-79d3-4782-8247-cacd42a595ea",
-            "level": 30,
-            "message": "s3 Upload completed in 0.087 secs s3://test-source-integration-internal/file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006/MOD09GQ.A5033248.FyuAeH.006.3234109639725_ndvi.jpg",
-            "sender": "test-source-integration-SyncGranuleNoVpc",
-            "timestamp": "2018-11-08T14:01:47.484Z",
-            "version": "23",
-            "RequestId": "642422df-56b6-408c-9d54-820655c93723"
-        },
-        {
+            "level": "debug",
+            "owner": "0123456",
+            "@version": "1",
+            "app_message": "await verifyFile {\"path\":\"test-source-integration-emsIngestReport-1610051806101-test-data/files\",\"size\":5812,\"type\":\"browse\",\"name\":\"BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg\"}, s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg",
+            "timestamp": "2021-01-07T20:38:05.233Z",
+            "message": "2021-01-07T20:38:05.233Z\teb31bb65-c95c-4f70-8c5f-1f840ff463e2\tINFO\t{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"message\":\"await verifyFile {\\\"path\\\":\\\"test-source-integration-emsIngestReport-1610051806101-test-data/files\\\",\\\"size\\\":5812,\\\"type\\\":\\\"browse\\\",\\\"name\\\":\\\"BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg\\\"}, s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:05.233Z\",\"version\":\"$LATEST\"}\n",
+            "logstash_instance_id": "i-077966e2d29b61d76",
+            "inner_message": "{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"app_message\":\"await verifyFile {\\\"path\\\":\\\"test-source-integration-emsIngestReport-1610051806101-test-data/files\\\",\\\"size\\\":5812,\\\"type\\\":\\\"browse\\\",\\\"name\\\":\\\"BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg\\\"}, s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:05.233Z\",\"version\":\"$LATEST\"}",
+            "sender": "test-source-integration-SyncGranule",
+            "granules": "[\"MOD14A1.A1512064.hpixL1.006.4931121344997\"]",
+            "messageType": "DATA_MESSAGE",
+            "logGroup": "/aws/lambda/test-source-integration-SyncGranule",
+            "id": "35905356849017303397656804117567004248907426146453225483",
+            "@timestamp": "2021-01-07T20:38:05.234Z"
+          },
+          {
+            "logStream": "2021/01/07/[$LATEST]8cabe6b8df384f3a812255266a10d45a",
+            "subscriptionFilters": [
+              "test-source-integration-SyncGranuleTaskLogSubscriptionToSharedDestination"
+            ],
+            "stackName": "test-source-integration",
+            "version": "$LATEST",
             "executions": "8e21ca0f-79d3-4782-8247-cacd42a595ea",
-            "level": 30,
-            "message": "synced 21708 bytes",
-            "sender": "test-source-integration-SyncGranuleNoVpc",
-            "timestamp": "2018-11-08T14:01:47.469Z",
-            "version": "23",
-            "RequestId": "642422df-56b6-408c-9d54-820655c93723"
-        },
-        {
+            "level": "warn",
+            "owner": "0123456",
+            "@version": "1",
+            "app_message": "Could not verify MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met expected checksum: undefined of type undefined.",
+            "timestamp": "2021-01-07T20:38:05.224Z",
+            "message": "2021-01-07T20:38:05.224Z\teb31bb65-c95c-4f70-8c5f-1f840ff463e2\tINFO\t{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"warn\",\"message\":\"Could not verify MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met expected checksum: undefined of type undefined.\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:05.224Z\",\"version\":\"$LATEST\"}\n",
+            "logstash_instance_id": "i-077966e2d29b61d76",
+            "inner_message": "{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"warn\",\"app_message\":\"Could not verify MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met expected checksum: undefined of type undefined.\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:05.224Z\",\"version\":\"$LATEST\"}",
+            "sender": "test-source-integration-SyncGranule",
+            "granules": "[\"MOD14A1.A1512064.hpixL1.006.4931121344997\"]",
+            "messageType": "DATA_MESSAGE",
+            "logGroup": "/aws/lambda/test-source-integration-SyncGranule",
+            "id": "35905356848794295945671497886151647066180942531393421322",
+            "@timestamp": "2021-01-07T20:38:05.224Z"
+          },
+          {
+            "logStream": "2021/01/07/[$LATEST]8cabe6b8df384f3a812255266a10d45a",
+            "subscriptionFilters": [
+              "test-source-integration-SyncGranuleTaskLogSubscriptionToSharedDestination"
+            ],
+            "stackName": "test-source-integration",
+            "version": "$LATEST",
             "executions": "8e21ca0f-79d3-4782-8247-cacd42a595ea",
-            "level": 20,
-            "message": "await validateChecksum {\"path\":\"test-source-integration-IngestGranuleSuccess-1541685563332-test-data/files\",\"fileSize\":44118,\"name\":\"MOD09GQ.A5033248.FyuAeH.006.3234109639725.hdf.met\",\"filename\":\"s3://test-source-integration-internal/file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006/MOD09GQ.A5033248.FyuAeH.006.3234109639725.hdf.met\",\"fileStagingDir\":\"file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006\",\"url_path\":\"{cmrMetadata.Granule.Collection.ShortName}___{cmrMetadata.Granule.Collection.VersionId}/{substring(file.name, 0, 3)}\",\"bucket\":\"test-source-integration-internal\"}, test-source-integration-internal, file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006/MOD09GQ.A5033248.FyuAeH.006.3234109639725.hdf.met",
-            "sender": "test-source-integration-SyncGranuleNoVpc",
-            "timestamp": "2018-11-08T14:01:47.469Z",
-            "version": "23",
-            "RequestId": "642422df-56b6-408c-9d54-820655c93723"
-        },
-        {
+            "level": "debug",
+            "owner": "0123456",
+            "@version": "1",
+            "app_message": "await verifyFile {\"path\":\"test-source-integration-emsIngestReport-1610051806101-test-data/files\",\"type\":\"metadata\",\"size\":14297,\"name\":\"MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met\"}, s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met",
+            "timestamp": "2021-01-07T20:38:05.224Z",
+            "message": "2021-01-07T20:38:05.224Z\teb31bb65-c95c-4f70-8c5f-1f840ff463e2\tINFO\t{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"message\":\"await verifyFile {\\\"path\\\":\\\"test-source-integration-emsIngestReport-1610051806101-test-data/files\\\",\\\"type\\\":\\\"metadata\\\",\\\"size\\\":14297,\\\"name\\\":\\\"MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met\\\"}, s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:05.224Z\",\"version\":\"$LATEST\"}\n",
+            "logstash_instance_id": "i-077966e2d29b61d76",
+            "inner_message": "{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"app_message\":\"await verifyFile {\\\"path\\\":\\\"test-source-integration-emsIngestReport-1610051806101-test-data/files\\\",\\\"type\\\":\\\"metadata\\\",\\\"size\\\":14297,\\\"name\\\":\\\"MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met\\\"}, s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:05.224Z\",\"version\":\"$LATEST\"}",
+            "sender": "test-source-integration-SyncGranule",
+            "granules": "[\"MOD14A1.A1512064.hpixL1.006.4931121344997\"]",
+            "messageType": "DATA_MESSAGE",
+            "logGroup": "/aws/lambda/test-source-integration-SyncGranule",
+            "id": "35905356848794295945671497886151647066180942531393421321",
+            "@timestamp": "2021-01-07T20:38:05.224Z"
+          },
+          {
+            "logStream": "2021/01/07/[$LATEST]8cabe6b8df384f3a812255266a10d45a",
+            "subscriptionFilters": [
+              "test-source-integration-SyncGranuleTaskLogSubscriptionToSharedDestination"
+            ],
+            "stackName": "test-source-integration",
+            "version": "$LATEST",
             "executions": "8e21ca0f-79d3-4782-8247-cacd42a595ea",
-            "level": 30,
-            "message": "s3 Upload completed in 0.075 secs s3://test-source-integration-internal/file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006/MOD09GQ.A5033248.FyuAeH.006.3234109639725.hdf.met",
-            "sender": "test-source-integration-SyncGranuleNoVpc",
-            "timestamp": "2018-11-08T14:01:47.448Z",
-            "version": "23",
-            "RequestId": "642422df-56b6-408c-9d54-820655c93723"
-        },
-        {
+            "level": "debug",
+            "owner": "0123456",
+            "@version": "1",
+            "app_message": "await sync file test-source-integration-emsIngestReport-1610051806101-test-data/files/BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg to s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg",
+            "timestamp": "2021-01-07T20:38:04.890Z",
+            "message": "2021-01-07T20:38:04.890Z\teb31bb65-c95c-4f70-8c5f-1f840ff463e2\tINFO\t{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"message\":\"await sync file test-source-integration-emsIngestReport-1610051806101-test-data/files/BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg to s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:04.890Z\",\"version\":\"$LATEST\"}\n",
+            "logstash_instance_id": "i-077966e2d29b61d76",
+            "inner_message": "{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"app_message\":\"await sync file test-source-integration-emsIngestReport-1610051806101-test-data/files/BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg to s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:04.890Z\",\"version\":\"$LATEST\"}",
+            "sender": "test-source-integration-SyncGranule",
+            "granules": "[\"MOD14A1.A1512064.hpixL1.006.4931121344997\"]",
+            "messageType": "DATA_MESSAGE",
+            "logGroup": "/aws/lambda/test-source-integration-SyncGranule",
+            "id": "35905356841345847049362269756878717163116389788395962376",
+            "@timestamp": "2021-01-07T20:38:04.890Z"
+          },
+          {
+            "logStream": "2021/01/07/[$LATEST]8cabe6b8df384f3a812255266a10d45a",
+            "subscriptionFilters": [
+              "test-source-integration-SyncGranuleTaskLogSubscriptionToSharedDestination"
+            ],
+            "stackName": "test-source-integration",
+            "version": "$LATEST",
             "executions": "8e21ca0f-79d3-4782-8247-cacd42a595ea",
-            "level": 30,
-            "message": "sync params: { Bucket: 'test-source-integration-internal',\n  CopySource: '/test-source-integration-internal/test-source-integration-IngestGranuleSuccess-1541685563332-test-data/files/MOD09GQ.A5033248.FyuAeH.006.3234109639725_ndvi.jpg',\n  Key: 'file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006/MOD09GQ.A5033248.FyuAeH.006.3234109639725_ndvi.jpg',\n  ACL: 'private' }",
-            "sender": "test-source-integration-SyncGranuleNoVpc",
-            "timestamp": "2018-11-08T14:01:47.397Z",
-            "version": "23",
-            "RequestId": "642422df-56b6-408c-9d54-820655c93723"
-        },
-        {
+            "level": "debug",
+            "owner": "0123456",
+            "@version": "1",
+            "app_message": "file file-staging/test-source-integration/MOD14A1___006/BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg exists in cumulus-sit-internal: false",
+            "timestamp": "2021-01-07T20:38:04.890Z",
+            "message": "2021-01-07T20:38:04.890Z\teb31bb65-c95c-4f70-8c5f-1f840ff463e2\tINFO\t{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"message\":\"file file-staging/test-source-integration/MOD14A1___006/BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg exists in cumulus-sit-internal: false\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:04.890Z\",\"version\":\"$LATEST\"}\n",
+            "logstash_instance_id": "i-077966e2d29b61d76",
+            "inner_message": "{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"app_message\":\"file file-staging/test-source-integration/MOD14A1___006/BROWSE.MOD14A1.A1512064.hpixL1.006.4931121344997.1.jpg exists in cumulus-sit-internal: false\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:04.890Z\",\"version\":\"$LATEST\"}",
+            "sender": "test-source-integration-SyncGranule",
+            "granules": "[\"MOD14A1.A1512064.hpixL1.006.4931121344997\"]",
+            "messageType": "DATA_MESSAGE",
+            "logGroup": "/aws/lambda/test-source-integration-SyncGranule",
+            "id": "35905356841345847049362269756878717163116389788395962375",
+            "@timestamp": "2021-01-07T20:38:04.890Z"
+          },
+          {
+            "logStream": "2021/01/07/[$LATEST]8cabe6b8df384f3a812255266a10d45a",
+            "subscriptionFilters": [
+              "test-source-integration-SyncGranuleTaskLogSubscriptionToSharedDestination"
+            ],
+            "stackName": "test-source-integration",
+            "version": "$LATEST",
             "executions": "8e21ca0f-79d3-4782-8247-cacd42a595ea",
-            "level": 30,
-            "message": "sync params: { Bucket: 'test-source-integration-internal',\n  CopySource: '/test-source-integration-internal/test-source-integration-IngestGranuleSuccess-1541685563332-test-data/files/MOD09GQ.A5033248.FyuAeH.006.3234109639725.hdf',\n  Key: 'file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006/MOD09GQ.A5033248.FyuAeH.006.3234109639725.hdf',\n  ACL: 'private' }",
-            "sender": "test-source-integration-SyncGranuleNoVpc",
-            "timestamp": "2018-11-08T14:01:47.386Z",
-            "version": "23",
-            "RequestId": "642422df-56b6-408c-9d54-820655c93723"
-        },
-        {
+            "level": "debug",
+            "owner": "0123456",
+            "@version": "1",
+            "app_message": "await sync file test-source-integration-emsIngestReport-1610051806101-test-data/files/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met to s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met",
+            "timestamp": "2021-01-07T20:38:04.887Z",
+            "message": "2021-01-07T20:38:04.887Z\teb31bb65-c95c-4f70-8c5f-1f840ff463e2\tINFO\t{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"message\":\"await sync file test-source-integration-emsIngestReport-1610051806101-test-data/files/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met to s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:04.887Z\",\"version\":\"$LATEST\"}\n",
+            "logstash_instance_id": "i-077966e2d29b61d76",
+            "inner_message": "{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"app_message\":\"await sync file test-source-integration-emsIngestReport-1610051806101-test-data/files/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met to s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:04.887Z\",\"version\":\"$LATEST\"}",
+            "sender": "test-source-integration-SyncGranule",
+            "granules": "[\"MOD14A1.A1512064.hpixL1.006.4931121344997\"]",
+            "messageType": "DATA_MESSAGE",
+            "logGroup": "/aws/lambda/test-source-integration-SyncGranule",
+            "id": "35905356841278944813766677887454110008298444703878021126",
+            "@timestamp": "2021-01-07T20:38:04.887Z"
+          },
+          {
+            "logStream": "2021/01/07/[$LATEST]8cabe6b8df384f3a812255266a10d45a",
+            "subscriptionFilters": [
+              "test-source-integration-SyncGranuleTaskLogSubscriptionToSharedDestination"
+            ],
+            "stackName": "test-source-integration",
+            "version": "$LATEST",
             "executions": "8e21ca0f-79d3-4782-8247-cacd42a595ea",
-            "level": 30,
-            "message": "sync params: { Bucket: 'test-source-integration-internal',\n  CopySource: '/test-source-integration-internal/test-source-integration-IngestGranuleSuccess-1541685563332-test-data/files/MOD09GQ.A5033248.FyuAeH.006.3234109639725.hdf.met',\n  Key: 'file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006/MOD09GQ.A5033248.FyuAeH.006.3234109639725.hdf.met',\n  ACL: 'private' }",
-            "sender": "test-source-integration-SyncGranuleNoVpc",
-            "timestamp": "2018-11-08T14:01:47.373Z",
-            "version": "23",
-            "RequestId": "642422df-56b6-408c-9d54-820655c93723"
-        },
-        {
+            "level": "debug",
+            "owner": "0123456",
+            "@version": "1",
+            "app_message": "file file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met exists in cumulus-sit-internal: false",
+            "timestamp": "2021-01-07T20:38:04.886Z",
+            "message": "2021-01-07T20:38:04.886Z\teb31bb65-c95c-4f70-8c5f-1f840ff463e2\tINFO\t{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"message\":\"file file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met exists in cumulus-sit-internal: false\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:04.886Z\",\"version\":\"$LATEST\"}\n",
+            "logstash_instance_id": "i-077966e2d29b61d76",
+            "inner_message": "{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"app_message\":\"file file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf.met exists in cumulus-sit-internal: false\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:04.886Z\",\"version\":\"$LATEST\"}",
+            "sender": "test-source-integration-SyncGranule",
+            "granules": "[\"MOD14A1.A1512064.hpixL1.006.4931121344997\"]",
+            "messageType": "DATA_MESSAGE",
+            "logGroup": "/aws/lambda/test-source-integration-SyncGranule",
+            "id": "35905356841278944813766677887454110008298444703878021125",
+            "@timestamp": "2021-01-07T20:38:04.887Z"
+          },
+          {
+            "logStream": "2021/01/07/[$LATEST]8cabe6b8df384f3a812255266a10d45a",
+            "subscriptionFilters": [
+              "test-source-integration-SyncGranuleTaskLogSubscriptionToSharedDestination"
+            ],
+            "stackName": "test-source-integration",
+            "version": "$LATEST",
             "executions": "8e21ca0f-79d3-4782-8247-cacd42a595ea",
-            "level": 30,
-            "message": "Sync s3://test-source-integration-internal/test-source-integration-IngestGranuleSuccess-1541685563332-test-data/files/MOD09GQ.A5033248.FyuAeH.006.3234109639725_ndvi.jpg to s3://test-source-integration-internal/file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006/MOD09GQ.A5033248.FyuAeH.006.3234109639725_ndvi.jpg",
-            "sender": "test-source-integration-SyncGranuleNoVpc",
-            "timestamp": "2018-11-08T14:01:47.371Z",
-            "version": "23",
-            "RequestId": "642422df-56b6-408c-9d54-820655c93723"
-        },
-        {
+            "level": "debug",
+            "owner": "0123456",
+            "@version": "1",
+            "app_message": "file file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf exists in cumulus-sit-internal: false",
+            "timestamp": "2021-01-07T20:38:04.881Z",
+            "message": "2021-01-07T20:38:04.881Z\teb31bb65-c95c-4f70-8c5f-1f840ff463e2\tINFO\t{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"message\":\"file file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf exists in cumulus-sit-internal: false\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:04.881Z\",\"version\":\"$LATEST\"}\n",
+            "logstash_instance_id": "i-077966e2d29b61d76",
+            "inner_message": "{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"app_message\":\"file file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf exists in cumulus-sit-internal: false\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:04.881Z\",\"version\":\"$LATEST\"}",
+            "sender": "test-source-integration-SyncGranule",
+            "granules": "[\"MOD14A1.A1512064.hpixL1.006.4931121344997\"]",
+            "messageType": "DATA_MESSAGE",
+            "logGroup": "/aws/lambda/test-source-integration-SyncGranule",
+            "id": "35905356841145140342575494148604895698662554534842138627",
+            "@timestamp": "2021-01-07T20:38:04.881Z"
+          },
+          {
+            "logStream": "2021/01/07/[$LATEST]8cabe6b8df384f3a812255266a10d45a",
+            "subscriptionFilters": [
+              "test-source-integration-SyncGranuleTaskLogSubscriptionToSharedDestination"
+            ],
+            "stackName": "test-source-integration",
+            "version": "$LATEST",
             "executions": "8e21ca0f-79d3-4782-8247-cacd42a595ea",
-            "level": 20,
-            "message": "await sync file to s3 test-source-integration-IngestGranuleSuccess-1541685563332-test-data/files/MOD09GQ.A5033248.FyuAeH.006.3234109639725_ndvi.jpg, test-source-integration-internal, file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006/MOD09GQ.A5033248.FyuAeH.006.3234109639725_ndvi.jpg",
-            "sender": "test-source-integration-SyncGranuleNoVpc",
-            "timestamp": "2018-11-08T14:01:47.370Z",
-            "version": "23",
-            "RequestId": "642422df-56b6-408c-9d54-820655c93723"
-        },
-        {
+            "level": "debug",
+            "owner": "0123456",
+            "@version": "1",
+            "app_message": "await sync file test-source-integration-emsIngestReport-1610051806101-test-data/files/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf to s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf",
+            "timestamp": "2021-01-07T20:38:04.881Z",
+            "message": "2021-01-07T20:38:04.881Z\teb31bb65-c95c-4f70-8c5f-1f840ff463e2\tINFO\t{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"message\":\"await sync file test-source-integration-emsIngestReport-1610051806101-test-data/files/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf to s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:04.881Z\",\"version\":\"$LATEST\"}\n",
+            "logstash_instance_id": "i-077966e2d29b61d76",
+            "inner_message": "{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"app_message\":\"await sync file test-source-integration-emsIngestReport-1610051806101-test-data/files/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf to s3://cumulus-sit-internal/file-staging/test-source-integration/MOD14A1___006/MOD14A1.A1512064.hpixL1.006.4931121344997.hdf\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:04.881Z\",\"version\":\"$LATEST\"}",
+            "sender": "test-source-integration-SyncGranule",
+            "granules": "[\"MOD14A1.A1512064.hpixL1.006.4931121344997\"]",
+            "messageType": "DATA_MESSAGE",
+            "logGroup": "/aws/lambda/test-source-integration-SyncGranule",
+            "id": "35905356841145140342575494148604895698662554534842138628",
+            "@timestamp": "2021-01-07T20:38:04.881Z"
+          },
+          {
+            "logStream": "2021/01/07/[$LATEST]8cabe6b8df384f3a812255266a10d45a",
+            "subscriptionFilters": [
+              "test-source-integration-SyncGranuleTaskLogSubscriptionToSharedDestination"
+            ],
+            "stackName": "test-source-integration",
+            "version": "$LATEST",
             "executions": "8e21ca0f-79d3-4782-8247-cacd42a595ea",
-            "level": 20,
-            "message": "file file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006/MOD09GQ.A5033248.FyuAeH.006.3234109639725_ndvi.jpg exists in test-source-integration-internal: false",
-            "sender": "test-source-integration-SyncGranuleNoVpc",
-            "timestamp": "2018-11-08T14:01:47.370Z",
-            "version": "23",
-            "RequestId": "642422df-56b6-408c-9d54-820655c93723"
-        },
-        {
+            "level": "debug",
+            "owner": "0123456",
+            "@version": "1",
+            "app_message": "awaiting all download.Files",
+            "timestamp": "2021-01-07T20:38:03.793Z",
+            "message": "2021-01-07T20:38:03.793Z\teb31bb65-c95c-4f70-8c5f-1f840ff463e2\tINFO\t{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"message\":\"awaiting all download.Files\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:03.793Z\",\"version\":\"$LATEST\"}\n",
+            "logstash_instance_id": "i-077966e2d29b61d76",
+            "inner_message": "{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"app_message\":\"awaiting all download.Files\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:03.793Z\",\"version\":\"$LATEST\"}",
+            "sender": "test-source-integration-SyncGranule",
+            "granules": "[\"MOD14A1.A1512064.hpixL1.006.4931121344997\"]",
+            "messageType": "DATA_MESSAGE",
+            "logGroup": "/aws/lambda/test-source-integration-SyncGranule",
+            "id": "35905356816881929566574176170614034218021137216335446018",
+            "@timestamp": "2021-01-07T20:38:03.793Z"
+          },
+          {
+            "logStream": "2021/01/07/[$LATEST]8cabe6b8df384f3a812255266a10d45a",
+            "subscriptionFilters": [
+              "test-source-integration-SyncGranuleTaskLogSubscriptionToSharedDestination"
+            ],
+            "stackName": "test-source-integration",
+            "version": "$LATEST",
             "executions": "8e21ca0f-79d3-4782-8247-cacd42a595ea",
-            "level": 30,
-            "message": "Sync s3://test-source-integration-internal/test-source-integration-IngestGranuleSuccess-1541685563332-test-data/files/MOD09GQ.A5033248.FyuAeH.006.3234109639725.hdf to s3://test-source-integration-internal/file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006/MOD09GQ.A5033248.FyuAeH.006.3234109639725.hdf",
-            "sender": "test-source-integration-SyncGranuleNoVpc",
-            "timestamp": "2018-11-08T14:01:47.354Z",
-            "version": "23",
-            "RequestId": "642422df-56b6-408c-9d54-820655c93723"
-        },
-        {
-            "executions": "8e21ca0f-79d3-4782-8247-cacd42a595ea",
-            "level": 20,
-            "message": "await sync file to s3 test-source-integration-IngestGranuleSuccess-1541685563332-test-data/files/MOD09GQ.A5033248.FyuAeH.006.3234109639725.hdf, test-source-integration-internal, file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006/MOD09GQ.A5033248.FyuAeH.006.3234109639725.hdf",
-            "sender": "test-source-integration-SyncGranuleNoVpc",
-            "timestamp": "2018-11-08T14:01:47.353Z",
-            "version": "23",
-            "RequestId": "642422df-56b6-408c-9d54-820655c93723"
-        },
-        {
-            "executions": "8e21ca0f-79d3-4782-8247-cacd42a595ea",
-            "level": 20,
-            "message": "file file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006/MOD09GQ.A5033248.FyuAeH.006.3234109639725.hdf exists in test-source-integration-internal: false",
-            "sender": "test-source-integration-SyncGranuleNoVpc",
-            "timestamp": "2018-11-08T14:01:47.353Z",
-            "version": "23",
-            "RequestId": "642422df-56b6-408c-9d54-820655c93723"
-        },
-        {
-            "executions": "8e21ca0f-79d3-4782-8247-cacd42a595ea",
-            "level": 20,
-            "message": "await sync file to s3 test-source-integration-IngestGranuleSuccess-1541685563332-test-data/files/MOD09GQ.A5033248.FyuAeH.006.3234109639725.hdf.met, test-source-integration-internal, file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006/MOD09GQ.A5033248.FyuAeH.006.3234109639725.hdf.met",
-            "sender": "test-source-integration-SyncGranuleNoVpc",
-            "timestamp": "2018-11-08T14:01:47.332Z",
-            "version": "23",
-            "RequestId": "642422df-56b6-408c-9d54-820655c93723"
-        },
-        {
-            "executions": "8e21ca0f-79d3-4782-8247-cacd42a595ea",
-            "level": 20,
-            "message": "file file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006/MOD09GQ.A5033248.FyuAeH.006.3234109639725.hdf.met exists in test-source-integration-internal: false",
-            "sender": "test-source-integration-SyncGranuleNoVpc",
-            "timestamp": "2018-11-08T14:01:47.332Z",
-            "version": "23",
-            "RequestId": "642422df-56b6-408c-9d54-820655c93723"
-        },
-        {
-            "executions": "8e21ca0f-79d3-4782-8247-cacd42a595ea",
-            "level": 30,
-            "message": "Sync s3://test-source-integration-internal/test-source-integration-IngestGranuleSuccess-1541685563332-test-data/files/MOD09GQ.A5033248.FyuAeH.006.3234109639725.hdf.met to s3://test-source-integration-internal/file-staging/test-source-integration/MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332___006/MOD09GQ.A5033248.FyuAeH.006.3234109639725.hdf.met",
-            "sender": "test-source-integration-SyncGranuleNoVpc",
-            "timestamp": "2018-11-08T14:01:47.332Z",
-            "version": "23",
-            "RequestId": "642422df-56b6-408c-9d54-820655c93723"
-        },
-        {
-            "executions": "8e21ca0f-79d3-4782-8247-cacd42a595ea",
-            "level": 20,
-            "message": "awaiting all download.Files",
-            "sender": "test-source-integration-SyncGranuleNoVpc",
-            "timestamp": "2018-11-08T14:01:47.313Z",
-            "version": "23",
-            "RequestId": "642422df-56b6-408c-9d54-820655c93723"
-        },
-        {
-            "executions": "8e21ca0f-79d3-4782-8247-cacd42a595ea",
-            "level": 20,
-            "message": "await ingest.ingest({\"granuleId\":\"MOD09GQ.A5033248.FyuAeH.006.3234109639725\",\"dataType\":\"MOD09GQ_test-test-source-integration-IngestGranuleSuccess-1541685563332\",\"version\":\"006\",\"files\":[{\"path\":\"test-source-integration-IngestGranuleSuccess-1541685563332-test-data/files\",\"fileSize\":17865615,\"name\":\"MOD09GQ.A5033248.FyuAeH.006.3234109639725.hdf\"},{\"path\":\"test-source-integration-IngestGranuleSuccess-1541685563332-test-data/files\",\"fileSize\":44118,\"name\":\"MOD09GQ.A5033248.FyuAeH.006.3234109639725.hdf.met\"},{\"path\":\"test-source-integration-IngestGranuleSuccess-1541685563332-test-data/files\",\"fileSize\":44118,\"name\":\"MOD09GQ.A5033248.FyuAeH.006.3234109639725_ndvi.jpg\"}]}, test-source-integration-internal)",
-            "sender": "test-source-integration-SyncGranuleNoVpc",
-            "timestamp": "2018-11-08T14:01:47.309Z",
-            "version": "23",
-            "RequestId": "642422df-56b6-408c-9d54-820655c93723"
-        },
-        {
-            "executions": "8e21ca0f-79d3-4782-8247-cacd42a595ea",
-            "level": 20,
-            "message": "awaiting lock.proceed in download() bucket: test-source-integration-internal, provider: {\"protocol\":\"s3\",\"globalConnectionLimit\":10,\"host\":\"test-source-integration-internal\",\"updatedAt\":1541685568865,\"id\":\"s3_provider_test-test-source-integration-IngestGranuleSuccess-1541685563332\",\"createdAt\":1541685568865}, granuleID: MOD09GQ.A5033248.FyuAeH.006.3234109639725",
-            "sender": "test-source-integration-SyncGranuleNoVpc",
-            "timestamp": "2018-11-08T14:01:47.259Z",
-            "version": "23",
-            "RequestId": "642422df-56b6-408c-9d54-820655c93723"
-        },
-        {
-            "executions": "8e21ca0f-79d3-4782-8247-cacd42a595ea",
-            "level": 20,
-            "message": "Configured duplicateHandling value: replace",
-            "sender": "test-source-integration-SyncGranuleNoVpc",
-            "timestamp": "2018-11-08T14:01:47.259Z",
-            "version": "23",
-            "RequestId": "642422df-56b6-408c-9d54-820655c93723"
-        }
+            "level": "debug",
+            "owner": "0123456",
+            "@version": "1",
+            "app_message": "awaiting lock.proceed in download() bucket: cumulus-sit-internal, provider: {\"createdAt\":1610051814176,\"id\":\"s3_provider_test-test-source-integration-emsIngestReport-1610051806101\",\"host\":\"cumulus-sit-internal\",\"globalConnectionLimit\":10,\"updatedAt\":1610051814176,\"protocol\":\"s3\"}, granuleID: MOD14A1.A1512064.hpixL1.006.4931121344997",
+            "timestamp": "2021-01-07T20:38:03.626Z",
+            "message": "2021-01-07T20:38:03.626Z\teb31bb65-c95c-4f70-8c5f-1f840ff463e2\tINFO\t{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"message\":\"awaiting lock.proceed in download() bucket: cumulus-sit-internal, provider: {\\\"createdAt\\\":1610051814176,\\\"id\\\":\\\"s3_provider_test-test-source-integration-emsIngestReport-1610051806101\\\",\\\"host\\\":\\\"cumulus-sit-internal\\\",\\\"globalConnectionLimit\\\":10,\\\"updatedAt\\\":1610051814176,\\\"protocol\\\":\\\"s3\\\"}, granuleID: MOD14A1.A1512064.hpixL1.006.4931121344997\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:03.626Z\",\"version\":\"$LATEST\"}\n",
+            "logstash_instance_id": "i-077966e2d29b61d76",
+            "inner_message": "{\"executions\":\"8e21ca0f-79d3-4782-8247-cacd42a595ea\",\"granules\":\"[\\\"MOD14A1.A1512064.hpixL1.006.4931121344997\\\"]\",\"level\":\"debug\",\"app_message\":\"awaiting lock.proceed in download() bucket: cumulus-sit-internal, provider: {\\\"createdAt\\\":1610051814176,\\\"id\\\":\\\"s3_provider_test-test-source-integration-emsIngestReport-1610051806101\\\",\\\"host\\\":\\\"cumulus-sit-internal\\\",\\\"globalConnectionLimit\\\":10,\\\"updatedAt\\\":1610051814176,\\\"protocol\\\":\\\"s3\\\"}, granuleID: MOD14A1.A1512064.hpixL1.006.4931121344997\",\"sender\":\"test-source-integration-SyncGranule\",\"stackName\":\"test-source-integration\",\"timestamp\":\"2021-01-07T20:38:03.626Z\",\"version\":\"$LATEST\"}",
+            "sender": "test-source-integration-SyncGranule",
+            "granules": "[\"MOD14A1.A1512064.hpixL1.006.4931121344997\"]",
+            "messageType": "DATA_MESSAGE",
+            "logGroup": "/aws/lambda/test-source-integration-SyncGranule",
+            "id": "35905356813157705118419562105977569266488860844836716545",
+            "@timestamp": "2021-01-07T20:38:03.626Z"
+          }
     ]
 }

--- a/cypress/integration/collections_spec.js
+++ b/cypress/integration/collections_spec.js
@@ -266,7 +266,7 @@ describe('Dashboard Collections Page', () => {
       cy.editJsonTextarea({ data: { duplicateHandling, meta }, update: true });
       cy.contains('form button', 'Submit').click();
       cy.contains('.default-modal .edit-collection__title', 'Edit Collection');
-      cy.contains('.default-modal .modal-body', `Collection ${name}___${version} has been updated`);
+      cy.contains('.default-modal .modal-body', `Collection ${name}___${version} has been updated`, { timeout: 10000 });
       cy.contains('.modal-footer button', 'Close').click();
 
       // displays the updated collection and its granules

--- a/cypress/integration/executions_spec.js
+++ b/cypress/integration/executions_spec.js
@@ -110,11 +110,19 @@ describe('Dashboard Executions Page', () => {
       const executionName = '8e21ca0f-79d3-4782-8247-cacd42a595ea';
       const executionArn = 'arn:aws:states:us-east-1:012345678901:execution:test-stack-HelloWorldWorkflow:8e21ca0f-79d3-4782-8247-cacd42a595ea';
 
-      cy.intercept('GET', '/logs', { fixture: 'execution-logs.json', statusCode: 200 });
-
       cy.intercept(
         { method: 'GET', url: `http://localhost:5001/executions/status/${executionArn}` },
         { fixture: 'valid-execution.json', statusCode: 200 }
+      );
+
+      cy.intercept(
+        { method: 'GET', url: `http://localhost:5001/logs/${executionName}` },
+        { fixture: 'execution-logs.json', statusCode: 200 }
+      );
+
+      cy.intercept(
+        { method: 'GET', url: 'http://localhost:5001/logs' },
+        { fixture: 'logs-success.json', statusCode: 200 }
       );
 
       cy.visit(`/executions/execution/${executionArn}`);
@@ -204,7 +212,15 @@ describe('Dashboard Executions Page', () => {
       const executionArn = 'arn:aws:states:us-east-1:123456789012:execution:TestSourceIntegrationIngestAndPublishGranuleStateMachine-yCAhWOss5Xgo:b313e777-d28a-435b-a0dd-f1fad08116t1';
       const stateMachine = 'arn:aws:states:us-east-1:123456789012:stateMachine:TestSourceIntegrationIngestAndPublishGranuleStateMachine-yCAhWOss5Xgo';
 
-      cy.intercept('GET', '/logs', { fixture: 'limited-execution.json', statusCode: 200 });
+      cy.intercept(
+        { method: 'GET', url: `http://localhost:5001/logs/${executionName}` },
+        { fixture: 'limited-execution.json', statusCode: 200 }
+      );
+
+      cy.intercept(
+        { method: 'GET', url: 'http://localhost:5001/logs' },
+        { fixture: 'logs-success.json', statusCode: 200 }
+      );
 
       cy.visit(`/executions/execution/${executionArn}`);
 

--- a/cypress/integration/executions_spec.js
+++ b/cypress/integration/executions_spec.js
@@ -110,13 +110,11 @@ describe('Dashboard Executions Page', () => {
       const executionName = '8e21ca0f-79d3-4782-8247-cacd42a595ea';
       const executionArn = 'arn:aws:states:us-east-1:012345678901:execution:test-stack-HelloWorldWorkflow:8e21ca0f-79d3-4782-8247-cacd42a595ea';
 
+      cy.intercept('GET', '/logs', { fixture: 'execution-logs.json', statusCode: 200 });
+
       cy.intercept(
         { method: 'GET', url: `http://localhost:5001/executions/status/${executionArn}` },
         { fixture: 'valid-execution.json', statusCode: 200 }
-      );
-      cy.intercept(
-        { method: 'GET', url: `http://localhost:5001/logs/${executionName}` },
-        { fixture: 'execution-logs.json', statusCode: 200 }
       );
 
       cy.visit(`/executions/execution/${executionArn}`);
@@ -145,7 +143,7 @@ describe('Dashboard Executions Page', () => {
       });
       cy.getFixture('execution-logs').its('results').then((logs) => {
         cy.get('@sections').eq(1).within(() => {
-          cy.get('pre').contains(JSON.stringify(logs[0].message));
+          cy.get('pre').contains(JSON.stringify(logs[0].app_message));
         });
       });
     });
@@ -206,10 +204,7 @@ describe('Dashboard Executions Page', () => {
       const executionArn = 'arn:aws:states:us-east-1:123456789012:execution:TestSourceIntegrationIngestAndPublishGranuleStateMachine-yCAhWOss5Xgo:b313e777-d28a-435b-a0dd-f1fad08116t1';
       const stateMachine = 'arn:aws:states:us-east-1:123456789012:stateMachine:TestSourceIntegrationIngestAndPublishGranuleStateMachine-yCAhWOss5Xgo';
 
-      cy.intercept(
-        { method: 'GET', url: `http://localhost:5001/logs/${executionName}` },
-        { fixture: 'limited-execution.json', statusCode: 200 }
-      );
+      cy.intercept('GET', '/logs', { fixture: 'limited-execution.json', statusCode: 200 });
 
       cy.visit(`/executions/execution/${executionArn}`);
 

--- a/cypress/integration/logs_spec.js
+++ b/cypress/integration/logs_spec.js
@@ -80,7 +80,6 @@ describe('Dashboard Logs', () => {
       cy.contains('.meta__row dt', 'Logs').should('exist');
       cy.contains('.meta__row dd a', 'View Execution Logs').should('exist').click();
       cy.url().should('include', '/logs');
-      cy.contains('.status--process h2', 'Execution Logs').should('exist');
     });
 
     it('should not display logs on an Execution page when metrics are not configured', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3921,14 +3921,14 @@
       }
     },
     "@cumulus/aws-client": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-4.0.0.tgz",
-      "integrity": "sha512-UhHaouJcr+53+BTqoOFkoLlgDCIjs4GigZEqfwuyOsbxx7JnDC/DxQoUoXvF+dS6A88lvsYTTJD/mZkncRBZjQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-7.0.0.tgz",
+      "integrity": "sha512-YdQqNeAsJsS3cw7jbAE9rb6gFCPU6HvLLJZrp8EVs5+tml0wLt6Gg4rpgst7NfXeAVFKGEmpwIhkDKE4v6JeTw==",
       "dev": true,
       "requires": {
-        "@cumulus/checksum": "4.0.0",
-        "@cumulus/errors": "4.0.0",
-        "@cumulus/logger": "4.0.0",
+        "@cumulus/checksum": "7.0.0",
+        "@cumulus/errors": "7.0.0",
+        "@cumulus/logger": "7.0.0",
         "aws-sdk": "^2.585.0",
         "jsonpath-plus": "^1.1.0",
         "lodash": "~4.17.20",
@@ -3945,9 +3945,9 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.2.0.tgz",
-          "integrity": "sha512-jPH38/MRh263KKcq0wBNOGFJbm+U6784RilTmHjB/HM9kH9V8WlCpVUcdOmip9cjXOh6MxZ5yk1z2SjDUJfWmA==",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.4.0.tgz",
+          "integrity": "sha512-gVB/tBsG+3AHI1SyDHRrX6n9ZL0Bcbifps9W9/Bgu3Oyu4/OrAh8SvDzDsvpP0oxfCt3oWNT+0fQ9LyUGwBTLg==",
           "dev": true,
           "requires": {
             "@types/retry": "^0.12.0",
@@ -3955,9 +3955,9 @@
           }
         },
         "p-wait-for": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/p-wait-for/-/p-wait-for-3.1.0.tgz",
-          "integrity": "sha512-0Uy19uhxbssHelu9ynDMcON6BmMk6pH8551CvxROhiz3Vx+yC4RqxjyIDk2V4ll0g9177RKT++PK4zcV58uJ7A==",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/p-wait-for/-/p-wait-for-3.2.0.tgz",
+          "integrity": "sha512-wpgERjNkLrBiFmkMEjuZJEWKKDrNfHCKA1OhyN1wg1FrLkULbviEy6py1AyJUgZ72YWFbZ38FIpnqvVqAlDUwA==",
           "dev": true,
           "requires": {
             "p-timeout": "^3.0.0"
@@ -3966,9 +3966,9 @@
       }
     },
     "@cumulus/checksum": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-4.0.0.tgz",
-      "integrity": "sha512-sbeANiBxcwDz4uftWkzMGcIDmkif9zjFUwR4y4XCYpV4U64JZrlqCkhkORa3cacrmFKI+Gf46kDXptPKRMSS2Q==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-7.0.0.tgz",
+      "integrity": "sha512-+AzAPD2C/GByDzluR0OwQRE0voe8iTRC5eRmbFJ/KOVXiemqoOLRi4G9EaJn3WL2qKdS0/lBdX5G2fWkrSYBKA==",
       "dev": true,
       "requires": {
         "cksum": "^1.3.0"
@@ -4305,9 +4305,9 @@
       }
     },
     "@cumulus/errors": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-4.0.0.tgz",
-      "integrity": "sha512-6sMwwx9CgiuvWCZ5WwJt3CMaR13gaynkVIic46RHt7IsfgVUVKjfapWSq6bXo39OuLPeHexIzPqbumnkEhHhxA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-7.0.0.tgz",
+      "integrity": "sha512-BUlrMJ7R5dMOQ4vlbdUKIJcEfH/M1eV+uFeamwvmNP5LbX8BqFLeHZJ4hymgaH/+TxTBERLR+vpMbyKjWA1DKQ==",
       "dev": true
     },
     "@cumulus/ingest": {
@@ -4521,9 +4521,9 @@
       }
     },
     "@cumulus/logger": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-4.0.0.tgz",
-      "integrity": "sha512-qLdu4yalGouK1A5ETpPB2ZO5S7Td5PwCdvKv4puvsijfQiqof07wuqQU/OnZ+WzTRpMULMWRWm2j+rKzMKx6eA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-7.0.0.tgz",
+      "integrity": "sha512-2dA2JCFT1kk12BLRBBRTtvkWEtEfFV0K5XkjyaFjsCN9fN86SKYZR0EQTKnoeXX77bfhmVcwkGNn7ZIGkL5yAQ==",
       "dev": true,
       "requires": {
         "lodash.iserror": "^3.1.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3759,24 +3759,24 @@
       "dev": true
     },
     "@cumulus/api": {
-      "version": "5.0.2-alpha.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/api/-/api-5.0.2-alpha.0.tgz",
-      "integrity": "sha512-xIqxgyHSaErEsHEmftxJ45NoOWM2GrImIx3gHhylH4Yqrv/B3Q34pxCNvbSfcnuYGAx6XT/4N+8DZLskfsSJEQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/api/-/api-7.0.0.tgz",
+      "integrity": "sha512-O0pGKDV5G5AZVqceumJtsLLNS3JVIq0INS8VOv8cR/ba5PT8khabkohu0K+WEPGonLAjkvH2RLNigpAHfAP0pA==",
       "dev": true,
       "requires": {
-        "@cumulus/aws-client": "5.0.1",
-        "@cumulus/cmr-client": "5.0.1",
-        "@cumulus/cmrjs": "5.0.1",
-        "@cumulus/collection-config-store": "5.0.1",
-        "@cumulus/common": "5.0.1",
-        "@cumulus/earthdata-login-client": "5.0.1",
-        "@cumulus/errors": "5.0.1",
-        "@cumulus/ingest": "5.0.1",
-        "@cumulus/launchpad-auth": "5.0.1",
-        "@cumulus/logger": "5.0.1",
-        "@cumulus/message": "5.0.1",
-        "@cumulus/pvl": "5.0.1",
-        "@cumulus/sftp-client": "5.0.1",
+        "@cumulus/aws-client": "7.0.0",
+        "@cumulus/cmr-client": "7.0.0",
+        "@cumulus/cmrjs": "7.0.0",
+        "@cumulus/collection-config-store": "7.0.0",
+        "@cumulus/common": "7.0.0",
+        "@cumulus/earthdata-login-client": "7.0.0",
+        "@cumulus/errors": "7.0.0",
+        "@cumulus/ingest": "7.0.0",
+        "@cumulus/launchpad-auth": "7.0.0",
+        "@cumulus/logger": "7.0.0",
+        "@cumulus/message": "7.0.0",
+        "@cumulus/pvl": "7.0.0",
+        "@cumulus/sftp-client": "7.0.0",
         "@elastic/elasticsearch": "^5.6.20",
         "@mapbox/dyno": "^1.4.2",
         "aggregate-error": "^3.0.1",
@@ -3818,14 +3818,14 @@
       },
       "dependencies": {
         "@cumulus/aws-client": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-5.0.1.tgz",
-          "integrity": "sha512-wFzmxbc+GmRAzMy7zG0HC/vxlq+G6aEJ/Gv69ivG6gTQ6lT2mC8l/PwNmVwllCjhdtYn5ZvDSwvj8a+BbBXj2Q==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-7.0.0.tgz",
+          "integrity": "sha512-YdQqNeAsJsS3cw7jbAE9rb6gFCPU6HvLLJZrp8EVs5+tml0wLt6Gg4rpgst7NfXeAVFKGEmpwIhkDKE4v6JeTw==",
           "dev": true,
           "requires": {
-            "@cumulus/checksum": "5.0.1",
-            "@cumulus/errors": "5.0.1",
-            "@cumulus/logger": "5.0.1",
+            "@cumulus/checksum": "7.0.0",
+            "@cumulus/errors": "7.0.0",
+            "@cumulus/logger": "7.0.0",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.20",
@@ -3842,9 +3842,9 @@
               "dev": true
             },
             "p-retry": {
-              "version": "4.3.0",
-              "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.3.0.tgz",
-              "integrity": "sha512-Pow4yaHpOiJou1QcpGcBJhGHiS4782LdDa6GhU91hlaNh3ExOOupjSJcxPQZYmUSZk3Pl2ARz/LRvW8Qu0+3mQ==",
+              "version": "4.4.0",
+              "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.4.0.tgz",
+              "integrity": "sha512-gVB/tBsG+3AHI1SyDHRrX6n9ZL0Bcbifps9W9/Bgu3Oyu4/OrAh8SvDzDsvpP0oxfCt3oWNT+0fQ9LyUGwBTLg==",
               "dev": true,
               "requires": {
                 "@types/retry": "^0.12.0",
@@ -3863,24 +3863,24 @@
           }
         },
         "@cumulus/checksum": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-5.0.1.tgz",
-          "integrity": "sha512-0Nb89tF/ZswMRlRSGxG1i2LLpDrD1b7bdhJqTF5YsqvC3z0NKXG6ECNfmWFC3x8XnSW+FydLu550lddZgmaMFQ==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-7.0.0.tgz",
+          "integrity": "sha512-+AzAPD2C/GByDzluR0OwQRE0voe8iTRC5eRmbFJ/KOVXiemqoOLRi4G9EaJn3WL2qKdS0/lBdX5G2fWkrSYBKA==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-5.0.1.tgz",
-          "integrity": "sha512-gNHxTBqZE7ManuMxl5dxBwf0BcpMcJYTCpqulNUSaASGlHFHCV7lHq7Rc7k3Y9VdBOAtyJZbOF1WDOUljn32uw==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-7.0.0.tgz",
+          "integrity": "sha512-BUlrMJ7R5dMOQ4vlbdUKIJcEfH/M1eV+uFeamwvmNP5LbX8BqFLeHZJ4hymgaH/+TxTBERLR+vpMbyKjWA1DKQ==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-5.0.1.tgz",
-          "integrity": "sha512-bLOYdO0iiYgNf6Ex/wY8/uqOzziTbyrsM9XbHedZCUxFClC1SEA3/rFgB3PPLNiF2mxZkF6qbTDWDe9eg+/CCg==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-7.0.0.tgz",
+          "integrity": "sha512-2dA2JCFT1kk12BLRBBRTtvkWEtEfFV0K5XkjyaFjsCN9fN86SKYZR0EQTKnoeXX77bfhmVcwkGNn7ZIGkL5yAQ==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
@@ -3975,13 +3975,13 @@
       }
     },
     "@cumulus/cmr-client": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@cumulus/cmr-client/-/cmr-client-5.0.1.tgz",
-      "integrity": "sha512-wHBRAiYJ4BMiUF48G9l46aJxBWyH20S/arkGXKdIOGEYYVmnYWpAk+yjbBPZYEF6fIQPVhqGbFRWnIHQARTZLA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/cmr-client/-/cmr-client-7.0.0.tgz",
+      "integrity": "sha512-ZkAbD4qgSWJCwvtLUfMOa7hlVFHUVrU6j8f9ZqrWvqCl/2oli+3JcQ+WC1ZIym6uHYs4A7j90MOiJ9+QweRvow==",
       "dev": true,
       "requires": {
-        "@cumulus/aws-client": "5.0.1",
-        "@cumulus/logger": "5.0.1",
+        "@cumulus/aws-client": "7.0.0",
+        "@cumulus/logger": "7.0.0",
         "got": "^11.7.0",
         "lodash": "^4.17.20",
         "public-ip": "^3.0.0",
@@ -3989,14 +3989,14 @@
       },
       "dependencies": {
         "@cumulus/aws-client": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-5.0.1.tgz",
-          "integrity": "sha512-wFzmxbc+GmRAzMy7zG0HC/vxlq+G6aEJ/Gv69ivG6gTQ6lT2mC8l/PwNmVwllCjhdtYn5ZvDSwvj8a+BbBXj2Q==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-7.0.0.tgz",
+          "integrity": "sha512-YdQqNeAsJsS3cw7jbAE9rb6gFCPU6HvLLJZrp8EVs5+tml0wLt6Gg4rpgst7NfXeAVFKGEmpwIhkDKE4v6JeTw==",
           "dev": true,
           "requires": {
-            "@cumulus/checksum": "5.0.1",
-            "@cumulus/errors": "5.0.1",
-            "@cumulus/logger": "5.0.1",
+            "@cumulus/checksum": "7.0.0",
+            "@cumulus/errors": "7.0.0",
+            "@cumulus/logger": "7.0.0",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.20",
@@ -4007,24 +4007,24 @@
           }
         },
         "@cumulus/checksum": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-5.0.1.tgz",
-          "integrity": "sha512-0Nb89tF/ZswMRlRSGxG1i2LLpDrD1b7bdhJqTF5YsqvC3z0NKXG6ECNfmWFC3x8XnSW+FydLu550lddZgmaMFQ==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-7.0.0.tgz",
+          "integrity": "sha512-+AzAPD2C/GByDzluR0OwQRE0voe8iTRC5eRmbFJ/KOVXiemqoOLRi4G9EaJn3WL2qKdS0/lBdX5G2fWkrSYBKA==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-5.0.1.tgz",
-          "integrity": "sha512-gNHxTBqZE7ManuMxl5dxBwf0BcpMcJYTCpqulNUSaASGlHFHCV7lHq7Rc7k3Y9VdBOAtyJZbOF1WDOUljn32uw==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-7.0.0.tgz",
+          "integrity": "sha512-BUlrMJ7R5dMOQ4vlbdUKIJcEfH/M1eV+uFeamwvmNP5LbX8BqFLeHZJ4hymgaH/+TxTBERLR+vpMbyKjWA1DKQ==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-5.0.1.tgz",
-          "integrity": "sha512-bLOYdO0iiYgNf6Ex/wY8/uqOzziTbyrsM9XbHedZCUxFClC1SEA3/rFgB3PPLNiF2mxZkF6qbTDWDe9eg+/CCg==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-7.0.0.tgz",
+          "integrity": "sha512-2dA2JCFT1kk12BLRBBRTtvkWEtEfFV0K5XkjyaFjsCN9fN86SKYZR0EQTKnoeXX77bfhmVcwkGNn7ZIGkL5yAQ==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
@@ -4037,9 +4037,9 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.3.0.tgz",
-          "integrity": "sha512-Pow4yaHpOiJou1QcpGcBJhGHiS4782LdDa6GhU91hlaNh3ExOOupjSJcxPQZYmUSZk3Pl2ARz/LRvW8Qu0+3mQ==",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.4.0.tgz",
+          "integrity": "sha512-gVB/tBsG+3AHI1SyDHRrX6n9ZL0Bcbifps9W9/Bgu3Oyu4/OrAh8SvDzDsvpP0oxfCt3oWNT+0fQ9LyUGwBTLg==",
           "dev": true,
           "requires": {
             "@types/retry": "^0.12.0",
@@ -4058,16 +4058,16 @@
       }
     },
     "@cumulus/cmrjs": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@cumulus/cmrjs/-/cmrjs-5.0.1.tgz",
-      "integrity": "sha512-fwO5oCfrxvr8MukbRn0N/IapLv1CtQnTCb1wRmpGTLTGrdNX/Q2yquNNeGL1Hm7imcaHiP7whkVNcfnQpdMo1Q==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/cmrjs/-/cmrjs-7.0.0.tgz",
+      "integrity": "sha512-8U2BlFmKfXYtNfEgjmjdcdEv2BvuEhylWkSH0dmiJe8DAzfRi2Hj5WwYF1AgvF3r6sLPxcOd1ou+4Mt0U1THtw==",
       "dev": true,
       "requires": {
-        "@cumulus/aws-client": "5.0.1",
-        "@cumulus/cmr-client": "5.0.1",
-        "@cumulus/common": "5.0.1",
-        "@cumulus/errors": "5.0.1",
-        "@cumulus/launchpad-auth": "5.0.1",
+        "@cumulus/aws-client": "7.0.0",
+        "@cumulus/cmr-client": "7.0.0",
+        "@cumulus/common": "7.0.0",
+        "@cumulus/errors": "7.0.0",
+        "@cumulus/launchpad-auth": "7.0.0",
         "js2xmlparser": "^4.0.0",
         "lodash": "^4.17.20",
         "public-ip": "^3.0.0",
@@ -4076,14 +4076,14 @@
       },
       "dependencies": {
         "@cumulus/aws-client": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-5.0.1.tgz",
-          "integrity": "sha512-wFzmxbc+GmRAzMy7zG0HC/vxlq+G6aEJ/Gv69ivG6gTQ6lT2mC8l/PwNmVwllCjhdtYn5ZvDSwvj8a+BbBXj2Q==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-7.0.0.tgz",
+          "integrity": "sha512-YdQqNeAsJsS3cw7jbAE9rb6gFCPU6HvLLJZrp8EVs5+tml0wLt6Gg4rpgst7NfXeAVFKGEmpwIhkDKE4v6JeTw==",
           "dev": true,
           "requires": {
-            "@cumulus/checksum": "5.0.1",
-            "@cumulus/errors": "5.0.1",
-            "@cumulus/logger": "5.0.1",
+            "@cumulus/checksum": "7.0.0",
+            "@cumulus/errors": "7.0.0",
+            "@cumulus/logger": "7.0.0",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.20",
@@ -4094,24 +4094,24 @@
           }
         },
         "@cumulus/checksum": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-5.0.1.tgz",
-          "integrity": "sha512-0Nb89tF/ZswMRlRSGxG1i2LLpDrD1b7bdhJqTF5YsqvC3z0NKXG6ECNfmWFC3x8XnSW+FydLu550lddZgmaMFQ==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-7.0.0.tgz",
+          "integrity": "sha512-+AzAPD2C/GByDzluR0OwQRE0voe8iTRC5eRmbFJ/KOVXiemqoOLRi4G9EaJn3WL2qKdS0/lBdX5G2fWkrSYBKA==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-5.0.1.tgz",
-          "integrity": "sha512-gNHxTBqZE7ManuMxl5dxBwf0BcpMcJYTCpqulNUSaASGlHFHCV7lHq7Rc7k3Y9VdBOAtyJZbOF1WDOUljn32uw==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-7.0.0.tgz",
+          "integrity": "sha512-BUlrMJ7R5dMOQ4vlbdUKIJcEfH/M1eV+uFeamwvmNP5LbX8BqFLeHZJ4hymgaH/+TxTBERLR+vpMbyKjWA1DKQ==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-5.0.1.tgz",
-          "integrity": "sha512-bLOYdO0iiYgNf6Ex/wY8/uqOzziTbyrsM9XbHedZCUxFClC1SEA3/rFgB3PPLNiF2mxZkF6qbTDWDe9eg+/CCg==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-7.0.0.tgz",
+          "integrity": "sha512-2dA2JCFT1kk12BLRBBRTtvkWEtEfFV0K5XkjyaFjsCN9fN86SKYZR0EQTKnoeXX77bfhmVcwkGNn7ZIGkL5yAQ==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
@@ -4124,9 +4124,9 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.3.0.tgz",
-          "integrity": "sha512-Pow4yaHpOiJou1QcpGcBJhGHiS4782LdDa6GhU91hlaNh3ExOOupjSJcxPQZYmUSZk3Pl2ARz/LRvW8Qu0+3mQ==",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.4.0.tgz",
+          "integrity": "sha512-gVB/tBsG+3AHI1SyDHRrX6n9ZL0Bcbifps9W9/Bgu3Oyu4/OrAh8SvDzDsvpP0oxfCt3oWNT+0fQ9LyUGwBTLg==",
           "dev": true,
           "requires": {
             "@types/retry": "^0.12.0",
@@ -4151,25 +4151,25 @@
       }
     },
     "@cumulus/collection-config-store": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@cumulus/collection-config-store/-/collection-config-store-5.0.1.tgz",
-      "integrity": "sha512-iMBkSPooD5YdKAyORXjyu7J/boZ94gwOjkb64Qp9bBJ5BxsbQIyzRrKNdBVjkAtPSgNgbAqh0Sq/ap3POAoY9g==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/collection-config-store/-/collection-config-store-7.0.0.tgz",
+      "integrity": "sha512-CMtCp/wLMa4IMvOG1gfy2e9t3nw3G1l6GoZ74F9s8+jxwtO7x56ZxOznXrpTG4MAjXY8Q+n9WzBDumMqoKGGXg==",
       "dev": true,
       "requires": {
-        "@cumulus/aws-client": "5.0.1",
-        "@cumulus/common": "5.0.1",
-        "@cumulus/message": "5.0.1"
+        "@cumulus/aws-client": "7.0.0",
+        "@cumulus/common": "7.0.0",
+        "@cumulus/message": "7.0.0"
       },
       "dependencies": {
         "@cumulus/aws-client": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-5.0.1.tgz",
-          "integrity": "sha512-wFzmxbc+GmRAzMy7zG0HC/vxlq+G6aEJ/Gv69ivG6gTQ6lT2mC8l/PwNmVwllCjhdtYn5ZvDSwvj8a+BbBXj2Q==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-7.0.0.tgz",
+          "integrity": "sha512-YdQqNeAsJsS3cw7jbAE9rb6gFCPU6HvLLJZrp8EVs5+tml0wLt6Gg4rpgst7NfXeAVFKGEmpwIhkDKE4v6JeTw==",
           "dev": true,
           "requires": {
-            "@cumulus/checksum": "5.0.1",
-            "@cumulus/errors": "5.0.1",
-            "@cumulus/logger": "5.0.1",
+            "@cumulus/checksum": "7.0.0",
+            "@cumulus/errors": "7.0.0",
+            "@cumulus/logger": "7.0.0",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.20",
@@ -4180,24 +4180,24 @@
           }
         },
         "@cumulus/checksum": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-5.0.1.tgz",
-          "integrity": "sha512-0Nb89tF/ZswMRlRSGxG1i2LLpDrD1b7bdhJqTF5YsqvC3z0NKXG6ECNfmWFC3x8XnSW+FydLu550lddZgmaMFQ==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-7.0.0.tgz",
+          "integrity": "sha512-+AzAPD2C/GByDzluR0OwQRE0voe8iTRC5eRmbFJ/KOVXiemqoOLRi4G9EaJn3WL2qKdS0/lBdX5G2fWkrSYBKA==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-5.0.1.tgz",
-          "integrity": "sha512-gNHxTBqZE7ManuMxl5dxBwf0BcpMcJYTCpqulNUSaASGlHFHCV7lHq7Rc7k3Y9VdBOAtyJZbOF1WDOUljn32uw==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-7.0.0.tgz",
+          "integrity": "sha512-BUlrMJ7R5dMOQ4vlbdUKIJcEfH/M1eV+uFeamwvmNP5LbX8BqFLeHZJ4hymgaH/+TxTBERLR+vpMbyKjWA1DKQ==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-5.0.1.tgz",
-          "integrity": "sha512-bLOYdO0iiYgNf6Ex/wY8/uqOzziTbyrsM9XbHedZCUxFClC1SEA3/rFgB3PPLNiF2mxZkF6qbTDWDe9eg+/CCg==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-7.0.0.tgz",
+          "integrity": "sha512-2dA2JCFT1kk12BLRBBRTtvkWEtEfFV0K5XkjyaFjsCN9fN86SKYZR0EQTKnoeXX77bfhmVcwkGNn7ZIGkL5yAQ==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
@@ -4210,9 +4210,9 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.3.0.tgz",
-          "integrity": "sha512-Pow4yaHpOiJou1QcpGcBJhGHiS4782LdDa6GhU91hlaNh3ExOOupjSJcxPQZYmUSZk3Pl2ARz/LRvW8Qu0+3mQ==",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.4.0.tgz",
+          "integrity": "sha512-gVB/tBsG+3AHI1SyDHRrX6n9ZL0Bcbifps9W9/Bgu3Oyu4/OrAh8SvDzDsvpP0oxfCt3oWNT+0fQ9LyUGwBTLg==",
           "dev": true,
           "requires": {
             "@types/retry": "^0.12.0",
@@ -4231,13 +4231,13 @@
       }
     },
     "@cumulus/common": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@cumulus/common/-/common-5.0.1.tgz",
-      "integrity": "sha512-QEFSQiLBWT9nh7gR3+W1tpmEuHbvJlY9wzsItsm47tYfifFmrJWBhVopxonhdvVD3+obIj8FI82IF3CFX9OiyA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/common/-/common-7.0.0.tgz",
+      "integrity": "sha512-DuB5BgdcIb3rqLtj7lyeZVj+iJI5KBy9caWeQ962k6HK+Zy9kWw5Ak5uLg+1e/vsMIX/NKV1XHCyEUvrkPxzYg==",
       "dev": true,
       "requires": {
-        "@cumulus/errors": "5.0.1",
-        "@cumulus/logger": "5.0.1",
+        "@cumulus/errors": "7.0.0",
+        "@cumulus/logger": "7.0.0",
         "ajv": "^6.12.3",
         "aws-sdk": "^2.585.0",
         "follow-redirects": "^1.2.4",
@@ -4257,15 +4257,15 @@
       },
       "dependencies": {
         "@cumulus/errors": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-5.0.1.tgz",
-          "integrity": "sha512-gNHxTBqZE7ManuMxl5dxBwf0BcpMcJYTCpqulNUSaASGlHFHCV7lHq7Rc7k3Y9VdBOAtyJZbOF1WDOUljn32uw==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-7.0.0.tgz",
+          "integrity": "sha512-BUlrMJ7R5dMOQ4vlbdUKIJcEfH/M1eV+uFeamwvmNP5LbX8BqFLeHZJ4hymgaH/+TxTBERLR+vpMbyKjWA1DKQ==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-5.0.1.tgz",
-          "integrity": "sha512-bLOYdO0iiYgNf6Ex/wY8/uqOzziTbyrsM9XbHedZCUxFClC1SEA3/rFgB3PPLNiF2mxZkF6qbTDWDe9eg+/CCg==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-7.0.0.tgz",
+          "integrity": "sha512-2dA2JCFT1kk12BLRBBRTtvkWEtEfFV0K5XkjyaFjsCN9fN86SKYZR0EQTKnoeXX77bfhmVcwkGNn7ZIGkL5yAQ==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
@@ -4284,9 +4284,9 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.3.0.tgz",
-          "integrity": "sha512-Pow4yaHpOiJou1QcpGcBJhGHiS4782LdDa6GhU91hlaNh3ExOOupjSJcxPQZYmUSZk3Pl2ARz/LRvW8Qu0+3mQ==",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.4.0.tgz",
+          "integrity": "sha512-gVB/tBsG+3AHI1SyDHRrX6n9ZL0Bcbifps9W9/Bgu3Oyu4/OrAh8SvDzDsvpP0oxfCt3oWNT+0fQ9LyUGwBTLg==",
           "dev": true,
           "requires": {
             "@types/retry": "^0.12.0",
@@ -4296,9 +4296,9 @@
       }
     },
     "@cumulus/earthdata-login-client": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@cumulus/earthdata-login-client/-/earthdata-login-client-5.0.1.tgz",
-      "integrity": "sha512-dU0ogLocfImO5yEY6OxQADyN30S9/lXI2+ju0mHJubAzzbHtmGPZvJ76ydoDUyliLnNQOjHTijjPWu972V1/8Q==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/earthdata-login-client/-/earthdata-login-client-7.0.0.tgz",
+      "integrity": "sha512-bCOSAsrabjFvABsFsSBDq/f07nhwvdyfCq35roCbGWZFxHp6humsPAWehXUugVyys/90AyQkYF34zoPjVS4bMA==",
       "dev": true,
       "requires": {
         "got": "^11.7.0"
@@ -4311,16 +4311,16 @@
       "dev": true
     },
     "@cumulus/ingest": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@cumulus/ingest/-/ingest-5.0.1.tgz",
-      "integrity": "sha512-u0oVxcfdqdsDP5/Q0Cf0x9rnvwwfLwPRmxQ832kHe457WUfsCK1NgVVtVKff6yjgr7p+kvZTqFwWunBBOTF6Ug==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/ingest/-/ingest-7.0.0.tgz",
+      "integrity": "sha512-hiprjsYDA7Rgj3vaXh5hgwJADrdiEDm6zvVf4YJYKVTU7ZaLahNZnv2uMhCeeZw/kuGk7tbTTVAA77dYasBHsg==",
       "dev": true,
       "requires": {
-        "@cumulus/aws-client": "5.0.1",
-        "@cumulus/common": "5.0.1",
-        "@cumulus/errors": "5.0.1",
-        "@cumulus/message": "5.0.1",
-        "@cumulus/sftp-client": "5.0.1",
+        "@cumulus/aws-client": "7.0.0",
+        "@cumulus/common": "7.0.0",
+        "@cumulus/errors": "7.0.0",
+        "@cumulus/message": "7.0.0",
+        "@cumulus/sftp-client": "7.0.0",
         "aws-sdk": "^2.585.0",
         "cksum": "^1.3.0",
         "delay": "^4.3.0",
@@ -4338,14 +4338,14 @@
       },
       "dependencies": {
         "@cumulus/aws-client": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-5.0.1.tgz",
-          "integrity": "sha512-wFzmxbc+GmRAzMy7zG0HC/vxlq+G6aEJ/Gv69ivG6gTQ6lT2mC8l/PwNmVwllCjhdtYn5ZvDSwvj8a+BbBXj2Q==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-7.0.0.tgz",
+          "integrity": "sha512-YdQqNeAsJsS3cw7jbAE9rb6gFCPU6HvLLJZrp8EVs5+tml0wLt6Gg4rpgst7NfXeAVFKGEmpwIhkDKE4v6JeTw==",
           "dev": true,
           "requires": {
-            "@cumulus/checksum": "5.0.1",
-            "@cumulus/errors": "5.0.1",
-            "@cumulus/logger": "5.0.1",
+            "@cumulus/checksum": "7.0.0",
+            "@cumulus/errors": "7.0.0",
+            "@cumulus/logger": "7.0.0",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.20",
@@ -4356,24 +4356,24 @@
           }
         },
         "@cumulus/checksum": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-5.0.1.tgz",
-          "integrity": "sha512-0Nb89tF/ZswMRlRSGxG1i2LLpDrD1b7bdhJqTF5YsqvC3z0NKXG6ECNfmWFC3x8XnSW+FydLu550lddZgmaMFQ==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-7.0.0.tgz",
+          "integrity": "sha512-+AzAPD2C/GByDzluR0OwQRE0voe8iTRC5eRmbFJ/KOVXiemqoOLRi4G9EaJn3WL2qKdS0/lBdX5G2fWkrSYBKA==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-5.0.1.tgz",
-          "integrity": "sha512-gNHxTBqZE7ManuMxl5dxBwf0BcpMcJYTCpqulNUSaASGlHFHCV7lHq7Rc7k3Y9VdBOAtyJZbOF1WDOUljn32uw==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-7.0.0.tgz",
+          "integrity": "sha512-BUlrMJ7R5dMOQ4vlbdUKIJcEfH/M1eV+uFeamwvmNP5LbX8BqFLeHZJ4hymgaH/+TxTBERLR+vpMbyKjWA1DKQ==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-5.0.1.tgz",
-          "integrity": "sha512-bLOYdO0iiYgNf6Ex/wY8/uqOzziTbyrsM9XbHedZCUxFClC1SEA3/rFgB3PPLNiF2mxZkF6qbTDWDe9eg+/CCg==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-7.0.0.tgz",
+          "integrity": "sha512-2dA2JCFT1kk12BLRBBRTtvkWEtEfFV0K5XkjyaFjsCN9fN86SKYZR0EQTKnoeXX77bfhmVcwkGNn7ZIGkL5yAQ==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
@@ -4401,9 +4401,9 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.3.0.tgz",
-          "integrity": "sha512-Pow4yaHpOiJou1QcpGcBJhGHiS4782LdDa6GhU91hlaNh3ExOOupjSJcxPQZYmUSZk3Pl2ARz/LRvW8Qu0+3mQ==",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.4.0.tgz",
+          "integrity": "sha512-gVB/tBsG+3AHI1SyDHRrX6n9ZL0Bcbifps9W9/Bgu3Oyu4/OrAh8SvDzDsvpP0oxfCt3oWNT+0fQ9LyUGwBTLg==",
           "dev": true,
           "requires": {
             "@types/retry": "^0.12.0",
@@ -4439,27 +4439,27 @@
       }
     },
     "@cumulus/launchpad-auth": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@cumulus/launchpad-auth/-/launchpad-auth-5.0.1.tgz",
-      "integrity": "sha512-tRbseqjGKDIQerhfZCIzj9g+/iHPdQ6tVmzposciU0oucF3xiKNtNHjdchJc46kcChKo61ZEV404T4zm4o9rwA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/launchpad-auth/-/launchpad-auth-7.0.0.tgz",
+      "integrity": "sha512-PfdwKNE2YRA5q2IUDPJ+J7yd98tR8kM5Q2R5oL+m8s3TEQ/5dl6XmbHcz8Sf13pK0W/orzHoWEWXcK6TpjFHrQ==",
       "dev": true,
       "requires": {
-        "@cumulus/aws-client": "5.0.1",
-        "@cumulus/logger": "5.0.1",
+        "@cumulus/aws-client": "7.0.0",
+        "@cumulus/logger": "7.0.0",
         "got": "^11.7.0",
         "lodash": "^4.17.20",
         "uuid": "^3.2.1"
       },
       "dependencies": {
         "@cumulus/aws-client": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-5.0.1.tgz",
-          "integrity": "sha512-wFzmxbc+GmRAzMy7zG0HC/vxlq+G6aEJ/Gv69ivG6gTQ6lT2mC8l/PwNmVwllCjhdtYn5ZvDSwvj8a+BbBXj2Q==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-7.0.0.tgz",
+          "integrity": "sha512-YdQqNeAsJsS3cw7jbAE9rb6gFCPU6HvLLJZrp8EVs5+tml0wLt6Gg4rpgst7NfXeAVFKGEmpwIhkDKE4v6JeTw==",
           "dev": true,
           "requires": {
-            "@cumulus/checksum": "5.0.1",
-            "@cumulus/errors": "5.0.1",
-            "@cumulus/logger": "5.0.1",
+            "@cumulus/checksum": "7.0.0",
+            "@cumulus/errors": "7.0.0",
+            "@cumulus/logger": "7.0.0",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.20",
@@ -4470,24 +4470,24 @@
           }
         },
         "@cumulus/checksum": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-5.0.1.tgz",
-          "integrity": "sha512-0Nb89tF/ZswMRlRSGxG1i2LLpDrD1b7bdhJqTF5YsqvC3z0NKXG6ECNfmWFC3x8XnSW+FydLu550lddZgmaMFQ==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-7.0.0.tgz",
+          "integrity": "sha512-+AzAPD2C/GByDzluR0OwQRE0voe8iTRC5eRmbFJ/KOVXiemqoOLRi4G9EaJn3WL2qKdS0/lBdX5G2fWkrSYBKA==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-5.0.1.tgz",
-          "integrity": "sha512-gNHxTBqZE7ManuMxl5dxBwf0BcpMcJYTCpqulNUSaASGlHFHCV7lHq7Rc7k3Y9VdBOAtyJZbOF1WDOUljn32uw==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-7.0.0.tgz",
+          "integrity": "sha512-BUlrMJ7R5dMOQ4vlbdUKIJcEfH/M1eV+uFeamwvmNP5LbX8BqFLeHZJ4hymgaH/+TxTBERLR+vpMbyKjWA1DKQ==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-5.0.1.tgz",
-          "integrity": "sha512-bLOYdO0iiYgNf6Ex/wY8/uqOzziTbyrsM9XbHedZCUxFClC1SEA3/rFgB3PPLNiF2mxZkF6qbTDWDe9eg+/CCg==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-7.0.0.tgz",
+          "integrity": "sha512-2dA2JCFT1kk12BLRBBRTtvkWEtEfFV0K5XkjyaFjsCN9fN86SKYZR0EQTKnoeXX77bfhmVcwkGNn7ZIGkL5yAQ==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
@@ -4500,9 +4500,9 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.3.0.tgz",
-          "integrity": "sha512-Pow4yaHpOiJou1QcpGcBJhGHiS4782LdDa6GhU91hlaNh3ExOOupjSJcxPQZYmUSZk3Pl2ARz/LRvW8Qu0+3mQ==",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.4.0.tgz",
+          "integrity": "sha512-gVB/tBsG+3AHI1SyDHRrX6n9ZL0Bcbifps9W9/Bgu3Oyu4/OrAh8SvDzDsvpP0oxfCt3oWNT+0fQ9LyUGwBTLg==",
           "dev": true,
           "requires": {
             "@types/retry": "^0.12.0",
@@ -4530,29 +4530,29 @@
       }
     },
     "@cumulus/message": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@cumulus/message/-/message-5.0.1.tgz",
-      "integrity": "sha512-ASVgrDIG4+LOxbt4ZKURAeRfY+JDgr5zN6twgSRe76N3VaRruBWq3JyP1ICweWzt7qMrkpu3P6pVO/JTccoQXg==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/message/-/message-7.0.0.tgz",
+      "integrity": "sha512-oUjw8Qo2AbWSSYvPcpW2/QJRueMgAjVAxQo5h/zVrfZVmkeDuVU2XqPikAZ4nxfgV51bw2nIZg/QCIJB4DMrug==",
       "dev": true,
       "requires": {
-        "@cumulus/aws-client": "5.0.1",
-        "@cumulus/common": "5.0.1",
-        "@cumulus/logger": "5.0.1",
-        "@cumulus/types": "5.0.1",
+        "@cumulus/aws-client": "7.0.0",
+        "@cumulus/common": "7.0.0",
+        "@cumulus/logger": "7.0.0",
+        "@cumulus/types": "7.0.0",
         "jsonpath-plus": "^3.0.0",
         "lodash": "^4.17.20",
         "uuid": "^8.2.0"
       },
       "dependencies": {
         "@cumulus/aws-client": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-5.0.1.tgz",
-          "integrity": "sha512-wFzmxbc+GmRAzMy7zG0HC/vxlq+G6aEJ/Gv69ivG6gTQ6lT2mC8l/PwNmVwllCjhdtYn5ZvDSwvj8a+BbBXj2Q==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-7.0.0.tgz",
+          "integrity": "sha512-YdQqNeAsJsS3cw7jbAE9rb6gFCPU6HvLLJZrp8EVs5+tml0wLt6Gg4rpgst7NfXeAVFKGEmpwIhkDKE4v6JeTw==",
           "dev": true,
           "requires": {
-            "@cumulus/checksum": "5.0.1",
-            "@cumulus/errors": "5.0.1",
-            "@cumulus/logger": "5.0.1",
+            "@cumulus/checksum": "7.0.0",
+            "@cumulus/errors": "7.0.0",
+            "@cumulus/logger": "7.0.0",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.20",
@@ -4571,24 +4571,24 @@
           }
         },
         "@cumulus/checksum": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-5.0.1.tgz",
-          "integrity": "sha512-0Nb89tF/ZswMRlRSGxG1i2LLpDrD1b7bdhJqTF5YsqvC3z0NKXG6ECNfmWFC3x8XnSW+FydLu550lddZgmaMFQ==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-7.0.0.tgz",
+          "integrity": "sha512-+AzAPD2C/GByDzluR0OwQRE0voe8iTRC5eRmbFJ/KOVXiemqoOLRi4G9EaJn3WL2qKdS0/lBdX5G2fWkrSYBKA==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-5.0.1.tgz",
-          "integrity": "sha512-gNHxTBqZE7ManuMxl5dxBwf0BcpMcJYTCpqulNUSaASGlHFHCV7lHq7Rc7k3Y9VdBOAtyJZbOF1WDOUljn32uw==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-7.0.0.tgz",
+          "integrity": "sha512-BUlrMJ7R5dMOQ4vlbdUKIJcEfH/M1eV+uFeamwvmNP5LbX8BqFLeHZJ4hymgaH/+TxTBERLR+vpMbyKjWA1DKQ==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-5.0.1.tgz",
-          "integrity": "sha512-bLOYdO0iiYgNf6Ex/wY8/uqOzziTbyrsM9XbHedZCUxFClC1SEA3/rFgB3PPLNiF2mxZkF6qbTDWDe9eg+/CCg==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-7.0.0.tgz",
+          "integrity": "sha512-2dA2JCFT1kk12BLRBBRTtvkWEtEfFV0K5XkjyaFjsCN9fN86SKYZR0EQTKnoeXX77bfhmVcwkGNn7ZIGkL5yAQ==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
@@ -4607,9 +4607,9 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.3.0.tgz",
-          "integrity": "sha512-Pow4yaHpOiJou1QcpGcBJhGHiS4782LdDa6GhU91hlaNh3ExOOupjSJcxPQZYmUSZk3Pl2ARz/LRvW8Qu0+3mQ==",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.4.0.tgz",
+          "integrity": "sha512-gVB/tBsG+3AHI1SyDHRrX6n9ZL0Bcbifps9W9/Bgu3Oyu4/OrAh8SvDzDsvpP0oxfCt3oWNT+0fQ9LyUGwBTLg==",
           "dev": true,
           "requires": {
             "@types/retry": "^0.12.0",
@@ -4634,36 +4634,36 @@
       }
     },
     "@cumulus/pvl": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@cumulus/pvl/-/pvl-5.0.1.tgz",
-      "integrity": "sha512-AKKQMiQFoDYqfbMCxoy6FQu92isOIAuMf+7Gft1UU84AUDFMMrzTtCKNjZ5Bb5z/WLcbNyrehCEgUF4yWJTgZw==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/pvl/-/pvl-7.0.0.tgz",
+      "integrity": "sha512-TXiM/JkxacAyYAwsmm76mGYeYJW5uXI3oYOqCu+58tNJEAxgCeSb+v56idAeHzY0Om5IsjDQnR1qjfZpJT6Xkw==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.20"
       }
     },
     "@cumulus/sftp-client": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@cumulus/sftp-client/-/sftp-client-5.0.1.tgz",
-      "integrity": "sha512-4CjNp7SIMVOmfVCasVZdSA0NPqo9gd7E7YBPk/shbeIe4NzjeokFXAaEiXBsvyYYeCiorPaHqB0hdT2Xw8PO6w==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/sftp-client/-/sftp-client-7.0.0.tgz",
+      "integrity": "sha512-pnadr59u083TT3Or+dPT9oEqa1T2HQ/SiDhOh97r4EwJPsl1G4Uk5+oVLlNG3+fLFFvkH/qQagM/0DHtDZzZqA==",
       "dev": true,
       "requires": {
-        "@cumulus/aws-client": "5.0.1",
-        "@cumulus/common": "5.0.1",
+        "@cumulus/aws-client": "7.0.0",
+        "@cumulus/common": "7.0.0",
         "lodash": "^4.17.20",
         "mime-types": "^2.1.27",
         "ssh2-sftp-client": "^5.2.1"
       },
       "dependencies": {
         "@cumulus/aws-client": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-5.0.1.tgz",
-          "integrity": "sha512-wFzmxbc+GmRAzMy7zG0HC/vxlq+G6aEJ/Gv69ivG6gTQ6lT2mC8l/PwNmVwllCjhdtYn5ZvDSwvj8a+BbBXj2Q==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-7.0.0.tgz",
+          "integrity": "sha512-YdQqNeAsJsS3cw7jbAE9rb6gFCPU6HvLLJZrp8EVs5+tml0wLt6Gg4rpgst7NfXeAVFKGEmpwIhkDKE4v6JeTw==",
           "dev": true,
           "requires": {
-            "@cumulus/checksum": "5.0.1",
-            "@cumulus/errors": "5.0.1",
-            "@cumulus/logger": "5.0.1",
+            "@cumulus/checksum": "7.0.0",
+            "@cumulus/errors": "7.0.0",
+            "@cumulus/logger": "7.0.0",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.20",
@@ -4674,42 +4674,42 @@
           }
         },
         "@cumulus/checksum": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-5.0.1.tgz",
-          "integrity": "sha512-0Nb89tF/ZswMRlRSGxG1i2LLpDrD1b7bdhJqTF5YsqvC3z0NKXG6ECNfmWFC3x8XnSW+FydLu550lddZgmaMFQ==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-7.0.0.tgz",
+          "integrity": "sha512-+AzAPD2C/GByDzluR0OwQRE0voe8iTRC5eRmbFJ/KOVXiemqoOLRi4G9EaJn3WL2qKdS0/lBdX5G2fWkrSYBKA==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-5.0.1.tgz",
-          "integrity": "sha512-gNHxTBqZE7ManuMxl5dxBwf0BcpMcJYTCpqulNUSaASGlHFHCV7lHq7Rc7k3Y9VdBOAtyJZbOF1WDOUljn32uw==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-7.0.0.tgz",
+          "integrity": "sha512-BUlrMJ7R5dMOQ4vlbdUKIJcEfH/M1eV+uFeamwvmNP5LbX8BqFLeHZJ4hymgaH/+TxTBERLR+vpMbyKjWA1DKQ==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-5.0.1.tgz",
-          "integrity": "sha512-bLOYdO0iiYgNf6Ex/wY8/uqOzziTbyrsM9XbHedZCUxFClC1SEA3/rFgB3PPLNiF2mxZkF6qbTDWDe9eg+/CCg==",
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-7.0.0.tgz",
+          "integrity": "sha512-2dA2JCFT1kk12BLRBBRTtvkWEtEfFV0K5XkjyaFjsCN9fN86SKYZR0EQTKnoeXX77bfhmVcwkGNn7ZIGkL5yAQ==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
           }
         },
         "mime-db": {
-          "version": "1.45.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.45.0.tgz",
-          "integrity": "sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==",
+          "version": "1.46.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.46.0.tgz",
+          "integrity": "sha512-svXaP8UQRZ5K7or+ZmfNhg2xX3yKDMUzqadsSqi4NCH/KomcH75MAMYAGVlvXn4+b/xOPhS3I2uHKRUzvjY7BQ==",
           "dev": true
         },
         "mime-types": {
-          "version": "2.1.28",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.28.tgz",
-          "integrity": "sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==",
+          "version": "2.1.29",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.29.tgz",
+          "integrity": "sha512-Y/jMt/S5sR9OaqteJtslsFZKWOIIqMACsJSiHghlCAyhf7jfVYjKBmLiX8OgpWeW+fjJ2b+Az69aPFPkUOY6xQ==",
           "dev": true,
           "requires": {
-            "mime-db": "1.45.0"
+            "mime-db": "1.46.0"
           }
         },
         "p-map": {
@@ -4719,9 +4719,9 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.3.0.tgz",
-          "integrity": "sha512-Pow4yaHpOiJou1QcpGcBJhGHiS4782LdDa6GhU91hlaNh3ExOOupjSJcxPQZYmUSZk3Pl2ARz/LRvW8Qu0+3mQ==",
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.4.0.tgz",
+          "integrity": "sha512-gVB/tBsG+3AHI1SyDHRrX6n9ZL0Bcbifps9W9/Bgu3Oyu4/OrAh8SvDzDsvpP0oxfCt3oWNT+0fQ9LyUGwBTLg==",
           "dev": true,
           "requires": {
             "@types/retry": "^0.12.0",
@@ -4740,9 +4740,9 @@
       }
     },
     "@cumulus/types": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@cumulus/types/-/types-5.0.1.tgz",
-      "integrity": "sha512-A8tJYiOc3BUMsyk/kqafs1sYlv+xuIvZJXnLsPSX9MwRuFcK1c5YDP6sccIiSunECib84FhmjbApdAo6VZyMzQ==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/types/-/types-7.0.0.tgz",
+      "integrity": "sha512-hMyuE3YyWinBtuxzx0YcMHkH2h29LT/bZI1Ue+L6vHqxW5nXIyWYsPFUzPqNgMDDe3EKHgPyuZDlmeOosxHluA==",
       "dev": true
     },
     "@cypress/listr-verbose-renderer": {
@@ -12966,9 +12966,9 @@
       "dev": true
     },
     "gaxios": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.1.0.tgz",
-      "integrity": "sha512-vb0to8xzGnA2qcgywAjtshOKKVDf2eQhJoiL6fHhgW5tVN7wNk7egnYIO9zotfn3lQ3De1VPdf7V5/BWfCtCmg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.2.0.tgz",
+      "integrity": "sha512-Ms7fNifGv0XVU+6eIyL9LB7RVESeML9+cMvkwGS70xyD6w2Z80wl6RiqiJ9k1KFlJCUTQqFFc8tXmPQfSKUe8g==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
@@ -13241,9 +13241,9 @@
       }
     },
     "got": {
-      "version": "11.8.1",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.1.tgz",
-      "integrity": "sha512-9aYdZL+6nHmvJwHALLwKSUZ0hMwGaJGYv3hoPLPgnT8BoBXm1SjnZeky+91tfwJaDzun2s4RsBRy48IEYv2q2Q==",
+      "version": "11.8.2",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.2.tgz",
+      "integrity": "sha512-D0QywKgIe30ODs+fm8wMZiAcZjypcCodPNuMz5H9Mny7RJ+IjJ10BdmGW7OM7fHXP+O7r6ZwapQ/YQmMSvB0UQ==",
       "dev": true,
       "requires": {
         "@sindresorhus/is": "^4.0.0",
@@ -13299,9 +13299,9 @@
           }
         },
         "defer-to-connect": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.0.tgz",
-          "integrity": "sha512-bYL2d05vOSf1JEZNx5vSAtPuBMkX8K9EUutg7zlKvTqKXHt7RhWJFbmd7qakVuf13i+IkGmp6FwSsONOf6VYIg==",
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+          "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
           "dev": true
         },
         "get-stream": {
@@ -13341,9 +13341,9 @@
           "dev": true
         },
         "p-cancelable": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.0.0.tgz",
-          "integrity": "sha512-wvPXDmbMmu2ksjkB4Z3nZWTSkJEb9lqVdMaCKpZUGJG9TMiNp9XcbG3fn9fPKjem04fJMJnXoyFPk2FmgiaiNg==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-2.1.0.tgz",
+          "integrity": "sha512-HAZyB3ZodPo+BDpb4/Iu7Jv4P6cSazBz9ZM0ChhEXp70scx834aWCEjQRwgt41UzzejUAPdbqqONfRWTPYrPAQ==",
           "dev": true
         },
         "responselike": {
@@ -14110,9 +14110,9 @@
       }
     },
     "http2-wrapper": {
-      "version": "1.0.0-beta.5.2",
-      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.0-beta.5.2.tgz",
-      "integrity": "sha512-xYz9goEyBnC8XwXDTuC/MZ6t+MrKVQZOk4s7+PaDkwIsQd8IwqvM+0M6bA/2lvG8GHXcPdf+MejTUeO2LCPCeQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-1.0.3.tgz",
+      "integrity": "sha512-V+23sDMr12Wnz7iTcDeJr3O6AIxlnvT/bmaAAAP/Xda35C90p9599p0F1eHR/N1KILWSoWVAiOMFjBBXaXSMxg==",
       "dev": true,
       "requires": {
         "quick-lru": "^5.1.1",
@@ -20628,9 +20628,9 @@
       }
     },
     "robots-parser": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/robots-parser/-/robots-parser-2.1.1.tgz",
-      "integrity": "sha512-6yWEYSdhK3bAEcYY0In3wgSBK70BiQoJArzdjZKCP/35b3gKIYu5Lc0qQqsoxjoLVebVoJiKK4VWGc5+oxvWBQ==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/robots-parser/-/robots-parser-2.2.0.tgz",
+      "integrity": "sha512-PsUtHqiuk5MiC6WFnTFxry7NZfuuwh5eG7WBx+iYS5zFx5BlitW0s5uizl8mfCBVW/v9t0FRI95L1cACXI6PJw==",
       "dev": true
     },
     "rst-selector-parser": {
@@ -20925,9 +20925,9 @@
       "dev": true
     },
     "secure-json-parse": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.3.0.tgz",
-      "integrity": "sha512-kEyTf2cpnuqp7Aiem+yz3QWgm58pYbLlYg4TnVWChZkUBQTcolYZIYRQXmXvEtGJGJ532LREyc8d7pbu9utu7A==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-2.3.1.tgz",
+      "integrity": "sha512-5uGhQLHSC9tVa7RGPkSwxbZVsJCZvIODOadAimCXkU1aCa1fWdszj2DktcutK8A7dD58PoRdxTYiy0jFl6qjnw==",
       "dev": true
     },
     "select-hose": {
@@ -23169,9 +23169,9 @@
       }
     },
     "urijs": {
-      "version": "1.19.5",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.5.tgz",
-      "integrity": "sha512-48z9VGWwdCV5KfizHsE05DWS5fhK6gFlx5MjO7xu0Krc5FGPWzjlXEVV0nPMrdVuP7xmMHiPZ2HoYZwKOFTZOg==",
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.6.tgz",
+      "integrity": "sha512-eSXsXZ2jLvGWeLYlQA3Gh36BcjF+0amo92+wHPyN1mdR8Nxf75fuEuYTd9c0a+m/vhCjRK0ESlE9YNLW+E1VEw==",
       "dev": true
     },
     "urix": {
@@ -25152,9 +25152,9 @@
       }
     },
     "xml-encryption": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/xml-encryption/-/xml-encryption-1.2.1.tgz",
-      "integrity": "sha512-hn5w3l5p2+nGjlmM0CAhMChDzVGhW+M37jH35Z+GJIipXbn9PUlAIRZ6I5Wm7ynlqZjFrMAr83d/CIp9VZJMTA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/xml-encryption/-/xml-encryption-1.2.2.tgz",
+      "integrity": "sha512-s0Fax5BpCZqLzYGtlmilUoi/kyhj8dHqaMOvTAQLifkDS4QVfIuBqhEj9POtk3YbZ0tSxp/hvbGj3iCOM1ej8w==",
       "dev": true,
       "requires": {
         "escape-html": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@babel/preset-react": "^7.10.4",
     "@babel/register": "^7.12.0",
     "@babel/runtime": "^7.12.0",
-    "@cumulus/api": "5.0.2-alpha.0",
+    "@cumulus/api": "7.0.0",
     "@cumulus/aws-client": "4.0.0",
     "@cypress/webpack-preprocessor": "^4.1.5",
     "audit-ci": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "@babel/register": "^7.12.0",
     "@babel/runtime": "^7.12.0",
     "@cumulus/api": "7.0.0",
-    "@cumulus/aws-client": "4.0.0",
+    "@cumulus/aws-client": "7.0.0",
     "@cypress/webpack-preprocessor": "^4.1.5",
     "audit-ci": "^3.1.1",
     "autoprefixer": "^9.8.6",


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2419: Dashboard doesn't display log entries for collection, granule etc.](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2419)

## Changes

* Fixes log viewer query for cloud metrics log
* Cloud Metrics log doesn't parse out provider and pdrName, so only query string search can be performed.
* Update the @cumulus/api version to 7.0.0 for searching from cloud metrics log

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Adhoc testing
- [x] Integration tests