### PR TITLE
[CUMULUS-2747] Show relevant create provider fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   - Remove table selectors and granule actions from all reconciliation report tables since they will not work on these tables due to the nature of the backend
 - **CUMULUS-2744**
   - Display granules associated with an execution in a table
+- **CUMULUS-2747**
+  - When creating a provider, only fields relevant for the selected protocol will be displayed
 
 ### Fixed
 

--- a/app/src/js/components/Add/add.js
+++ b/app/src/js/components/Add/add.js
@@ -23,6 +23,7 @@ const AddRecord = ({
   enums,
   exclude,
   include,
+  handleInputChange,
   primaryProperty,
   schemaKey,
   schemaState,
@@ -37,8 +38,10 @@ const AddRecord = ({
   const schema = schemaState[schemaKey];
 
   useEffect(() => {
-    dispatch(getSchema(schemaKey));
-  }, [dispatch, schemaKey]);
+    if (!schema) {
+      dispatch(getSchema(schemaKey));
+    }
+  }, [dispatch, schema, schemaKey]);
 
   useEffect(() => {
     const status = get(state, ['created', pk, 'status']);
@@ -84,7 +87,7 @@ const AddRecord = ({
           <Schema
             data={data}
             schema={schema}
-            pk={'new-collection'}
+            handleInputChange={handleInputChange}
             onSubmit={post}
             onCancel={navigateBack}
             status={record.status}
@@ -133,7 +136,8 @@ AddRecord.propTypes = {
   // appearing on the form.
   exclude: PropTypes.arrayOf(
     PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(RegExp)])
-  )
+  ),
+  handleInputChange: PropTypes.objectOf(PropTypes.func)
 };
 
 Schema.defaultProps = {

--- a/app/src/js/components/Add/add.js
+++ b/app/src/js/components/Add/add.js
@@ -55,11 +55,11 @@ const AddRecord = ({
     }
   }, [baseRoute, pk, state]);
 
-  function navigateBack () {
+  function navigateBack() {
     historyPushWithQueryParams(`/${baseRoute.split('/')[1]}`);
   }
 
-  function post (_id, payload) {
+  function post(_id, payload) {
     if (attachMeta) {
       payload.createdAt = new Date().getTime();
       payload.updatedAt = payload.createdAt;
@@ -91,7 +91,9 @@ const AddRecord = ({
             onSubmit={post}
             onCancel={navigateBack}
             status={record.status}
-            error={error || (record.status === 'inflight' ? null : record.error)}
+            error={
+              error || (record.status === 'inflight' ? null : record.error)
+            }
             include={include}
             exclude={exclude}
             enums={enums}
@@ -137,18 +139,18 @@ AddRecord.propTypes = {
   exclude: PropTypes.arrayOf(
     PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(RegExp)])
   ),
-  handleInputChange: PropTypes.objectOf(PropTypes.func)
+  handleInputChange: PropTypes.objectOf(PropTypes.func),
 };
 
 Schema.defaultProps = {
   // Exclude no schema properties
   exclude: [],
   // Include all schema properties
-  include: [/.+/]
+  include: [/.+/],
 };
 
 export default withRouter(
   connect((state) => ({
-    schemaState: state.schema
+    schemaState: state.schema,
   }))(AddRecord)
 );

--- a/app/src/js/components/Form/Form.js
+++ b/app/src/js/components/Form/Form.js
@@ -74,7 +74,7 @@ const generateInputState = (inputMeta, id) => {
  * @param {Array} forms list of config objects, representing form items.
  * @param {String} form.type must match TEXT, TEXT_AREA, or other type listed above.
  * @param {String} form.label arbitrary label for the field.
- * @param {Function} form.validate function returning true or fase based on the form input.
+ * @param {Function} form.validate function returning true or false based on the form input.
  * @param {String} form.error text to display when a form doesn't pass validation.
  * @return {JSX}
  */
@@ -103,7 +103,8 @@ export class Form extends React.Component {
     return this.props.status && this.props.status === 'inflight';
   }
 
-  onChange (inputId, value) {
+  onChange (inputId, value, handleChange) {
+    if (typeof handleChange === 'function') handleChange(value);
     // Update the internal key/value store, in addition to marking as dirty
     this.setState(createNextState((state) => {
       state.inputs[inputId].value = value;
@@ -123,7 +124,7 @@ export class Form extends React.Component {
     state
   }) {
     const { dirty, inputs } = state;
-    let { value } = inputs[inputId];
+    let { value } = inputs[inputId] || {};
 
     // don't set a value for values that haven't changed and aren't required
     if (!dirty[inputId] && !field.required) return;
@@ -266,7 +267,7 @@ export class Form extends React.Component {
         {errors.length > 0 && <ErrorReport report={errorMessage(errors)} disableScroll={true} />}
         <ul>
           {this.props.inputMeta.map((input) => {
-            const { type, label } = input;
+            const { type, label, handleChange } = input;
             let element;
 
             switch (type) {
@@ -289,9 +290,9 @@ export class Form extends React.Component {
             }
 
             const inputId = generateComponentId(input.schemaProperty, this.id);
-            let { value, error } = inputState[inputId];
+            let { value, error } = inputState[inputId] || {};
 
-            // coerce non-null values to string to simplify proptype warnings on numbers
+            // coerce non-null values to string to simplify PropType warnings on numbers
             if (type !== formTypes.list && type !== formTypes.subform && !value && value !== 0) {
               value = String(value);
             }
@@ -327,7 +328,7 @@ export class Form extends React.Component {
               fieldset,
               type: textType,
               autoComplete,
-              onChange: this.onChange,
+              onChange: (id, val) => this.onChange(id, val, handleChange),
               ...additionalConfig
             });
 

--- a/app/src/js/components/Form/Form.js
+++ b/app/src/js/components/Form/Form.js
@@ -254,9 +254,6 @@ export class Form extends React.Component {
   componentDidUpdate(prevProps) {
     const { inputMeta } = this.props;
 
-    console.log(this.state.dirty);
-    console.log(this.state.inputs);
-
     if (prevProps.inputMeta !== inputMeta) {
       const inputs = generateInputState(inputMeta, this.id, this.state.inputs);
       const dirty = generateDirty(inputs);

--- a/app/src/js/components/Form/Form.js
+++ b/app/src/js/components/Form/Form.js
@@ -230,17 +230,7 @@ export class Form extends React.Component {
     }
   }
 
-  componentDidUpdate (prevProps) {
-    const { inputMeta } = this.props;
-
-    if (prevProps.inputMeta !== inputMeta) {
-      const inputs = generateInputState(inputMeta, this.id);
-      const dirty = generateDirty(inputs);
-
-      // eslint-disable-next-line react/no-did-update-set-state
-      this.setState({ inputs, dirty });
-    }
-
+  componentDidUpdate () {
     if (this.state.submitted) {
       this.submitPayload();
     }

--- a/app/src/js/components/Form/Form.js
+++ b/app/src/js/components/Form/Form.js
@@ -299,7 +299,8 @@ export class Form extends React.Component {
 
             // filter out empty values from the list
             if (type === formTypes.list) {
-              value = value.filter((item) => item !== '');
+              console.log(input);
+              value = value?.filter((item) => item !== '');
             }
 
             // dropdowns have options

--- a/app/src/js/components/Form/Form.js
+++ b/app/src/js/components/Form/Form.js
@@ -299,7 +299,6 @@ export class Form extends React.Component {
 
             // filter out empty values from the list
             if (type === formTypes.list) {
-              console.log(input);
               value = value?.filter((item) => item !== '');
             }
 

--- a/app/src/js/components/Form/Form.js
+++ b/app/src/js/components/Form/Form.js
@@ -16,7 +16,10 @@ import SubForm from '../SubForm/sub-form';
 import t from '../../utils/strings';
 import { window } from '../../utils/browser';
 
-const scrollTo = window && typeof window.scrollTo === 'function' ? window.scrollTo : () => true;
+const scrollTo =
+  window && typeof window.scrollTo === 'function'
+    ? window.scrollTo
+    : () => true;
 
 export const formTypes = {
   text: 'TEXT',
@@ -24,17 +27,22 @@ export const formTypes = {
   dropdown: 'DROPDOWN',
   list: 'LIST',
   number: 'NUMBER',
-  subform: 'SUB_FORM'
+  subform: 'SUB_FORM',
 };
 
 export const defaults = {
-  json: '{\n  \n}'
+  json: '{\n  \n}',
 };
 
-const errorMessage = (errors) => `Please review the following fields and submit again: ${errors.map((error) => `'${error}'`).join(', ')}`;
+const errorMessage = (errors) => `Please review the following fields and submit again: ${errors
+    .map((error) => `'${error}'`)
+    .join(', ')}`;
 
 const generateDirty = (inputs) => Object.entries(inputs).reduce(
-  (dirty, [id, { value }]) => ({ ...dirty, [id]: isFinite(value) || !isEmpty(value) }),
+  (dirty, [id, { value }]) => ({
+    ...dirty,
+    [id]: isFinite(value) || !isEmpty(value),
+  }),
   {}
 );
 
@@ -53,9 +61,14 @@ const generateInputState = (inputMeta, id, oldInputState = {}) => {
 
     if (!inputValue && inputValue !== 0) {
       switch (type) {
-        case formTypes.list: inputValue = []; break;
-        case formTypes.subform: inputValue = {}; break;
-        default: inputValue = '';
+        case formTypes.list:
+          inputValue = [];
+          break;
+        case formTypes.subform:
+          inputValue = {};
+          break;
+        default:
+          inputValue = '';
       }
     }
 
@@ -65,7 +78,7 @@ const generateInputState = (inputMeta, id, oldInputState = {}) => {
       value: inputValue,
       schemaProperty,
       validationError: error, // this is the stored error message for the field
-      error: null // this is the displayed error for the field
+      error: null, // this is the displayed error for the field
     };
   });
 
@@ -83,7 +96,7 @@ const generateInputState = (inputMeta, id, oldInputState = {}) => {
  * @return {JSX}
  */
 export class Form extends React.Component {
-  constructor (props) {
+  constructor(props) {
     super(props);
 
     // Generate ID for this form
@@ -99,34 +112,32 @@ export class Form extends React.Component {
       inputs,
       dirty,
       errors: [],
-      submitted: false
+      submitted: false,
     };
   }
 
-  isInflight () {
+  isInflight() {
     return this.props.status && this.props.status === 'inflight';
   }
 
-  onChange (inputId, value, handleChange) {
+  onChange(inputId, value, handleChange) {
     if (typeof handleChange === 'function') handleChange(value);
     // Update the internal key/value store, in addition to marking as dirty
-    this.setState(createNextState((state) => {
-      state.inputs[inputId].value = value;
-      state.dirty[inputId] = true;
-      // validate the field for live changes
-      this.validateField({
-        field: this.state.inputs[inputId],
-        inputId,
-        state
-      });
-    }));
+    this.setState(
+      createNextState((state) => {
+        state.inputs[inputId].value = value;
+        state.dirty[inputId] = true;
+        // validate the field for live changes
+        this.validateField({
+          field: this.state.inputs[inputId],
+          inputId,
+          state,
+        });
+      })
+    );
   }
 
-  validateField ({
-    field,
-    inputId,
-    state
-  }) {
+  validateField({ field, inputId, state }) {
     const { dirty, inputs } = state;
     let { value } = inputs[inputId] || {};
 
@@ -164,7 +175,7 @@ export class Form extends React.Component {
     }
   }
 
-  onCancel (e) {
+  onCancel(e) {
     e.preventDefault();
 
     if (!this.isInflight()) {
@@ -172,28 +183,30 @@ export class Form extends React.Component {
     }
   }
 
-  onSubmit (e) {
+  onSubmit(e) {
     if (e) e.preventDefault();
     if (this.isInflight()) return;
 
     // validate input values in the store
 
-    this.setState(createNextState((state) => {
-      this.props.inputMeta.forEach((field) => {
-        const inputId = generateComponentId(field.schemaProperty, this.id);
+    this.setState(
+      createNextState((state) => {
+        this.props.inputMeta.forEach((field) => {
+          const inputId = generateComponentId(field.schemaProperty, this.id);
 
-        this.validateField({
-          field,
-          inputId,
-          state
+          this.validateField({
+            field,
+            inputId,
+            state,
+          });
         });
-      });
 
-      state.submitted = true;
-    }));
+        state.submitted = true;
+      })
+    );
   }
 
-  submitPayload () {
+  submitPayload() {
     const { inputs, errors } = this.state;
     const payload = {};
 
@@ -202,11 +215,12 @@ export class Form extends React.Component {
         const entryValue = entry[1];
         const { value, required, schemaProperty, type, mode } = entryValue;
 
-        if (required ||
+        if (
+          required ||
           // only add an optional array when it is not empty
           (Array.isArray(value) && value.length > 0) ||
           // only add an optional value when it is not an empty string or will create an empty object
-          (!Array.isArray(value) && (value !== '' && value !== '{}'))
+          (!Array.isArray(value) && value !== '' && value !== '{}')
         ) {
           let payloadValue = value;
           // these should be safe since we've already validated at this point
@@ -226,15 +240,18 @@ export class Form extends React.Component {
     this.setState({ submitted: false });
   }
 
-  scrollToTop () {
-    if (this.DOMElement && typeof this.DOMElement.scrollIntoView === 'function') {
+  scrollToTop() {
+    if (
+      this.DOMElement &&
+      typeof this.DOMElement.scrollIntoView === 'function'
+    ) {
       this.DOMElement.scrollIntoView(true);
     } else {
       scrollTo(0, 0);
     }
   }
 
-  componentDidUpdate (prevProps) {
+  componentDidUpdate(prevProps) {
     const { inputMeta } = this.props;
 
     console.log(this.state.dirty);
@@ -252,7 +269,7 @@ export class Form extends React.Component {
     }
   }
 
-  render () {
+  render() {
     const inputState = this.state.inputs;
     const { errors } = this.state;
     const { status } = this.props;
@@ -266,11 +283,19 @@ export class Form extends React.Component {
       submitButtonText = 'Submit';
     }
 
-    const hasRequiredFields = this.props.inputMeta.filter((input) => input.required).length >= 0;
+    const hasRequiredFields =
+      this.props.inputMeta.filter((input) => input.required).length >= 0;
 
     const form = (
-      <div className="container" ref={(element) => { this.DOMElement = element; }}>
-        {errors.length > 0 && <ErrorReport report={errorMessage(errors)} disableScroll={true} />}
+      <div
+        className="container"
+        ref={(element) => {
+          this.DOMElement = element;
+        }}
+      >
+        {errors.length > 0 && (
+          <ErrorReport report={errorMessage(errors)} disableScroll={true} />
+        )}
         <ul>
           {this.props.inputMeta.map((input) => {
             const { type, label, handleChange } = input;
@@ -299,7 +324,12 @@ export class Form extends React.Component {
             let { value, error } = inputState[inputId] || {};
 
             // coerce non-null values to string to simplify PropType warnings on numbers
-            if (type !== formTypes.list && type !== formTypes.subform && !value && value !== 0) {
+            if (
+              type !== formTypes.list &&
+              type !== formTypes.subform &&
+              !value &&
+              value !== 0
+            ) {
               value = String(value);
             }
 
@@ -309,14 +339,18 @@ export class Form extends React.Component {
             }
 
             // dropdowns have options
-            const options = (type === formTypes.dropdown && input.options) || null;
+            const options =
+              (type === formTypes.dropdown && input.options) || null;
             // textarea forms pass a mode value to ace
             const mode = (type === formTypes.textArea && input.mode) || null;
             // subforms have fieldsets that define child form structure
-            const fieldset = (type === formTypes.subform && input.fieldSet) || null;
-            const autoComplete = (type === formTypes.text && input.isPassword) ? 'on' : null;
+            const fieldset =
+              (type === formTypes.subform && input.fieldSet) || null;
+            const autoComplete =
+              type === formTypes.text && input.isPassword ? 'on' : null;
             // text forms can be type=password or number
-            let textType = (type === formTypes.text && input.isPassword) ? 'password' : null;
+            let textType =
+              type === formTypes.text && input.isPassword ? 'password' : null;
             const additionalConfig = {};
 
             if (type === formTypes.number) {
@@ -335,15 +369,19 @@ export class Form extends React.Component {
               type: textType,
               autoComplete,
               onChange: (id, val) => this.onChange(id, val, handleChange),
-              ...additionalConfig
+              ...additionalConfig,
             });
 
-            return <li className='form__item' key={inputId}>{elem}</li>;
+            return (
+              <li className="form__item" key={inputId}>
+                {elem}
+              </li>
+            );
           })}
         </ul>
 
         {hasRequiredFields && (
-          <div className='form__item form__item--require__description'>
+          <div className="form__item form__item--require__description">
             <p>
               <span className="label__required">* </span>
               <span className="label__name">Required field</span>
@@ -353,16 +391,20 @@ export class Form extends React.Component {
 
         {this.props.submit && (
           <button
-            className={`button button__animation--md button__arrow button__arrow--md button__animation button__arrow--white form-group__element--right button--submit${this.isInflight() ? ' button--disabled' : ''}`}
+            className={`button button__animation--md button__arrow button__arrow--md button__animation button__arrow--white form-group__element--right button--submit${
+              this.isInflight() ? ' button--disabled' : ''
+            }`}
             onClick={this.onSubmit}
           >
-            { submitButtonText }
+            {submitButtonText}
           </button>
         )}
 
         {this.props.cancel && (
           <button
-            className={`button button__animation--md button__arrow button__arrow--md button__animation button--secondary form-group__element--right button--cancel${this.isInflight() ? ' button--disabled' : ''}`}
+            className={`button button__animation--md button__arrow button__arrow--md button__animation button--secondary form-group__element--right button--cancel${
+              this.isInflight() ? ' button--disabled' : ''
+            }`}
             onClick={this.onCancel}
           >
             Cancel
@@ -371,16 +413,16 @@ export class Form extends React.Component {
       </div>
     );
 
-    return this.props.nowrap
-      ? form
-      : (
-        <form
-          className='page__section--fullpage-form page__section--fullpage-form--internal'
-          id={`form-${this.id}`}
-        >
-          {form}
-        </form>
-      );
+    return this.props.nowrap ? (
+      form
+    ) : (
+      <form
+        className="page__section--fullpage-form page__section--fullpage-form--internal"
+        id={`form-${this.id}`}
+      >
+        {form}
+      </form>
+    );
   }
 }
 
@@ -390,5 +432,5 @@ Form.propTypes = {
   submit: PropTypes.func,
   cancel: PropTypes.func,
   status: PropTypes.string,
-  nowrap: PropTypes.bool
+  nowrap: PropTypes.bool,
 };

--- a/app/src/js/components/FormList/form-list.js
+++ b/app/src/js/components/FormList/form-list.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
 const FormList = ({ error, id, label, onChange, value }) => {
-  const [values, setValues] = useState(value.length ? value : ['']);
+  const [values, setValues] = useState(value?.length ? value : ['']);
 
   function handleChange(index, newValue) {
     // make a copy of values so we can update the index

--- a/app/src/js/components/FormSchema/schema.js
+++ b/app/src/js/components/FormSchema/schema.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-restricted-syntax */
 /* eslint-disable import/no-cycle */
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { get, set } from 'object-path';
 import startCase from 'lodash/startCase';
@@ -246,13 +246,7 @@ const Schema = ({
   schema,
   status,
 }) => {
-  const [fields, setFields] = useState(
-    createFormConfig({ data, schema, include, exclude, enums, handleInputChange })
-  );
-
-  useEffect(() => {
-    setFields(createFormConfig({ data, schema, include, exclude, enums, handleInputChange }));
-  }, [enums, data, schema, include, exclude, handleInputChange]);
+  const fields = createFormConfig({ data, schema, include, exclude, enums, handleInputChange });
 
   return (
     <div

--- a/app/src/js/components/FormSchema/schema.js
+++ b/app/src/js/components/FormSchema/schema.js
@@ -207,7 +207,7 @@ function textField(config, property, validate) {
   config.type = formTypes.text;
   config.validate = validate;
   config.error = validate && get(errors, property, errors.required);
-  if (property === 'password' || property === 'username') config.isPassword = true;
+  if (property === 'password' || property === 'username') { config.isPassword = true; }
 
   return config;
 }
@@ -246,7 +246,14 @@ const Schema = ({
   schema,
   status,
 }) => {
-  const fields = createFormConfig({ data, schema, include, exclude, enums, handleInputChange });
+  const fields = createFormConfig({
+    data,
+    schema,
+    include,
+    exclude,
+    enums,
+    handleInputChange,
+  });
 
   return (
     <div
@@ -301,7 +308,7 @@ Schema.propTypes = {
   exclude: PropTypes.arrayOf(
     PropTypes.oneOfType([PropTypes.string, PropTypes.instanceOf(RegExp)])
   ),
-  handleInputChange: PropTypes.objectOf(PropTypes.func)
+  handleInputChange: PropTypes.objectOf(PropTypes.func),
 };
 
 Schema.defaultProps = {

--- a/app/src/js/components/FormSchema/schema.js
+++ b/app/src/js/components/FormSchema/schema.js
@@ -224,7 +224,6 @@ function dropdownField(config, property, validate) {
   config.type = formTypes.dropdown;
   config.validate = validate;
   config.error = validate && get(errors, property, errors.required);
-  console.log(config);
   return config;
 }
 

--- a/app/src/js/components/Providers/add.js
+++ b/app/src/js/components/Providers/add.js
@@ -21,9 +21,9 @@ const AddProvider = ({ providers }) => {
   const handleInputChange = {
     protocol: (value) => {
       if (value === 's3') setExclude(s3Excludes);
-      else if (!value.includes('http') && !value.includes('sftp')) setExclude([...nonHttpsExcludes, ...nonSftpExcludes]);
+      else if (value.includes('http')) setExclude(nonSftpExcludes);
       else if (value === 'sftp') setExclude(nonHttpsExcludes);
-      else setExclude([]);
+      else setExclude([...nonHttpsExcludes, ...nonSftpExcludes]);
       setSelectedProtocol(value);
     },
   };

--- a/app/src/js/components/Providers/add.js
+++ b/app/src/js/components/Providers/add.js
@@ -54,14 +54,11 @@ const AddProvider = ({ providers }) => {
 };
 
 AddProvider.propTypes = {
-  dispatch: PropTypes.func,
-  providers: PropTypes.object,
-  schema: PropTypes.object
+  providers: PropTypes.object
 };
 
 export default withRouter(
   connect((state) => ({
-    providers: state.providers,
-    schema: state.schema,
+    providers: state.providers
   }))(AddProvider)
 );

--- a/app/src/js/components/Providers/add.js
+++ b/app/src/js/components/Providers/add.js
@@ -3,7 +3,6 @@ import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
-// import isEqual from 'lodash/isEqual';
 import { createProvider } from '../../actions';
 import AddRecord from '../Add/add';
 import { isValidProvider } from '../../utils/validate';

--- a/app/src/js/components/Providers/add.js
+++ b/app/src/js/components/Providers/add.js
@@ -1,38 +1,66 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { Helmet } from 'react-helmet';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
+// import isEqual from 'lodash/isEqual';
 import { createProvider } from '../../actions';
 import AddRecord from '../Add/add';
 import { isValidProvider } from '../../utils/validate';
 
 const SCHEMA_KEY = 'provider';
 
-const AddProvider = ({ providers }) => (
-  <div className="add_providers">
-    <Helmet>
-      <title> Add Provider </title>
-    </Helmet>
-    <AddRecord
-      baseRoute="/providers/provider"
-      createRecord={createProvider}
-      primaryProperty="id"
-      schemaKey={SCHEMA_KEY}
-      state={providers}
-      title="Create a provider"
-      validate={isValidProvider}
-      validationError={'Concurrent Connection Limit cannot be a negative value'}
-    />
-  </div>
-);
+const nonHttpsExcludes = ['allowedRedirects'];
+const s3Excludes = [...nonHttpsExcludes, 'username', 'password', 'port'];
+
+const AddProvider = ({ providers }) => {
+  const [exclude, setExclude] = useState([]);
+  const [selectedProtocol, setSelectedProtocol] = useState('http');
+
+  const handleInputChange = {
+    protocol: (value) => {
+      if (value === 's3') setExclude(s3Excludes);
+      else if (!value.includes('http')) setExclude(nonHttpsExcludes);
+      else setExclude([]);
+      setSelectedProtocol(value);
+    },
+  };
+
+  const data = {
+    protocol: selectedProtocol
+  };
+
+  return (
+    <div className="add_providers">
+      <Helmet>
+        <title> Add Provider </title>
+      </Helmet>
+      <AddRecord
+        baseRoute="/providers/provider"
+        createRecord={createProvider}
+        data={data}
+        exclude={exclude}
+        handleInputChange={handleInputChange}
+        primaryProperty="id"
+        schemaKey={SCHEMA_KEY}
+        state={providers}
+        title="Create a provider"
+        validate={isValidProvider}
+        validationError="Concurrent Connection Limit cannot be a negative value"
+      />
+    </div>
+  );
+};
 
 AddProvider.propTypes = {
+  dispatch: PropTypes.func,
   providers: PropTypes.object,
+  schema: PropTypes.object
 };
 
 export default withRouter(
   connect((state) => ({
     providers: state.providers,
+    schema: state.schema,
   }))(AddProvider)
 );

--- a/app/src/js/components/Providers/add.js
+++ b/app/src/js/components/Providers/add.js
@@ -11,7 +11,13 @@ const SCHEMA_KEY = 'provider';
 
 const nonSftpExcludes = ['privateKey', 'cmKeyId'];
 const nonHttpsExcludes = ['allowedRedirects', 'certificateUri'];
-const s3Excludes = [...nonSftpExcludes, ...nonHttpsExcludes, 'username', 'password', 'port'];
+const s3Excludes = [
+  ...nonSftpExcludes,
+  ...nonHttpsExcludes,
+  'username',
+  'password',
+  'port',
+];
 
 const AddProvider = ({ providers }) => {
   const [exclude, setExclude] = useState(nonSftpExcludes);
@@ -28,7 +34,7 @@ const AddProvider = ({ providers }) => {
   };
 
   const data = {
-    protocol: selectedProtocol
+    protocol: selectedProtocol,
   };
 
   return (
@@ -54,11 +60,11 @@ const AddProvider = ({ providers }) => {
 };
 
 AddProvider.propTypes = {
-  providers: PropTypes.object
+  providers: PropTypes.object,
 };
 
 export default withRouter(
   connect((state) => ({
-    providers: state.providers
+    providers: state.providers,
   }))(AddProvider)
 );

--- a/app/src/js/components/Providers/add.js
+++ b/app/src/js/components/Providers/add.js
@@ -10,17 +10,19 @@ import { isValidProvider } from '../../utils/validate';
 
 const SCHEMA_KEY = 'provider';
 
-const nonHttpsExcludes = ['allowedRedirects'];
-const s3Excludes = [...nonHttpsExcludes, 'username', 'password', 'port'];
+const nonSftpExcludes = ['privateKey', 'cmKeyId'];
+const nonHttpsExcludes = ['allowedRedirects', 'certificateUri'];
+const s3Excludes = [...nonSftpExcludes, ...nonHttpsExcludes, 'username', 'password', 'port'];
 
 const AddProvider = ({ providers }) => {
-  const [exclude, setExclude] = useState([]);
+  const [exclude, setExclude] = useState(nonSftpExcludes);
   const [selectedProtocol, setSelectedProtocol] = useState('http');
 
   const handleInputChange = {
     protocol: (value) => {
       if (value === 's3') setExclude(s3Excludes);
-      else if (!value.includes('http')) setExclude(nonHttpsExcludes);
+      else if (!value.includes('http') && !value.includes('sftp')) setExclude([...nonHttpsExcludes, ...nonSftpExcludes]);
+      else if (value === 'sftp') setExclude(nonHttpsExcludes);
       else setExclude([]);
       setSelectedProtocol(value);
     },

--- a/app/src/js/components/Providers/add.js
+++ b/app/src/js/components/Providers/add.js
@@ -28,7 +28,7 @@ const AddProvider = ({ providers }) => {
       if (value === 's3') setExclude(s3Excludes);
       else if (value.includes('http')) setExclude(nonSftpExcludes);
       else if (value === 'sftp') setExclude(nonHttpsExcludes);
-      else setExclude([...nonHttpsExcludes, ...nonSftpExcludes]);
+      else if (value === 'ftp') setExclude([...nonHttpsExcludes, ...nonSftpExcludes]);
       setSelectedProtocol(value);
     },
   };

--- a/cypress/integration/providers_spec.js
+++ b/cypress/integration/providers_spec.js
@@ -38,80 +38,197 @@ describe('Dashboard Providers Page', () => {
       cy.get('.table .tbody .tr').should('have.length', 2);
     });
 
-    it('should add a new provider', () => {
-      const name = 'TESTPROVIDER';
-      const connectionLimit = 5;
-      const protocol = 's3';
-      const host = 'test-host';
-      const port = 443;
+    describe('add a new provider', () => {
+      const expectedFieldsAll = [
+        'Provider Name',
+        'Concurrent Connection Limit',
+        'Protocol',
+        'Host',
+      ];
+      const expectedFieldsAuth = ['Port', 'Username', 'Password'];
+      const expectedFieldsHttp = ['Allowed Redirects', 'Certificate Uri'];
+      const expectedFieldsSftp = ['Private Key', 'Cm Key Id'];
+      it('should go to add providers page', () => {
+        cy.visit('/providers');
+        cy.contains('.heading--large', 'Provider Overview');
+        cy.contains('a', 'Add Provider').as('addProvider');
+        cy.get('@addProvider').should('have.attr', 'href', '/providers/add');
+        cy.get('@addProvider').click();
+        cy.contains('.heading--xlarge', 'Providers');
+        cy.contains('.heading--large', 'Create a provider');
+      });
 
-      cy.visit('/providers');
+      it('should display correct fields for an http provider', () => {
+        const protocol = 'http';
+        const expectedFields = [
+          ...expectedFieldsAll,
+          ...expectedFieldsAuth,
+          ...expectedFieldsHttp,
+        ];
+        const unexpectedFields = [...expectedFieldsSftp];
 
-      cy.contains('.heading--large', 'Provider Overview');
-      cy.contains('a', 'Add Provider').as('addProvider');
-      cy.get('@addProvider').should('have.attr', 'href', '/providers/add');
-      cy.get('@addProvider').click();
+        cy.visit('/providers/add');
+        cy.get('form div ul').as('providerInput');
+        cy.get('@providerInput')
+          .contains('.dropdown__label', 'Protocol')
+          .siblings()
+          .find('div[class*="container"]')
+          .click();
+        cy.contains('div[id*="react-select"]', protocol).click();
+        expectedFields.forEach((field) => {
+          cy.get('@providerInput').contains(field).should('exist');
+        });
+        unexpectedFields.forEach((field) => {
+          cy.get('@providerInput').contains(field).should('not.exist');
+        });
+      });
 
-      cy.contains('.heading--xlarge', 'Providers');
-      cy.contains('.heading--large', 'Create a provider');
+      it('should display correct fields for an https provider', () => {
+        const protocol = 'https';
+        const expectedFields = [
+          ...expectedFieldsAll,
+          ...expectedFieldsAuth,
+          ...expectedFieldsHttp,
+        ];
+        const unexpectedFields = [...expectedFieldsSftp];
 
-      // fill the form and submit
-      cy.get('form div ul').as('providerinput');
-      cy.get('@providerinput')
-        .contains('Provider Name')
-        .siblings('input')
-        .type(name);
-      cy.get('@providerinput')
-        .contains('Concurrent Connection Limit')
-        .siblings('input')
-        .clear()
-        .type(connectionLimit);
-      cy.get('@providerinput')
-        .contains('.dropdown__label', 'Protocol')
-        .siblings()
-        .find('div[class*="container"]')
-        .click();
-      cy.contains('div[id*="react-select"]', protocol).click();
-      cy.get('@providerinput')
-        .contains('Host')
-        .siblings('input')
-        .type(host);
-      cy.get('@providerinput')
-        .contains('Port')
-        .siblings('input')
-        .type(port);
+        cy.visit('/providers/add');
+        cy.get('form div ul').as('providerInput');
+        cy.get('@providerInput')
+          .contains('.dropdown__label', 'Protocol')
+          .siblings()
+          .find('div[class*="container"]')
+          .click();
+        cy.contains('div[id*="react-select"]', protocol).click();
+        expectedFields.forEach((field) => {
+          cy.get('@providerInput').contains(field).should('exist');
+        });
+        unexpectedFields.forEach((field) => {
+          cy.get('@providerInput').contains(field).should('not.exist');
+        });
+      });
 
-      cy.get('form div button').contains('Submit').click();
-      cy.wait('@postProvider');
-      cy.wait('@getProvider');
-      cy.url().should('include', `providers/provider/${name}`);
-      cy.contains('.heading--xlarge', 'Providers');
-      cy.contains('.heading--large', name);
-      cy.contains('.heading--medium', 'Provider Overview');
-      cy.get('.metadata__details')
-        .within(() => {
+      it('should display correct fields for an s3 provider', () => {
+        const protocol = 's3';
+        const expectedFields = [...expectedFieldsAll];
+        const unexpectedFields = [
+          ...expectedFieldsAuth,
+          ...expectedFieldsHttp,
+          ...expectedFieldsSftp,
+        ];
+
+        cy.visit('/providers/add');
+        cy.get('form div ul').as('providerInput');
+        cy.get('@providerInput')
+          .contains('.dropdown__label', 'Protocol')
+          .siblings()
+          .find('div[class*="container"]')
+          .click();
+        cy.contains('div[id*="react-select"]', protocol).click();
+        expectedFields.forEach((field) => {
+          cy.get('@providerInput').contains(field).should('exist');
+        });
+        unexpectedFields.forEach((field) => {
+          cy.get('@providerInput').contains(field).should('not.exist');
+        });
+      });
+
+      it('should display correct fields for an ftp provider', () => {
+        const protocol = 'ftp';
+        const expectedFields = [...expectedFieldsAll, ...expectedFieldsAuth];
+        const unexpectedFields = [...expectedFieldsHttp, ...expectedFieldsSftp];
+
+        cy.visit('/providers/add');
+        cy.get('form div ul').as('providerInput');
+        cy.get('@providerInput')
+          .contains('.dropdown__label', 'Protocol')
+          .siblings()
+          .find('div[class*="container"]')
+          .click();
+        cy.contains('div[id*="react-select"]', protocol).click();
+        expectedFields.forEach((field) => {
+          cy.get('@providerInput').contains(field).should('exist');
+        });
+        unexpectedFields.forEach((field) => {
+          cy.get('@providerInput').contains(field).should('not.exist');
+        });
+      });
+      it('should display correct fields for an sftp provider', () => {
+        const protocol = 'sftp';
+        const expectedFields = [
+          ...expectedFieldsAll,
+          ...expectedFieldsAuth,
+          ...expectedFieldsSftp,
+        ];
+        const unexpectedFields = [...expectedFieldsHttp];
+
+        cy.visit('/providers/add');
+        cy.get('form div ul').as('providerInput');
+        cy.get('@providerInput')
+          .contains('.dropdown__label', 'Protocol')
+          .siblings()
+          .find('div[class*="container"]')
+          .click();
+        cy.contains('div[id*="react-select"]', protocol).click();
+        expectedFields.forEach((field) => {
+          cy.get('@providerInput').contains(field).should('exist');
+        });
+        unexpectedFields.forEach((field) => {
+          cy.get('@providerInput').contains(field).should('not.exist');
+        });
+      });
+      it('should add a new provider', () => {
+        const name = 'TEST_PROVIDER';
+        const connectionLimit = 5;
+        const protocol = 's3';
+        const host = 'test-host';
+
+        // fill the form and submit
+        cy.get('form div ul').as('providerInput');
+        cy.get('@providerInput')
+          .contains('Provider Name')
+          .siblings('input')
+          .type(name);
+        cy.get('@providerInput')
+          .contains('Concurrent Connection Limit')
+          .siblings('input')
+          .clear()
+          .type(connectionLimit);
+        cy.get('@providerInput')
+          .contains('.dropdown__label', 'Protocol')
+          .siblings()
+          .find('div[class*="container"]')
+          .click();
+        cy.contains('div[id*="react-select"]', protocol).click();
+        cy.get('@providerInput').contains('Host').siblings('input').type(host);
+
+        cy.get('form div button').contains('Submit').click();
+        cy.wait('@postProvider');
+        cy.wait('@getProvider');
+        cy.url().should('include', `providers/provider/${name}`);
+        cy.contains('.heading--xlarge', 'Providers');
+        cy.contains('.heading--large', name);
+        cy.contains('.heading--medium', 'Provider Overview');
+        cy.get('.metadata__details').within(() => {
           cy.contains('Global Connection Limit')
             .next()
             .should('have.text', connectionLimit);
-          cy.contains('Protocol')
-            .next()
-            .should('have.text', protocol);
-          cy.contains('Host')
-            .next()
-            .should('have.text', host);
-          cy.contains('Port')
-            .next()
-            .should('have.text', port);
+          cy.contains('Protocol').next().should('have.text', protocol);
+          cy.contains('Host').next().should('have.text', host);
         });
 
-      // Verify the new provider is added to the providers list, after allowing
-      // ES indexing to finish (hopefully), so that the new provider is part
-      // of the query results.
-      cy.wait(1000);
-      cy.contains('a', 'Back to Providers').click();
-      cy.wait('@getProviders');
-      cy.contains('.table .tbody .tr a', name)
-        .should('have.attr', 'href', `/providers/provider/${name}`);
+        // Verify the new provider is added to the providers list, after allowing
+        // ES indexing to finish (hopefully), so that the new provider is part
+        // of the query results.
+        cy.wait(1000);
+        cy.contains('a', 'Back to Providers').click();
+        cy.wait('@getProviders');
+        cy.contains('.table .tbody .tr a', name).should(
+          'have.attr',
+          'href',
+          `/providers/provider/${name}`
+        );
+      });
     });
 
     it('should edit a provider', () => {
@@ -122,26 +239,26 @@ describe('Dashboard Providers Page', () => {
 
       cy.visit(`/providers/provider/${name}`);
       cy.contains('.heading--large', name);
-      cy.contains('a', 'Edit').as('editprovider');
-      cy.get('@editprovider')
+      cy.contains('a', 'Edit').as('editProvider');
+      cy.get('@editProvider')
         .should('have.attr', 'href')
         .and('include', `/providers/edit/${name}`);
-      cy.get('@editprovider').click();
+      cy.get('@editProvider').click();
 
       cy.contains('.heading--large', `Edit provider: ${name}`);
 
-      cy.get('form div ul').as('providerinput');
-      cy.get('@providerinput')
+      cy.get('form div ul').as('providerInput');
+      cy.get('@providerInput')
         .contains('Concurrent Connection Limit')
         .siblings('input')
         .clear()
         .type(connectionLimit);
-      cy.get('@providerinput')
+      cy.get('@providerInput')
         .contains('Host')
         .siblings('input')
         .clear()
         .type(host);
-      cy.get('@providerinput')
+      cy.get('@providerInput')
         .contains('Port')
         .siblings('input')
         .clear()
@@ -153,18 +270,13 @@ describe('Dashboard Providers Page', () => {
       cy.contains('.heading--xlarge', 'Providers');
       cy.contains('.heading--large', name);
       cy.contains('.heading--medium', 'Provider Overview');
-      cy.get('.metadata__details')
-        .within(() => {
-          cy.contains('Global Connection Limit')
-            .next()
-            .should('have.text', connectionLimit);
-          cy.contains('Host')
-            .next()
-            .should('have.text', host);
-          cy.contains('Port')
-            .next()
-            .should('have.text', port);
-        });
+      cy.get('.metadata__details').within(() => {
+        cy.contains('Global Connection Limit')
+          .next()
+          .should('have.text', connectionLimit);
+        cy.contains('Host').next().should('have.text', host);
+        cy.contains('Port').next().should('have.text', port);
+      });
     });
 
     it('should delete a provider', () => {
@@ -192,9 +304,7 @@ describe('Dashboard Providers Page', () => {
       cy.contains('button', 'Confirm').click();
 
       // error should be displayed indicating that deletion failed
-      cy.contains('Provider Overview')
-        .parents('section')
-        .get('.error__report');
+      cy.contains('Provider Overview').parents('section').get('.error__report');
 
       // provider should still exist in list
       cy.contains('a', 'Back to Providers').click();

--- a/cypress/integration/providers_spec.js
+++ b/cypress/integration/providers_spec.js
@@ -183,8 +183,15 @@ describe('Dashboard Providers Page', () => {
         const protocol = 's3';
         const host = 'test-host';
 
+        cy.visit('/providers/add');
         // fill the form and submit
         cy.get('form div ul').as('providerInput');
+        cy.get('@providerInput')
+          .contains('.dropdown__label', 'Protocol')
+          .siblings()
+          .find('div[class*="container"]')
+          .click();
+        cy.contains('div[id*="react-select"]', protocol).click();
         cy.get('@providerInput')
           .contains('Provider Name')
           .siblings('input')
@@ -194,12 +201,6 @@ describe('Dashboard Providers Page', () => {
           .siblings('input')
           .clear()
           .type(connectionLimit);
-        cy.get('@providerInput')
-          .contains('.dropdown__label', 'Protocol')
-          .siblings()
-          .find('div[class*="container"]')
-          .click();
-        cy.contains('div[id*="react-select"]', protocol).click();
         cy.get('@providerInput').contains('Host').siblings('input').type(host);
 
         cy.get('form div button').contains('Submit').click();


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-2747: Create Provider page should only show needed inputs based on protocol](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2747)

## Changes

* Updated create provider page to only show inputs that are relevant for a particular protocol.
	  * SFTP is the only protocol with Private Key and Cm Key Id
	  * HTTP/HTTPS have Allowed Redirects and Certificate Uri
	  * All but S3 have Port, Username, and Password fields

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Adhoc testing
- [x] Integration tests