### PR TITLE
Prevent windows from changing line endings.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 * text eol=lf
+*.png binary
+*.pdf binary
+*.ttf binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 * text eol=lf
 *.png binary
+*.jpg binary
 *.pdf binary
 *.ttf binary

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,7 +44,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **CUMULUS-2524**
   - CSS and UI tweaks to padding/margin, width, and color/contrast
 - **CUMULUS-2534**
-  - Added a copy button to errors pages so the error can be copied and searched up on the internet. 
+  - Added a copy button to errors pages so the error can be copied and searched up on the internet.
 - **CUMULUS-2535**
   - Ensured that the KPI cards would be updated on all tabs whenever the page was updated
 - **CUMULUS-2540**
@@ -52,15 +52,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **CUMULUS-2544**
   - Changed the timestamp so that the date and time is shown rather than time elapsed since last occurrence
 - **CUMULUS-2551**
-  - Added a sortable column to individual granules tab so you can sort each file within the granule by size. 
+  - Added a sortable column to individual granules tab so you can sort each file within the granule by size.
 - **CUMULUS-2554**
-  - Add focus styles for various browser support and keyboard/mouse inputs 
+  - Add focus styles for various browser support and keyboard/mouse inputs
 - **CUMULUS-2573**
   - Changed the dropdown menu in the individual providers page into a delete button.
 - **CUMULUS-2579**
   - Fixed React Issue with the Footer pertaining to missing keys.
 - **CUMULUS-2604**
   - Deleted Collections column in the Providers overview page.
+- **CUMULUS-2616**
+  - added .gitattributes file that prevents windows from changing the line endings on checkout from github.
 
 ### Fixed
 


### PR DESCRIPTION
-------

**Summary:** Summary of changes

Addresses [CUMULUS-2616: bootcamp update](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2616)

## Changes

* Adds .gitattribute file to prevent windows from changing the line endings.
 https://docs.github.com/en/get-started/getting-started-with-git/configuring-git-to-handle-line-endings#per-repository-settings

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests