### PR TITLE
[CUMULUS-2549] Collections table sorting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Ensured that the KPI cards would be updated on all tabs whenever the page was updated
 - **CUMULUS-2544**
   - Changed the timestamp so that the date and time is shown rather than time elapsed since last occurrence
+- **CUMULUS-2549**
+  - All columns on collections overview page are now sortable
 - **CUMULUS-2551**
   - Added a sortable column to individual granules tab so you can sort each file within the granule by size. 
 - **CUMULUS-2554**

--- a/app/src/js/components/SortableTable/SortableTable.js
+++ b/app/src/js/components/SortableTable/SortableTable.js
@@ -120,6 +120,7 @@ const SortableTable = ({
 
   const tableRows = page || rows;
 
+  // useMemo code modified from https://github.com/tannerlinsley/react-table/blob/master/src/plugin-hooks/useSortBy.js#L272
   const [sortedRows] = React.useMemo(() => {
     // we only want to do this if we're already manually sorting but have columns we want to sort client side
     if (!manualSortBy || !sortBy.length) {
@@ -168,8 +169,9 @@ const SortableTable = ({
   }, [selectedRowIds, onSelect]);
 
   useEffect(() => {
+    const availableSortBy = sortBy.filter((sortColumn) => !sortColumn.id.includes('__no-sort'));
     if (typeof changeSortProps === 'function') {
-      changeSortProps(sortBy);
+      changeSortProps(availableSortBy);
     }
   }, [changeSortProps, sortBy]);
 

--- a/app/src/js/utils/sortable-table.js
+++ b/app/src/js/utils/sortable-table.js
@@ -1,0 +1,122 @@
+import React, { useEffect, forwardRef, useRef } from 'react';
+import PropTypes from 'prop-types';
+
+export const getColumnWidth = (rows, accessor, headerText, originalWidth) => {
+  const maxWidth = 400;
+  const magicSpacing = 10;
+  const cellLength = Math.max(
+    ...rows.map(
+      (row) => (`${row.values[accessor]}` || '').length * magicSpacing
+    ),
+    headerText.length * magicSpacing,
+    originalWidth
+  );
+  return Math.min(maxWidth, cellLength);
+};
+
+/**
+ * IndeterminateCheckbox
+ * @description Component for rendering the header and column checkboxs when canSelect is true
+ * Taken from react-table examples
+ */
+export const IndeterminateCheckbox = forwardRef(
+  ({ indeterminate, title, ...rest }, ref) => {
+    const defaultRef = useRef();
+    const resolvedRef = ref || defaultRef;
+
+    useEffect(() => {
+      resolvedRef.current.indeterminate = indeterminate;
+    }, [resolvedRef, indeterminate]);
+
+    return (
+      <input
+        type="checkbox"
+        ref={resolvedRef}
+        aria-label={title}
+        title={title}
+        {...rest}
+      />
+    );
+  }
+);
+
+IndeterminateCheckbox.propTypes = {
+  indeterminate: PropTypes.any,
+  onChange: PropTypes.func,
+  title: PropTypes.string,
+};
+
+export function checkInView(container, element, partial) {
+  if (!container || !element) {
+    return true;
+  }
+
+  // Get container properties
+  const cLeft = container.scrollLeft;
+  const cRight = cLeft + container.clientWidth;
+
+  // Get element properties
+  const eLeft = element.offsetLeft - container.offsetLeft;
+  const eRight = eLeft + element.clientWidth;
+
+  // Check if in view
+  const isTotal = eLeft >= cLeft && eRight <= cRight;
+  const isPartial =
+    partial &&
+    ((eLeft < cLeft && eRight > cLeft) || (eRight > cRight && eLeft < cRight));
+
+  // Return outcome
+  return isTotal || isPartial;
+}
+
+export const sortData = ({
+  allColumns,
+  availableSortBy,
+  orderByFn,
+  rows,
+  sortedFlatRows,
+}) => {
+  // Use the orderByFn to compose multiple sortBy's together.
+  // This will also perform a stable sorting using the row index
+  // if needed.
+  const sortedData = orderByFn(
+    rows,
+    availableSortBy.map((sort) => {
+      // Support custom sorting methods for each column
+      const column = allColumns.find((d) => d.id === sort.id);
+
+      if (!column) {
+        throw new Error(
+          `React-Table: Could not find a column with id: ${sort.id} while sorting`
+        );
+      }
+
+      const { sortMethod } = column;
+      // Return the correct sortFn.
+      // This function should always return in ascending order
+      return (a, b) => sortMethod(a, b, sort.id, sort.desc);
+    }),
+    // Map the directions
+    availableSortBy.map((sort) => {
+      // Detect and use the sortInverted option
+      const column = allColumns.find((d) => d.id === sort.id);
+
+      if (column && column.sortInverted) {
+        return sort.desc;
+      }
+
+      return !sort.desc;
+    })
+  );
+
+  // If there are sub-rows, sort them
+  sortedData.forEach((row) => {
+    sortedFlatRows.push(row);
+    if (!row.subRows || row.subRows.length === 0) {
+      return;
+    }
+    row.subRows = sortData(row.subRows);
+  });
+
+  return sortedData;
+};

--- a/app/src/js/utils/sortable-table.js
+++ b/app/src/js/utils/sortable-table.js
@@ -14,6 +14,8 @@ export const getColumnWidth = (rows, accessor, headerText, originalWidth) => {
   return Math.min(maxWidth, cellLength);
 };
 
+/** Code below modifed from https://github.com/tannerlinsley/react-table */
+
 /**
  * IndeterminateCheckbox
  * @description Component for rendering the header and column checkboxs when canSelect is true
@@ -120,3 +122,141 @@ export const sortData = ({
 
   return sortedData;
 };
+
+/** Modified from https://github.com/tannerlinsley/react-table/blob/master/src/sortTypes.js */
+
+const reSplitAlphaNumeric = /([0-9]+)/gm;
+
+// Mixed sorting is slow, but very inclusive of many edge cases.
+// It handles numbers, mixed alphanumeric combinations, and even
+// null, undefined, and Infinity
+export const alphanumericSort = (rowA, rowB, columnId) => {
+  let [a, b] = getRowValuesByColumnID(rowA, rowB, columnId);
+
+  // Force to strings (or "" for unsupported types)
+  a = toString(a);
+  b = toString(b);
+
+  // Split on number groups, but keep the delimiter
+  // Then remove falsey split values
+  a = a.split(reSplitAlphaNumeric).filter(Boolean);
+  b = b.split(reSplitAlphaNumeric).filter(Boolean);
+
+  // While
+  while (a.length && b.length) {
+    const aa = a.shift();
+    const bb = b.shift();
+
+    const an = parseInt(aa, 10);
+    const bn = parseInt(bb, 10);
+
+    const combo = [an, bn].sort();
+
+    // Both are string
+    if (Number.isNaN(combo[0])) {
+      if (aa > bb) {
+        return 1;
+      }
+      if (bb > aa) {
+        return -1;
+      }
+    }
+
+    // One is a string, one is a number
+    if (Number.isNaN(combo[1])) {
+      return Number.isNaN(an) ? -1 : 1;
+    }
+
+    // Both are numbers
+    if (an > bn) {
+      return 1;
+    }
+    if (bn > an) {
+      return -1;
+    }
+  }
+
+  return a.length - b.length;
+};
+export function datetimeSort(rowA, rowB, columnId) {
+  let [a, b] = getRowValuesByColumnID(rowA, rowB, columnId);
+
+  a = a.getTime();
+  b = b.getTime();
+
+  return compareBasic(a, b);
+}
+
+export function basicSort(rowA, rowB, columnId) {
+  const [a, b] = getRowValuesByColumnID(rowA, rowB, columnId);
+
+  return compareBasic(a, b);
+}
+
+export function stringSort(rowA, rowB, columnId) {
+  let [a = '', b = ''] = getRowValuesByColumnID(rowA, rowB, columnId);
+
+  a = a.split('').filter(Boolean);
+  b = b.split('').filter(Boolean);
+
+  while (a.length && b.length) {
+    const aa = a.shift();
+    const bb = b.shift();
+
+    const alower = aa.toLowerCase();
+    const blower = bb.toLowerCase();
+
+    // Case insensitive comparison until characters match
+    if (alower > blower) {
+      return 1;
+    }
+    if (blower > alower) {
+      return -1;
+    }
+    // If lowercase characters are identical
+    if (aa > bb) {
+      return 1;
+    }
+    if (bb > aa) {
+      return -1;
+    }
+  }
+
+  return a.length - b.length;
+}
+
+export function numberSort(rowA, rowB, columnId) {
+  let [a, b] = getRowValuesByColumnID(rowA, rowB, columnId);
+
+  const replaceNonNumeric = /[^0-9.]/gi;
+
+  a = Number(String(a).replace(replaceNonNumeric, ''));
+  b = Number(String(b).replace(replaceNonNumeric, ''));
+
+  return compareBasic(a, b);
+}
+
+// Utils
+
+function compareBasic(a, b) {
+  if (a > b) return 1;
+  if (a < b) return -1;
+  return 0;
+}
+
+function getRowValuesByColumnID(row1, row2, columnId) {
+  return [row1.values[columnId], row2.values[columnId]];
+}
+
+function toString(a) {
+  if (typeof a === 'number') {
+    if (Number.isNaN(a) || a === Infinity || a === -Infinity) {
+      return '';
+    }
+    return String(a);
+  }
+  if (typeof a === 'string') {
+    return a;
+  }
+  return '';
+}

--- a/app/src/js/utils/table-config/collections.js
+++ b/app/src/js/utils/table-config/collections.js
@@ -8,17 +8,7 @@ import BatchDeleteConfirmContent from '../../components/DeleteCollection/BatchDe
 import BatchDeleteCompleteContent from '../../components/DeleteCollection/BatchDeleteCompleteContent';
 import BatchDeleteWithGranulesContent from '../../components/DeleteCollection/BatchDeleteWithGranulesContent';
 import { getPersistentQueryParams, historyPushWithQueryParams } from '../url-helper';
-
-function getRowValuesByColumnID(row1, row2, columnId) {
-  return [row1.values[columnId], row2.values[columnId]];
-}
-
-const statsSort = (rowA, rowB, columnId) => {
-  const [a, b] = getRowValuesByColumnID(rowA, rowB, columnId);
-  if (a > b) return 1;
-  if (a < b) return -1;
-  return 0;
-};
+import { numberSort, stringSort } from '../sortable-table';
 
 export const tableColumns = [
   {
@@ -49,36 +39,37 @@ export const tableColumns = [
   {
     Header: strings.granules,
     accessor: (row) => tally(get(row, 'stats.total')),
-    id: 'stats.total',
-    sortMethod: (rowA, rowB, columnId) => statsSort(rowA, rowB, columnId),
+    id: 'granules__no-sort',
+    sortMethod: (rowA, rowB, columnId) => numberSort(rowA, rowB, columnId),
     width: 100
   },
   {
     Header: 'Completed',
     accessor: (row) => tally(get(row, 'stats.completed')),
-    id: 'stats.completed',
-    sortMethod: (rowA, rowB, columnId) => statsSort(rowA, rowB, columnId),
+    id: 'completed__no-sort',
+    sortMethod: (rowA, rowB, columnId) => numberSort(rowA, rowB, columnId),
     width: 100
   },
   {
     Header: 'Running',
     accessor: (row) => tally(get(row, 'stats.running')),
-    id: 'stats.running',
-    sortMethod: (rowA, rowB, columnId) => statsSort(rowA, rowB, columnId),
+    id: 'running__no-sort',
+    sortMethod: (rowA, rowB, columnId) => numberSort(rowA, rowB, columnId),
     width: 100
   },
   {
     Header: 'Failed',
     accessor: (row) => tally(get(row, 'stats.failed')),
-    id: 'stats.failed',
-    sortMethod: (rowA, rowB, columnId) => statsSort(rowA, rowB, columnId),
+    id: 'failed__no-sort',
+    sortMethod: (rowA, rowB, columnId) => numberSort(rowA, rowB, columnId),
     width: 100
   },
   {
     Header: 'MMT',
     accessor: 'MMTLink',
+    id: 'mmt__no-sort',
     Cell: ({ cell: { value } }) => (value ? <a href={value} target="_blank">MMT</a> : null), // eslint-disable-line react/prop-types
-    disableSortBy: true,
+    sortMethod: (rowA, rowB, columnId) => stringSort(rowA, rowB, columnId),
     width: 100
   },
   {

--- a/app/src/js/utils/table-config/collections.js
+++ b/app/src/js/utils/table-config/collections.js
@@ -9,6 +9,17 @@ import BatchDeleteCompleteContent from '../../components/DeleteCollection/BatchD
 import BatchDeleteWithGranulesContent from '../../components/DeleteCollection/BatchDeleteWithGranulesContent';
 import { getPersistentQueryParams, historyPushWithQueryParams } from '../url-helper';
 
+function getRowValuesByColumnID(row1, row2, columnId) {
+  return [row1.values[columnId], row2.values[columnId]];
+}
+
+const statsSort = (rowA, rowB, columnId) => {
+  const [a, b] = getRowValuesByColumnID(rowA, rowB, columnId);
+  if (a > b) return 1;
+  if (a < b) return -1;
+  return 0;
+};
+
 export const tableColumns = [
   {
     Header: 'Name',
@@ -38,29 +49,29 @@ export const tableColumns = [
   {
     Header: strings.granules,
     accessor: (row) => tally(get(row, 'stats.total')),
-    id: 'granules',
-    disableSortBy: true,
+    id: 'stats.total',
+    sortMethod: (rowA, rowB, columnId) => statsSort(rowA, rowB, columnId),
     width: 100
   },
   {
     Header: 'Completed',
     accessor: (row) => tally(get(row, 'stats.completed')),
-    id: 'completed',
-    disableSortBy: true,
+    id: 'stats.completed',
+    sortMethod: (rowA, rowB, columnId) => statsSort(rowA, rowB, columnId),
     width: 100
   },
   {
     Header: 'Running',
     accessor: (row) => tally(get(row, 'stats.running')),
-    id: 'running',
-    disableSortBy: true,
+    id: 'stats.running',
+    sortMethod: (rowA, rowB, columnId) => statsSort(rowA, rowB, columnId),
     width: 100
   },
   {
     Header: 'Failed',
     accessor: (row) => tally(get(row, 'stats.failed')),
-    id: 'failed',
-    disableSortBy: true,
+    id: 'stats.failed',
+    sortMethod: (rowA, rowB, columnId) => statsSort(rowA, rowB, columnId),
     width: 100
   },
   {


### PR DESCRIPTION
**Summary:** Make stats and MMT link columns sortable on collections overview page

Addresses [CUMULUS-2549: Dashboard: As a Cumulus Operator, I need to be able to sort every column in the Collections Overview table](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2549)

## Changes

* Created sortable table utils file to contain helper function
* Handle custom sorting methods that are passed to the table config - modified some code from react-table. This can't be overridden when manual sorting is set to true, which is necessary for the server side sorting of the other columns. Instead implemented custom versions for our code

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Adhoc testing
- [ ] Integration tests