### PR TITLE
Cumulus-2056 Executions Display Improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,11 @@ This version of the dashboard requires Cumulus API 7.0.0
 - **CUMULUS-2430**
   - Overview KPI status cards: Change styling to new design
 
+- **CUMULUS-2056**
+  - Added Events link to Details section of Executions page
+  - On Events tab of Execution page, highlighted in the red the failed tasks
+  - On Events tab of Execution page, made tasks expandable to show event details
+
 ### Added
 
 - **CUMULUS-2297**

--- a/app/src/css/_buttons.scss
+++ b/app/src/css/_buttons.scss
@@ -88,6 +88,24 @@ $delete-btn-hover-bg-color: darken($error-red, 10%);
     }
   }
 
+  &--failed {
+    background-color: $error-red;
+    position: relative;
+
+      &:before{
+        color: $white;
+        position: absolute;
+        font-family: 'FontAwesome';
+        font-weight: 900;
+        left: 10px;
+      }
+      &:hover {
+        background-color: $delete-btn-hover-bg-color;
+        color: #fff;
+        border: 0;
+      }
+  }
+
   &--primary, &--primary:visited {
     &:hover {
       background-color: darken($ocean-blue, 10%);

--- a/app/src/css/_buttons.scss
+++ b/app/src/css/_buttons.scss
@@ -50,6 +50,18 @@ $delete-btn-hover-bg-color: darken($error-red, 10%);
     }
   }
 
+  &--events{
+    background-color: $light-green;
+    padding: .4em 1.5em .4em 1.5em;
+    float: right;
+
+    &:hover {
+      background-color: darken($light-green, 10%);
+      color: #fff;
+      border: 0;
+    }
+  }
+
   &--large{
     padding: .7em 2em;
     font-weight: $base-font-bold;

--- a/app/src/js/components/Executions/execution-status.js
+++ b/app/src/js/components/Executions/execution-status.js
@@ -78,7 +78,16 @@ const ExecutionStatus = ({
 
       <section className="page__section">
         <div className="heading__wrapper--border">
-          <h2 className="heading--medium with-description">Details</h2>
+          <h2 className="heading--medium with-description">Details
+          <Link
+            className="button button--small button--events"
+            to={() => ({
+              pathname: `/executions/execution/${executionArn}/events`
+            })}
+          >
+          Events
+          </Link>
+          </h2>
         </div>
         <div className="execution__content status--process">
           <Metadata
@@ -92,14 +101,6 @@ const ExecutionStatus = ({
             })}
           />
         </div>
-        <Link
-          className="button button--small button--green"
-          to={() => ({
-            pathname: `/executions/execution/${executionArn}/events`
-          })}
-        >
-        Events
-        </Link>
       </section>
     </div>
   );

--- a/app/src/js/components/Executions/execution-status.js
+++ b/app/src/js/components/Executions/execution-status.js
@@ -79,14 +79,14 @@ const ExecutionStatus = ({
       <section className="page__section">
         <div className="heading__wrapper--border">
           <h2 className="heading--medium with-description">Details
-          <Link
-            className="button button--small button--events"
-            to={() => ({
-              pathname: `/executions/execution/${executionArn}/events`
-            })}
-          >
-          Events
-          </Link>
+            <Link
+              className="button button--small button--events"
+              to={() => ({
+                pathname: `/executions/execution/${executionArn}/events`
+              })}
+            >
+            Events
+            </Link>
           </h2>
         </div>
         <div className="execution__content status--process">

--- a/app/src/js/components/Executions/execution-status.js
+++ b/app/src/js/components/Executions/execution-status.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Helmet } from 'react-helmet';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { withRouter } from 'react-router-dom';
+import { Link, withRouter } from 'react-router-dom';
 import { getExecutionStatus, getCumulusInstanceMetadata } from '../../actions';
 import { metaAccessors } from '../../utils/table-config/execution-status';
 
@@ -92,6 +92,14 @@ const ExecutionStatus = ({
             })}
           />
         </div>
+        <Link
+          className="button button--small button--green"
+          to={() => ({
+            pathname: `/executions/execution/${executionArn}/events`
+          })}
+        >
+        Events
+        </Link>
       </section>
     </div>
   );

--- a/app/src/js/utils/table-config/execution-status.js
+++ b/app/src/js/utils/table-config/execution-status.js
@@ -14,7 +14,41 @@ export const tableColumns = [
   },
   {
     Header: 'Type',
-    accessor: 'type'
+    accessor: 'eventDetails',
+    Cell: ({ cell: { value } }) => {
+      const [showModal, setShowModal] = useState(false);
+      const { id } = value || {};
+      function toggleModal(e) {
+        if (e) {
+          e.preventDefault();
+        }
+        setShowModal(!showModal);
+      }
+      if (value) {
+        return (
+          <>
+            <button
+              onClick={toggleModal}
+              className="button button--small button--no-left-padding"
+            >
+              {value.type}
+            </button>
+            <DefaultModal
+              showModal={showModal}
+              title={`ID ${id}: Event Details`}
+              onCloseModal={toggleModal}
+              hasConfirmButton={false}
+              cancelButtonClass="button--close"
+              cancelButtonText="Close"
+              className="execution__modal"
+            >
+              <pre>{JSON.stringify(value, null, 2)}</pre>
+            </DefaultModal>
+          </>
+        );
+      }
+      return 'N/A';
+    },
   },
   {
     Header: 'Timestamp',

--- a/app/src/js/utils/table-config/execution-status.js
+++ b/app/src/js/utils/table-config/execution-status.js
@@ -28,9 +28,9 @@ export const tableColumns = [
       if (eventDetails) {
         let buttonClass;
         if (eventDetails.type === 'LambdaFunctionFailed') {
-          buttonClass = "button button--small button--no-left-padding button--failed"
+          buttonClass = 'button button--small button--no-left-padding button--failed';
         } else {
-          buttonClass = "button button--small button--no-left-padding"
+          buttonClass = 'button button--small button--no-left-padding';
         }
         return (
           <>

--- a/app/src/js/utils/table-config/execution-status.js
+++ b/app/src/js/utils/table-config/execution-status.js
@@ -14,35 +14,43 @@ export const tableColumns = [
   },
   {
     Header: 'Type',
-    accessor: 'eventDetails',
-    Cell: ({ cell: { value } }) => {
+    accessor: 'type',
+    Cell: ({ cell: { value }, row: { original: { eventDetails } } }) => {
       const [showModal, setShowModal] = useState(false);
-      const { id } = value || {};
+      const { id } = eventDetails || {};
       function toggleModal(e) {
         if (e) {
           e.preventDefault();
         }
         setShowModal(!showModal);
       }
-      if (value) {
+      if (eventDetails) {
+        let buttonClass;
+        if (eventDetails.type === 'LambdaFunctionFailed') {
+          console.log('does this get hit');
+          console.log(eventDetails.type);
+          buttonClass = "button button--small button--no-left-padding button--failed"
+        } else {
+          buttonClass = "button button--small button--no-left-padding"
+        }
         return (
           <>
             <button
               onClick={toggleModal}
-              className="button button--small button--no-left-padding"
+              className={buttonClass}
             >
-              {value.type}
+              {eventDetails.type}
             </button>
             <DefaultModal
               showModal={showModal}
-              title={`ID ${id}: Event Details`}
+              title={`ID ${id}: ${value}`}
               onCloseModal={toggleModal}
               hasConfirmButton={false}
               cancelButtonClass="button--close"
               cancelButtonText="Close"
               className="execution__modal"
             >
-              <pre>{JSON.stringify(value, null, 2)}</pre>
+              <pre>{JSON.stringify(eventDetails, null, 2)}</pre>
             </DefaultModal>
           </>
         );

--- a/app/src/js/utils/table-config/execution-status.js
+++ b/app/src/js/utils/table-config/execution-status.js
@@ -28,8 +28,6 @@ export const tableColumns = [
       if (eventDetails) {
         let buttonClass;
         if (eventDetails.type === 'LambdaFunctionFailed') {
-          console.log('does this get hit');
-          console.log(eventDetails.type);
           buttonClass = "button button--small button--no-left-padding button--failed"
         } else {
           buttonClass = "button button--small button--no-left-padding"

--- a/cypress/integration/executions_spec.js
+++ b/cypress/integration/executions_spec.js
@@ -264,8 +264,6 @@ describe('Dashboard Executions Page', () => {
         .within(() => {
           cy.get('a').should('have.attr', 'href', `/executions/execution/${executionArn}/logs`);
         });
-
-      cy.contains('.heading--medium', 'Events').should('not.exist');
     });
 
     it('should show an execution graph for a single execution', () => {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2056: Updated to execution page](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2056)

## Changes

* On executions Details page, Added button at bottom to go to Events
* On Events page, made task type an expandable button for step details
* On Events page, highlighted failed tasks in red

