### PR TITLE
Bug fix to select granules on multiple pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Fixed DatePicker prop so the leading zeroes can be entered without having too many zeroes clouding the input.
 - **CUMULUS-NONE**
   - Update Bamboo and scripts to deploy the Dashboard to our SIT for Cumulus team testing.
+  - Fixed containsPublishedGranules to ignore granules without a published key.
 
 ### Added
 

--- a/app/src/js/components/Granules/overview.js
+++ b/app/src/js/components/Granules/overview.js
@@ -102,7 +102,7 @@ class GranulesOverview extends React.Component {
     };
     const { granules, config } = this.props;
     const { selected } = this.state;
-    const selectedGranules = selected.map((id) => granules.list.data.find((g) => id === g.granuleId));
+    const selectedGranules = selected.map((id) => granules.list.data.filter((g) => id === g.granuleId));
     let actions = bulkActions(granules, actionConfig, selectedGranules);
     if (config.enableRecovery) {
       actions = actions.concat(recoverAction(granules, actionConfig));

--- a/app/src/js/components/Granules/overview.js
+++ b/app/src/js/components/Granules/overview.js
@@ -102,7 +102,7 @@ class GranulesOverview extends React.Component {
     };
     const { granules, config } = this.props;
     const { selected } = this.state;
-    const selectedGranules = selected.map((id) => granules.list.data.filter((g) => id === g.granuleId));
+    const selectedGranules = selected.map((id) => granules.list.data.find((g) => id === g.granuleId));
     let actions = bulkActions(granules, actionConfig, selectedGranules);
     if (config.enableRecovery) {
       actions = actions.concat(recoverAction(granules, actionConfig));

--- a/app/src/js/utils/table-config/granules.js
+++ b/app/src/js/utils/table-config/granules.js
@@ -275,7 +275,7 @@ const containsPublishedGranules = (selectedGranules) => {
   let publishedGranules = [];
 
   if (Array.isArray(selectedGranules) && selectedGranules.length > 0) {
-    publishedGranules = selectedGranules.filter((g) => g.published === true);
+    publishedGranules = selectedGranules.filter((g) => g && g.published === true);
   }
 
   if (publishedGranules.length < 1) {

--- a/test/utils/table-config/granules.js
+++ b/test/utils/table-config/granules.js
@@ -7,6 +7,7 @@ import cloneDeep from 'lodash.clonedeep';
 import { __RewireAPI__ as GranulesRewireAPI } from '../../../app/src/js/utils/table-config/granules';
 
 const setOnConfirm = GranulesRewireAPI.__get__('setOnConfirm');
+const containsPublishedGranules = GranulesRewireAPI.__get__('containsPublishedGranules');
 
 GranulesRewireAPI.__Rewire__('historyPushWithQueryParams', sinon.fake());
 const historyPushWithQueryParams = GranulesRewireAPI.__get__('historyPushWithQueryParams');
@@ -101,4 +102,47 @@ test('setOnConfirm navigates to the correct processing page irrespective of the 
     confirmCallback();
     t.true(historyPushWithQueryParams.calledWith(o.expected));
   });
+});
+
+test('containsPublishedGranules returns true if any granule is published', (t)=> {
+  const testGranules = [
+    {
+      "execution": "https://example.com/states/home?region=us-east-1#/executions/details/arn:aws:states:us-east-1:123456789:execution:stack-IngestGranule:53f19d45-ead3-444d-9b74-83995df71657",
+      "published": false,
+    },
+    {
+      "execution": "https://example.com/states/home?region=us-east-1#/executions/details/arn:aws:states:us-east-1:123456789:execution:stack-IngestGranule:53f19d45-ead3-444d-9b74-83995df71657",
+      "published": true,
+    }
+  ];
+
+  t.true (containsPublishedGranules(testGranules));
+});
+
+test('containsPublishedGranules returns false if no granules are published', (t)=>{
+    const testGranules = [
+    {
+      "execution": "https://example.com/states/home?region=us-east-1#/executions/details/arn:aws:states:us-east-1:123456789:execution:stack-IngestGranule:53f19d45-ead3-444d-9b74-83995df71657",
+      "published": false,
+    },
+    {
+      "execution": "https://example.com/states/home?region=us-east-1#/executions/details/arn:aws:states:us-east-1:123456789:execution:stack-IngestGranule:53f19d45-ead3-444d-9b74-83995df71657",
+      "published": false,
+    }
+  ];
+
+  t.false(containsPublishedGranules(testGranules));
+});
+
+test('containsPublishedGranules returns false if a granule is missing a published key', (t)=>{
+  const testGranules = [
+    {
+      "execution": "https://example.com/states/home?region=us-east-1#/executions/details/arn:aws:states:us-east-1:123456789:execution:stack-IngestGranule:53f19d45-ead3-444d-9b74-83995df71657",
+    },
+    {
+      "execution": "https://example.com/states/home?region=us-east-1#/executions/details/arn:aws:states:us-east-1:123456789:execution:stack-IngestGranule:53f19d45-ead3-444d-9b74-83995df71657",
+    }
+  ];
+
+  t.false(containsPublishedGranules(testGranules));
 });


### PR DESCRIPTION
**Summary:** don't send undefined as a granule.

Addresses [CUMULUS-bugfix: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2576)

## Changes

* Stop sending undefined granules in selectedGranules array
* Ignore granules without a published key
* test

## PR Checklist

- [X ] Update CHANGELOG
- [X ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests