### PR TITLE
CUMULUS-2348: Version bump for next Cumulus API release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Breaking Changes
 
-This version of the dashboard requires Cumulus API `change-me-next-api-release-after-8.0.0`
+This version of the dashboard requires Cumulus API `v8.1.0`
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Breaking Changes
 
-This version of the dashboard requires Cumulus API 7.2.1-alpha.0
+This version of the dashboard requires Cumulus API `change-me-next-api-release-after-8.0.0`
 
 ### Added
 

--- a/app/src/js/config/index.js
+++ b/app/src/js/config/index.js
@@ -8,7 +8,7 @@ const deploymentConfig = require('./config');
 const baseConfig = {
   environment: 'development',
   requireEarthdataLogin: false,
-  minCompatibleApiVersion: 'change-me-next-api-release-after-8.0.0',
+  minCompatibleApiVersion: 'v8.1.0',
   oauthMethod: 'earthdata',
 
   graphicsPath: '/src/assets/images/',

--- a/app/src/js/config/index.js
+++ b/app/src/js/config/index.js
@@ -8,7 +8,7 @@ const deploymentConfig = require('./config');
 const baseConfig = {
   environment: 'development',
   requireEarthdataLogin: false,
-  minCompatibleApiVersion: '7.0.0',
+  minCompatibleApiVersion: 'change-me-next-api-release-after-8.0.0',
   oauthMethod: 'earthdata',
 
   graphicsPath: '/src/assets/images/',


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2348: Implement Granule Recovery status](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2348)

## Changes

* CUMULUS-2348 requires next @cumulus/api release after 8.0.0, it now uses @cumulus/api@7.2.1-alpha.0 for local API testing.
