### PR TITLE
[CUMULUS-2721] Remove rec report actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- **CUMULUS-2721**
+  - Remove table selectors and granule actions from all reconciliation report tables since they will not work on these tables due to the nature of the backend
+
 ## [v8.0.0] - 2021-11-04
 
 ## Breaking Changes

--- a/app/src/js/components/ReconciliationReports/gnf-report.js
+++ b/app/src/js/components/ReconciliationReports/gnf-report.js
@@ -15,7 +15,6 @@ import { getCollectionId } from '../../utils/format';
 
 const GnfReport = ({
   filterString,
-  groupAction,
   legend,
   onSelect,
   recordData,
@@ -114,7 +113,6 @@ const GnfReport = ({
         </div>
         <List
           data={combinedGranules}
-          groupAction={groupAction}
           legend={legend}
           onSelect={onSelect}
           rowId="granuleId"
@@ -128,10 +126,6 @@ const GnfReport = ({
 
 GnfReport.propTypes = {
   filterString: PropTypes.string,
-  groupAction: PropTypes.shape({
-    title: PropTypes.string,
-    description: PropTypes.string,
-  }),
   legend: PropTypes.node,
   onSelect: PropTypes.func,
   recordData: PropTypes.object,

--- a/app/src/js/components/ReconciliationReports/gnf-report.js
+++ b/app/src/js/components/ReconciliationReports/gnf-report.js
@@ -39,13 +39,15 @@ const GnfReport = ({
 
   const cmrGranules = onlyInCmr.map((granule) => {
     const { GranuleUR, ShortName, Version } = granule;
+    const collectionId = getCollectionId({ name: ShortName, version: Version });
     return {
       ...granule,
       granuleId: GranuleUR,
-      collectionId: getCollectionId({ name: ShortName, version: Version }),
+      collectionId,
       cmr: true,
       cumulus: false,
       s3: false,
+      disableSelect: !collectionId
     };
   });
 
@@ -53,6 +55,7 @@ const GnfReport = ({
     ...granule,
     cmr: false,
     cumulus: true,
+    disableSelect: !granule.collectionId
   }));
 
   const allGranules = [

--- a/app/src/js/components/ReconciliationReports/gnf-report.js
+++ b/app/src/js/components/ReconciliationReports/gnf-report.js
@@ -14,7 +14,6 @@ import { getFilesSummary, getGranuleFilesSummary } from './reshape-report';
 import { getCollectionId } from '../../utils/format';
 
 const GnfReport = ({
-  bulkActions,
   filterString,
   groupAction,
   legend,
@@ -47,7 +46,6 @@ const GnfReport = ({
       cmr: true,
       cumulus: false,
       s3: false,
-      disableSelect: !collectionId
     };
   });
 
@@ -55,7 +53,6 @@ const GnfReport = ({
     ...granule,
     cmr: false,
     cumulus: true,
-    disableSelect: !granule.collectionId
   }));
 
   const allGranules = [
@@ -116,7 +113,6 @@ const GnfReport = ({
           />
         </div>
         <List
-          bulkActions={bulkActions}
           data={combinedGranules}
           groupAction={groupAction}
           legend={legend}
@@ -131,7 +127,6 @@ const GnfReport = ({
 };
 
 GnfReport.propTypes = {
-  bulkActions: PropTypes.array,
   filterString: PropTypes.string,
   groupAction: PropTypes.shape({
     title: PropTypes.string,

--- a/app/src/js/components/ReconciliationReports/inventory-report.js
+++ b/app/src/js/components/ReconciliationReports/inventory-report.js
@@ -179,11 +179,11 @@ const InventoryReport = ({
               const { columns, data, id, name, type } = table;
               const isExpanded = expandedState[activeId][id];
               const listProps = {};
+              listProps.rowId = 'granuleId';
 
-              if (type === 'granule' || type === 'file') {
+              if (type === 'granule') {
                 listProps.bulkActions = bulkActions;
                 listProps.groupAction = groupAction;
-                listProps.rowId = 'granuleId';
               } else if (type === 'collection') {
                 listProps.rowId = 'name';
               }

--- a/app/src/js/components/ReconciliationReports/inventory-report.js
+++ b/app/src/js/components/ReconciliationReports/inventory-report.js
@@ -28,10 +28,8 @@ const bucketsForFilter = (allBuckets) => {
 };
 
 const InventoryReport = ({
-  bulkActions,
   filterBucket,
   filterString,
-  groupAction,
   onSelect,
   legend,
   recordData,
@@ -179,13 +177,10 @@ const InventoryReport = ({
               const { columns, data, id, name, type } = table;
               const isExpanded = expandedState[activeId][id];
               const listProps = {};
-              listProps.rowId = 'granuleId';
-
-              if (type === 'granule') {
-                listProps.bulkActions = bulkActions;
-                listProps.groupAction = groupAction;
-              } else if (type === 'collection') {
+              if (type === 'collection') {
                 listProps.rowId = 'name';
+              } else {
+                listProps.rowId = 'granuleId';
               }
 
               return (
@@ -238,13 +233,8 @@ const InventoryReport = ({
 };
 
 InventoryReport.propTypes = {
-  bulkActions: PropTypes.array,
   filterBucket: PropTypes.string,
   filterString: PropTypes.string,
-  groupAction: PropTypes.shape({
-    title: PropTypes.string,
-    description: PropTypes.string,
-  }),
   legend: PropTypes.node,
   onSelect: PropTypes.func,
   recordData: PropTypes.object,

--- a/app/src/js/components/ReconciliationReports/reconciliation-report.js
+++ b/app/src/js/components/ReconciliationReports/reconciliation-report.js
@@ -1,33 +1,21 @@
 import PropTypes from 'prop-types';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import get from 'lodash/get';
 import {
   getReconciliationReport,
   listWorkflows,
-  applyWorkflowToGranule,
-  applyRecoveryWorkflowToGranule
 } from '../../actions';
 import Loading from '../LoadingIndicator/loading-indicator';
 import InventoryReport from './inventory-report';
 import GnfReport from './gnf-report';
 import Legend from './legend';
-import { workflowOptionNames } from '../../selectors';
-import {
-  bulkActions,
-  defaultWorkflowMeta,
-  executeDialog,
-  groupAction,
-  recoverAction
-} from '../../utils/table-config/granules';
 
 const ReconciliationReport = ({
   dispatch = {},
-  granules = {},
   match,
   reconciliationReports = [],
-  workflowOptions = []
 }) => {
   const { reconciliationReportName: encodedReportName } = match.params;
   const reconciliationReportName = decodeURIComponent(encodedReportName);
@@ -49,10 +37,6 @@ const ReconciliationReport = ({
   const { reportType = 'Inventory' } = recordData || {};
   const filterBucket = list.params.bucket;
 
-  const [workflow, setWorkflow] = useState(workflowOptions[0]);
-  const [workflowMeta, setWorkflowMeta] = useState(defaultWorkflowMeta);
-  const [selected, setSelected] = useState([]);
-
   useEffect(() => {
     dispatch(getReconciliationReport(reconciliationReportName));
   }, [dispatch, reconciliationReportName]);
@@ -60,64 +44,6 @@ const ReconciliationReport = ({
   useEffect(() => {
     dispatch(listWorkflows());
   }, [dispatch]);
-
-  useEffect(() => {
-    setWorkflow(workflowOptions[0]);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [JSON.stringify(workflowOptions)]);
-
-  function generateBulkActions() {
-    const config = {
-      execute: {
-        options: getExecuteOptions(),
-        action: applyWorkflow,
-      },
-      recover: {
-        options: getExecuteOptions(),
-        action: applyRecoveryWorkflow
-      }
-    };
-    const selectedGranules = selected;
-    let actions = bulkActions(granules, config, selectedGranules);
-    if (config.enableRecovery) {
-      actions = actions.concat(recoverAction(granules, config));
-    }
-    return actions;
-  }
-
-  function selectWorkflow(_selector, selectedWorkflow) {
-    setWorkflow(selectedWorkflow);
-  }
-
-  function applyWorkflow(granuleId) {
-    const { meta } = JSON.parse(workflowMeta);
-    setWorkflowMeta(defaultWorkflowMeta);
-    return applyWorkflowToGranule(granuleId, workflow, meta);
-  }
-
-  function applyRecoveryWorkflow(granuleId) {
-    return applyRecoveryWorkflowToGranule(granuleId);
-  }
-
-  function getExecuteOptions() {
-    return [
-      executeDialog({
-        selectHandler: selectWorkflow,
-        label: 'workflow',
-        value: workflow,
-        options: workflowOptions,
-        initialMeta: workflowMeta,
-        metaHandler: setWorkflowMeta,
-      }),
-    ];
-  }
-
-  function updateSelection(selectedIds, currentSelectedRows) {
-    const allSelectedRows = selected.concat(currentSelectedRows);
-    const selectedRows = selectedIds
-      .map((id) => allSelectedRows.find((g) => id === g.granuleId)).filter(Boolean);
-    setSelected(selectedRows);
-  }
 
   if (!record || (record.inflight && !record.data)) {
     return <Loading />;
@@ -128,22 +54,16 @@ const ReconciliationReport = ({
       {
         {
           Inventory: <InventoryReport
-            bulkActions={generateBulkActions()}
             filterBucket={filterBucket}
             filterString={filterString}
-            groupAction={groupAction}
             legend={<Legend />}
-            onSelect={updateSelection}
             recordData={recordData}
             reportName={reconciliationReportName}
             reportUrl={reportUrl}
           />,
           'Granule Not Found': <GnfReport
-            bulkActions={generateBulkActions()}
             filterString={filterString}
-            groupAction={groupAction}
             legend={<Legend />}
-            onSelect={updateSelection}
             recordData={recordData}
             reportName={reconciliationReportName}
             reportUrl={reportUrl}
@@ -156,17 +76,13 @@ const ReconciliationReport = ({
 
 ReconciliationReport.propTypes = {
   dispatch: PropTypes.func,
-  granules: PropTypes.object,
   match: PropTypes.object,
   reconciliationReports: PropTypes.object,
-  workflowOptions: PropTypes.array
 };
 
 export { ReconciliationReport };
 export default withRouter(
   connect((state) => ({
-    granules: state.granules,
     reconciliationReports: state.reconciliationReports,
-    workflowOptions: workflowOptionNames(state)
   }))(ReconciliationReport)
 );

--- a/app/src/js/components/ReconciliationReports/reshape-report.js
+++ b/app/src/js/components/ReconciliationReports/reshape-report.js
@@ -1,6 +1,7 @@
 /* eslint node/no-deprecated-api: 0 */
 import path from 'path';
 import url from 'url';
+import { getCollectionId } from '../../utils/format';
 import {
   tableColumnsCollections,
   tableColumnsFiles,
@@ -15,6 +16,7 @@ export const getFilesSummary = ({ onlyInDynamoDb = [], onlyInS3 = [], okCountByG
       filename: path.basename(parsed.pathname),
       bucket: parsed.hostname,
       path: parsed.href,
+      disableSelect: true
     };
   });
 
@@ -28,6 +30,7 @@ export const getFilesSummary = ({ onlyInDynamoDb = [], onlyInS3 = [], okCountByG
     return {
       s3,
       cumulus: true,
+      disableSelect: true,
       ...parsedFile
     };
   });
@@ -46,6 +49,7 @@ const getGranulesSummary = ({ onlyInCumulus = [], onlyInCmr = [] }) => {
   const granulesInCumulus = onlyInCumulus;
   const granulesInCmr = onlyInCmr.map((granule) => ({
     granuleId: granule.GranuleUR,
+    collectionId: getCollectionId({ name: granule.ShortName, version: granule.Version })
   }));
   return { granulesInCumulus, granulesInCmr };
 };
@@ -55,6 +59,7 @@ export const getGranuleFilesSummary = ({ onlyInCumulus = [], onlyInCmr = [] }) =
     const parsedFile = parseFileObject(file);
     return {
       cmr: 'missing',
+      disableSelect: true,
       ...parsedFile
     };
   });
@@ -63,6 +68,7 @@ export const getGranuleFilesSummary = ({ onlyInCumulus = [], onlyInCmr = [] }) =
     const parsed = url.parse(d.URL);
     const bucket = parsed.hostname.split('.')[0];
     return {
+      disableSelect: true,
       granuleId: d.GranuleUR,
       filename: path.basename(parsed.pathname),
       bucket,
@@ -160,14 +166,14 @@ export const reshapeReport = (recordData, filterString, filterBucket) => {
   }
 
   /**
-   * The reconciation report display mechanism is set up to display cards as
+   * The reconciliation report display mechanism is set up to display cards as
    * headers for cumulus internal consistency as well as comparison between
    * Cumulus and CMR.  We set up a configuration from the input record to ease
    * the display of that information.
    *
    * The comparison configuration should consist of an Array of Objects, where
    * the objects have keys `id` used for selection and 'tables' which should be
-   * an array of Objects that are passed to Sortabletable.
+   * an array of Objects that are passed to SortableTable.
    */
   const internalComparison = [
     {

--- a/app/src/js/components/ReconciliationReports/reshape-report.js
+++ b/app/src/js/components/ReconciliationReports/reshape-report.js
@@ -16,7 +16,6 @@ export const getFilesSummary = ({ onlyInDynamoDb = [], onlyInS3 = [], okCountByG
       filename: path.basename(parsed.pathname),
       bucket: parsed.hostname,
       path: parsed.href,
-      disableSelect: true
     };
   });
 
@@ -30,7 +29,6 @@ export const getFilesSummary = ({ onlyInDynamoDb = [], onlyInS3 = [], okCountByG
     return {
       s3,
       cumulus: true,
-      disableSelect: true,
       ...parsedFile
     };
   });
@@ -59,7 +57,6 @@ export const getGranuleFilesSummary = ({ onlyInCumulus = [], onlyInCmr = [] }) =
     const parsedFile = parseFileObject(file);
     return {
       cmr: 'missing',
-      disableSelect: true,
       ...parsedFile
     };
   });
@@ -68,7 +65,6 @@ export const getGranuleFilesSummary = ({ onlyInCumulus = [], onlyInCmr = [] }) =
     const parsed = url.parse(d.URL);
     const bucket = parsed.hostname.split('.')[0];
     return {
-      disableSelect: true,
       granuleId: d.GranuleUR,
       filename: path.basename(parsed.pathname),
       bucket,

--- a/app/src/js/components/SortableTable/SortableTable.js
+++ b/app/src/js/components/SortableTable/SortableTable.js
@@ -151,11 +151,9 @@ const SortableTable = ({
             Header: ({ getToggleAllRowsSelectedProps }) => ( // eslint-disable-line react/prop-types
               <IndeterminateCheckbox {...getToggleAllRowsSelectedProps()} />
             ),
-            Cell: ({ row }) => { // eslint-disable-line react/prop-types
-              // eslint-disable-next-line react/prop-types
-              const { original: { disableSelect }, getToggleRowSelectedProps } = row;
-              return <>{!disableSelect && <IndeterminateCheckbox {...getToggleRowSelectedProps()} />}</>;
-            },
+            Cell: ({ row }) => ( // eslint-disable-line react/prop-types
+              <IndeterminateCheckbox {...row.getToggleRowSelectedProps()} /> // eslint-disable-line react/prop-types
+            ),
           },
           ...columns
         ]);
@@ -186,7 +184,7 @@ const SortableTable = ({
       return ids;
     }, []);
 
-    const currentSelectedRows = selectedFlatRows.map((row) => omit(row.original, ['files'])).filter((row) => !row.original?.disableSelect);
+    const currentSelectedRows = selectedFlatRows.map((row) => omit(row.original, ['files']));
 
     if (typeof onSelect === 'function') {
       onSelect(selectedIds, currentSelectedRows);

--- a/app/src/js/components/SortableTable/SortableTable.js
+++ b/app/src/js/components/SortableTable/SortableTable.js
@@ -30,7 +30,7 @@ const getColumnWidth = (rows, accessor, headerText, originalWidth) => {
 
 /**
  * IndeterminateCheckbox
- * @description Component for rendering the header and column checkboxs when canSelect is true
+ * @description Component for rendering the header and column checkboxes when canSelect is true
  * Taken from react-table examples
  */
 const IndeterminateCheckbox = forwardRef(
@@ -151,9 +151,11 @@ const SortableTable = ({
             Header: ({ getToggleAllRowsSelectedProps }) => ( // eslint-disable-line react/prop-types
               <IndeterminateCheckbox {...getToggleAllRowsSelectedProps()} />
             ),
-            Cell: ({ row }) => ( // eslint-disable-line react/prop-types
-              <IndeterminateCheckbox {...row.getToggleRowSelectedProps()} /> // eslint-disable-line react/prop-types
-            ),
+            Cell: ({ row }) => { // eslint-disable-line react/prop-types
+              // eslint-disable-next-line react/prop-types
+              const { original: { disableSelect }, getToggleRowSelectedProps } = row;
+              return <>{!disableSelect && <IndeterminateCheckbox {...getToggleRowSelectedProps()} />}</>;
+            },
           },
           ...columns
         ]);
@@ -184,7 +186,7 @@ const SortableTable = ({
       return ids;
     }, []);
 
-    const currentSelectedRows = selectedFlatRows.map((row) => omit(row.original, ['files']));
+    const currentSelectedRows = selectedFlatRows.map((row) => omit(row.original, ['files'])).filter((row) => !row.original?.disableSelect);
 
     if (typeof onSelect === 'function') {
       onSelect(selectedIds, currentSelectedRows);
@@ -285,13 +287,12 @@ const SortableTable = ({
     clearInterval(leftScrollInterval);
   }
 
-  function handleRightScrollbuttonOnMouseLeave() {
+  function handleRightScrollButtonOnMouseLeave() {
     hideScrollRightButton();
     clearInterval(rightScrollInterval);
   }
 
   function showScrollLeftButton(event) {
-    console.log('showLeft');
     setLeftScrollButtonVisibility({ display: 'flex', opacity: leftScrollButtonVisibility.opacity });
     setTimeout(() => {
       setLeftScrollButtonVisibility({ display: 'flex', opacity: 1 });
@@ -506,7 +507,7 @@ const SortableTable = ({
         onMouseDown={() => startScrollTableRight()}
         onMouseUp={() => stopScrollTableRight()}
         onMouseEnter={() => showScrollRightButton()}
-        onMouseLeave={() => handleRightScrollbuttonOnMouseLeave()}>
+        onMouseLeave={() => handleRightScrollButtonOnMouseLeave()}>
         <div><i className="fa fa-arrow-circle-right fa-2x"></i></div>
         <div>SCROLL</div>
       </div>

--- a/app/src/js/utils/table-config/reconciliation-reports.js
+++ b/app/src/js/utils/table-config/reconciliation-reports.js
@@ -101,6 +101,10 @@ const checkReportDeleted = (reportName, reports) => reports.every((report) => re
 
 export const bulkActions = (reports) => [];
 
+/**
+ * Commenting out Conflict Details for all the following tables
+ * since it does not currently function
+ */
 export const tableColumnsS3Files = [
   {
     Header: 'Filename',

--- a/app/src/js/utils/table-config/reconciliation-reports.js
+++ b/app/src/js/utils/table-config/reconciliation-reports.js
@@ -112,12 +112,12 @@ export const tableColumnsS3Files = [
     Cell: <span className='status-indicator status-indicator--failed'></span>,
     disableSortBy: true
   },
-  {
-    Header: 'Conflict Details',
-    id: 'conflictDetails',
-    Cell: 'View Details',
-    disableSortBy: true
-  },
+  // {
+  //   Header: 'Conflict Details',
+  //   id: 'conflictDetails',
+  //   Cell: 'View Details',
+  //   disableSortBy: true
+  // },
   {
     Header: 'Bucket',
     accessor: 'bucket'
@@ -144,12 +144,12 @@ export const tableColumnsFiles = [
     Cell: <span className='status-indicator status-indicator--orange'></span>,
     disableSortBy: true
   },
-  {
-    Header: 'Conflict Details',
-    id: 'conflictDetails',
-    Cell: 'View Details',
-    disableSortBy: true
-  },
+  // {
+  //   Header: 'Conflict Details',
+  //   id: 'conflictDetails',
+  //   Cell: 'View Details',
+  //   disableSortBy: true
+  // },
   {
     Header: 'Bucket',
     accessor: 'bucket'
@@ -166,12 +166,12 @@ export const tableColumnsCollections = [
     Header: 'Collection name',
     accessor: 'name',
   },
-  {
-    Header: 'Conflict Details',
-    id: 'conflictDetails',
-    Cell: 'View Details',
-    disableSortBy: true
-  }
+  // {
+  //   Header: 'Conflict Details',
+  //   id: 'conflictDetails',
+  //   Cell: 'View Details',
+  //   disableSortBy: true
+  // }
 ];
 
 export const tableColumnsGranules = [
@@ -180,17 +180,21 @@ export const tableColumnsGranules = [
     accessor: 'granuleId'
   },
   {
+    Header: 'Collection ID',
+    accessor: 'collectionId'
+  },
+  {
     Header: 'Conflict Type',
     id: 'conflictType',
     Cell: <span className='status-indicator status-indicator--failed'></span>,
     disableSortBy: true
   },
-  {
-    Header: 'Conflict Details',
-    id: 'conflictDetails',
-    Cell: 'View Details',
-    disableSortBy: true
-  }
+  // {
+  //   Header: 'Conflict Details',
+  //   id: 'conflictDetails',
+  //   Cell: 'View Details',
+  //   disableSortBy: true
+  // }
 ];
 
 export const tableColumnsGnf = [

--- a/cypress/integration/reconciliation_spec.js
+++ b/cypress/integration/reconciliation_spec.js
@@ -303,17 +303,17 @@ describe('Dashboard Reconciliation Reports Page', () => {
       cy.contains('.heading--medium', 'Total Conflict Comparisons');
       cy.contains('.num-title', '11');
 
-      cy.get('.table .th').eq(1).should('contain', 'Collection ID');
-      cy.get('.table .th').eq(2).should('contain', 'Granule ID');
-      cy.get('.table .th').eq(3).should('contain', 'S3');
-      cy.get('.table .th').eq(4).should('contain', 'Cumulus');
-      cy.get('.table .th').eq(5).should('contain', 'CMR');
+      cy.get('.table .th').eq(0).should('contain', 'Collection ID');
+      cy.get('.table .th').eq(1).should('contain', 'Granule ID');
+      cy.get('.table .th').eq(2).should('contain', 'S3');
+      cy.get('.table .th').eq(3).should('contain', 'Cumulus');
+      cy.get('.table .th').eq(4).should('contain', 'CMR');
 
-      cy.get('.table .tbody .tr[data-value="MOD09GQ.A0002421.oD4zvB.006.4281362831355"] .td').eq(1).should('contain', 'MOD09GQ___006');
-      cy.get('.table .tbody .tr[data-value="MOD09GQ.A0002421.oD4zvB.006.4281362831355"] .td').eq(2).should('contain', 'MOD09GQ.A0002421.oD4zvB.006.4281362831355');
+      cy.get('.table .tbody .tr[data-value="MOD09GQ.A0002421.oD4zvB.006.4281362831355"] .td').eq(0).should('contain', 'MOD09GQ___006');
+      cy.get('.table .tbody .tr[data-value="MOD09GQ.A0002421.oD4zvB.006.4281362831355"] .td').eq(1).should('contain', 'MOD09GQ.A0002421.oD4zvB.006.4281362831355');
+      cy.get('.table .tbody .tr[data-value="MOD09GQ.A0002421.oD4zvB.006.4281362831355"] .td').eq(2).find('span').should('have.class', 'status-indicator--failed');
       cy.get('.table .tbody .tr[data-value="MOD09GQ.A0002421.oD4zvB.006.4281362831355"] .td').eq(3).find('span').should('have.class', 'status-indicator--failed');
-      cy.get('.table .tbody .tr[data-value="MOD09GQ.A0002421.oD4zvB.006.4281362831355"] .td').eq(4).find('span').should('have.class', 'status-indicator--failed');
-      cy.get('.table .tbody .tr[data-value="MOD09GQ.A0002421.oD4zvB.006.4281362831355"] .td').eq(5).find('span').should('have.class', 'status-indicator--success');
+      cy.get('.table .tbody .tr[data-value="MOD09GQ.A0002421.oD4zvB.006.4281362831355"] .td').eq(4).find('span').should('have.class', 'status-indicator--success');
 
       /** Legend */
       cy.get('.legend').should('have.length', 1);

--- a/cypress/integration/reconciliation_spec.js
+++ b/cypress/integration/reconciliation_spec.js
@@ -193,12 +193,12 @@ describe('Dashboard Reconciliation Reports Page', () => {
         {
           title: 'DynamoDB',
           count: 35,
-          secondColumn: 'GranuleId'
+          firstColumn: 'GranuleId'
         },
         {
           title: 'S3',
           count: 216,
-          secondColumn: 'Filename'
+          firstColumn: 'Filename'
         },
         // collections do not have select column, so need to check first column
         {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2721: reconciliation reports should not have selectors and granule actions available.](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2721)

## Changes

* Removes selectors and granule actions on rec report tables 

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Adhoc testing
- [x] Integration tests