### PR TITLE
[CUMULUS-2435] Add step name to execution events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ This version of the dashboard requires Cumulus API 7.2.1-alpha.0
   - Implement Granule Recovery status
   - Requires @cumulus/api@7.2.1-alpha.0
 
+- **CUMULUS-2435**
+  - Add step name to execution events
+
 ### Changed
 
 - **CUMULUS-2282**

--- a/app/src/js/components/Executions/execution-events.js
+++ b/app/src/js/components/Executions/execution-events.js
@@ -35,8 +35,11 @@ const ExecutionEvents = ({
   const { events } = executionHistory || {};
   const mutableEvents = cloneDeep(events);
   if (mutableEvents) {
-    mutableEvents.forEach((event) => {
+    mutableEvents.forEach((event, index, eventsArray) => {
       event.eventDetails = getEventDetails(event);
+      if (index === 0 || event.name || !event.type.match('LambdaFunction')) return;
+      const prevStep = eventsArray[index - 1];
+      event.name = prevStep.name;
     });
   }
 

--- a/app/src/js/utils/table-config/execution-status.js
+++ b/app/src/js/utils/table-config/execution-status.js
@@ -11,10 +11,15 @@ export const tableColumns = [
   {
     Header: 'Id',
     accessor: 'id',
+    width: 10
   },
   {
     Header: 'Type',
     accessor: 'type'
+  },
+  {
+    Header: 'Step',
+    accessor: 'name',
   },
   {
     Header: 'Timestamp',
@@ -22,7 +27,7 @@ export const tableColumns = [
     Cell: ({ cell: { value } }) => fullDate(value)
   },
   {
-    Header: 'Input Details',
+    Header: 'Event Details',
     accessor: 'eventDetails',
     Cell: ({ cell: { value } }) => {
       const [showModal, setShowModal] = useState(false);

--- a/app/src/js/utils/table-config/execution-status.js
+++ b/app/src/js/utils/table-config/execution-status.js
@@ -18,7 +18,7 @@ export const tableColumns = [
     accessor: 'type'
   },
   {
-    Header: 'Step',
+    Header: 'Step Name',
     accessor: 'name',
   },
   {

--- a/cypress/integration/executions_spec.js
+++ b/cypress/integration/executions_spec.js
@@ -182,7 +182,7 @@ describe('Dashboard Executions Page', () => {
         cy.get('@events').each(($el, index, $list) => {
           const timestamp = fullDate(events[index].timestamp);
           cy.wrap($el).children('.td').as('columns');
-          cy.get('@columns').should('have.length', 4);
+          cy.get('@columns').should('have.length', 5);
           const id = index + 1;
           const idMatch = `"id": ${id},`;
           const previousIdMatch = `"previousEventId": ${index}`;

--- a/cypress/integration/executions_spec.js
+++ b/cypress/integration/executions_spec.js
@@ -174,6 +174,13 @@ describe('Dashboard Executions Page', () => {
       cy.contains('.heading--large', executionName);
       cy.contains('.num-title', 7);
 
+      cy.get('.table .thead .tr .th').as('columnHeaders');
+      cy.get('@columnHeaders').eq(0).should('contain.text', 'Id');
+      cy.get('@columnHeaders').eq(1).should('contain.text', 'Type');
+      cy.get('@columnHeaders').eq(2).should('contain.text', 'Step');
+      cy.get('@columnHeaders').eq(3).should('contain.text', 'Timestamp');
+      cy.get('@columnHeaders').eq(4).should('contain.text', 'Event Details');
+
       cy.get('.table .tbody .tr').as('events');
       cy.get('@events').should('have.length', 7);
 
@@ -188,9 +195,9 @@ describe('Dashboard Executions Page', () => {
           const previousIdMatch = `"previousEventId": ${index}`;
 
           cy.get('@columns').eq(0).should('have.text', (index + 1).toString());
-          cy.get('@columns').eq(2).should('have.text', timestamp);
+          cy.get('@columns').eq(3).should('have.text', timestamp);
           cy.get('.execution__modal').should('not.exist');
-          cy.get('@columns').eq(3).contains('More Details').click();
+          cy.get('@columns').eq(4).contains('More Details').click();
           cy.get('.execution__modal').should('exist');
           cy.get('.execution__modal .modal-title').contains(`ID ${id}: Event Details`);
           cy.get('.execution__modal .modal-body').contains(idMatch);

--- a/test/components/executions/execution-events.js
+++ b/test/components/executions/execution-events.js
@@ -10,19 +10,66 @@ import executionHistory from '../../../test/fixtures/execution-history-all';
 
 configure({ adapter: new Adapter() });
 
-test('Execution Events shows event history', function (t) {
+const match = {
+  params: { executionArn: executionHistory.execution.executionArn },
+};
+
+const dispatch = () => {};
+
+test('Execution Events displays the correct step name', function (t) {
+  const plainEventsExecutionHistory = {
+    events: [
+      {
+        id: 0,
+        type: 'ExecutionStarted',
+      },
+      {
+        id: 1,
+        type: 'TaskStateEntered',
+        name: 'SyncGranule',
+      },
+      {
+        id: 2,
+        type: 'LambdaFunctionScheduled',
+      },
+      {
+        id: 3,
+        type: 'LambdaFunctionStarted',
+      },
+      {
+        id: 4,
+        type: 'LambdaFunctionSucceeded',
+      },
+      {
+        id: 5,
+        type: 'TaskStateExited',
+        name: 'SyncGranule',
+      },
+      {
+        id: 6,
+        type: 'ChoiceStateEntered',
+        name: 'ChooseProcess',
+      },
+      {
+        id: 7,
+        type: 'ChoiceStateExited',
+        name: 'ChooseProcess',
+      },
+      {
+        id: 8,
+        type: 'ExecutionSucceeded',
+      },
+    ],
+  };
+
   const executionStatus = {
     execution: executionHistory.execution,
-    executionHistory: executionHistory.executionHistory,
+    executionHistory: plainEventsExecutionHistory,
     stateMachine: executionHistory.execution,
     inflight: true,
     error: false,
-    meta: {}
+    meta: {},
   };
-
-  const match = { params: { executionArn: executionHistory.execution.executionArn } };
-
-  const dispatch = () => {};
 
   const executionEventsRendered = shallow(
     <ExecutionEvents
@@ -37,37 +84,89 @@ test('Execution Events shows event history', function (t) {
   t.is(sortableTable.length, 1);
 
   const sortableTableWrapper = sortableTable.dive();
-  const tableRows = sortableTableWrapper.find('div.tr[data-value]');
+  const tableRows = sortableTableWrapper.find('.tbody .tr');
+  t.is(tableRows.length, 9);
+
+  const expectedStepNames = [
+    '',
+    'SyncGranule',
+    'SyncGranule',
+    'SyncGranule',
+    'SyncGranule',
+    'SyncGranule',
+    'ChooseProcess',
+    'ChooseProcess',
+    '',
+  ];
+
+  tableRows.forEach((row, index) => {
+    const columns = row.find('Cell');
+    t.is(columns.length, 5);
+    const stepName = columns.at(2).shallow().text();
+    t.is(stepName, expectedStepNames[index])
+  });
+});
+
+test('Execution Events shows event history', function (t) {
+  const executionStatus = {
+    execution: executionHistory.execution,
+    executionHistory: executionHistory.executionHistory,
+    stateMachine: executionHistory.execution,
+    inflight: true,
+    error: false,
+    meta: {},
+  };
+
+  const executionEventsRendered = shallow(
+    <ExecutionEvents
+      dispatch={dispatch}
+      location={{}}
+      match={match}
+      executionStatus={executionStatus}
+    />
+  );
+
+  const sortableTable = executionEventsRendered.find('SortableTable');
+  t.is(sortableTable.length, 1);
+
+  const sortableTableWrapper = sortableTable.dive();
+  const tableRows = sortableTableWrapper.find('.tbody .tr');
   t.is(tableRows.length, 19);
 
   const expectedWorkflowTasksData = {
     StatusReport: {
       version: '$LATEST',
       name: 'test-SfSnsReport',
-      arn: 'arn:aws:lambda:us-east-1:000000000000:function:test-SfSnsReport'
+      arn: 'arn:aws:lambda:us-east-1:000000000000:function:test-SfSnsReport',
     },
     DiscoverGranules: {
       version: '$LATEST',
       name: 'test-DiscoverGranules',
-      arn: 'arn:aws:lambda:us-east-1:000000000000:function:test-DiscoverGranules'
+      arn: 'arn:aws:lambda:us-east-1:000000000000:function:test-DiscoverGranules',
     },
     StopStatus: {
       version: '$LATEST',
       name: 'test-SfSnsReport',
-      arn: 'arn:aws:lambda:us-east-1:000000000000:function:test-SfSnsReport'
-    }
+      arn: 'arn:aws:lambda:us-east-1:000000000000:function:test-SfSnsReport',
+    },
   };
 
-  tableRows.forEach(row => {
+  tableRows.forEach((row) => {
     const columns = row.find('Cell');
     t.is(columns.length, 5);
     const moreDetails = columns.last().shallow().find('pre');
-    moreDetails.map(node => {
+    moreDetails.map((node) => {
       const parsedDetailsOutput = JSON.parse(node.text()).output;
-      if (parsedDetailsOutput && parsedDetailsOutput.meta &&
+      if (
+        parsedDetailsOutput &&
+        parsedDetailsOutput.meta &&
         parsedDetailsOutput.meta.workflow_tasks &&
-        Object.keys(parsedDetailsOutput.meta.workflow_tasks).length === 3) {
-        t.deepEqual(parsedDetailsOutput.meta.workflow_tasks, expectedWorkflowTasksData);
+        Object.keys(parsedDetailsOutput.meta.workflow_tasks).length === 3
+      ) {
+        t.deepEqual(
+          parsedDetailsOutput.meta.workflow_tasks,
+          expectedWorkflowTasksData
+        );
       }
     });
   });

--- a/test/components/executions/execution-events.js
+++ b/test/components/executions/execution-events.js
@@ -60,7 +60,7 @@ test('Execution Events shows event history', function (t) {
 
   tableRows.forEach(row => {
     const columns = row.find('Cell');
-    t.is(columns.length, 4);
+    t.is(columns.length, 5);
     const moreDetails = columns.last().shallow().find('pre');
     moreDetails.map(node => {
       const parsedDetailsOutput = JSON.parse(node.text()).output;


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2435: Show Step Name in the Events table of an Execution](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2435)

## Changes

* Adds step name to execution events table

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Adhoc testing
- [x] Integration tests