### PR TITLE
CUMULUS-2604: deleted collections column from providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Changed the dropdown menu in the individual providers page into a delete button.
 - **CUMULUS-2579**
   - Fixed React Issue with the Footer pertaining to missing keys.
+- **CUMULUS-2604**
+  - Deleted Collections column in the Providers overview page.
 
 ### Fixed
 

--- a/app/src/js/utils/table-config/providers.js
+++ b/app/src/js/utils/table-config/providers.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { fromNowWithTooltip } from '../format';
-import { strings } from '../../components/locale';
 import { getPersistentQueryParams } from '../url-helper';
 
 export const tableColumns = [
@@ -13,10 +12,6 @@ export const tableColumns = [
   {
     Header: 'Host',
     accessor: 'host'
-  },
-  {
-    Header: strings.collections,
-    accessor: 'collections'
   },
   {
     Header: 'Global Connection Limit',


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2604: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2604)

Very simple change which just deletes the collections column in the providers overview page

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [x] Adhoc testing
- [x] Integration tests