### PR TITLE
downgrade docker cluster to use elasticsearch that matches AWS version 5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **CUMULUS-2459**
   - Updated localAPI docker-compose.yml to include SSM, Postgres container to be used with RDS compatible API
   - Updated integration tests due to changes in API behavior related to Postgres contstraints between tables
+- **CUMULUS-NONE**
+  - Downgrades elasticsearch version in testing container to 5.3 to match AWS version.
 
 ### Fixed
 

--- a/localAPI/docker-compose.yml
+++ b/localAPI/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3"
 services:
   elasticsearch:
-    image: ${DOCKER_REPOSITORY}elasticsearch:5.6
+    image: ${DOCKER_REPOSITORY}elasticsearch:5.3
     network_mode: "service:shim"
     environment:
       ES_JAVA_OPTS: "-Xms750m -Xmx750m"


### PR DESCRIPTION
**Summary:**
Changes docker container versions of elasticsearch from 5.6 => 5.3 to match AWS.
Addresses CUMULUS-bugfix: CI problems, but also we should just do this.