### PR TITLE
cumulus 2843 Fix dashboard schema converter that is changing 'S3 URI for custom SSL certificate’ to ’S 3…’

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,5 @@
 {
+  "root": false,
   "extends": [
     "airbnb-base",
     "standard",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+- **CUMULUS-2843**
+  Replaces lodash/startCase with custom function used to create titles from schema.
+
 ## [v9.0.0] - 2022-02-01
 
 ## Breaking Changes

--- a/app/src/js/components/FormSchema/schema.js
+++ b/app/src/js/components/FormSchema/schema.js
@@ -3,7 +3,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { get, set } from 'object-path';
-import startCase from 'lodash/startCase';
 import noop from 'lodash/noop';
 import { Form, formTypes } from '../Form/Form';
 import {
@@ -17,6 +16,14 @@ import t from '../../utils/strings';
 import ErrorReport from '../Errors/report';
 
 const { errors } = t;
+
+/**
+ * Replace first character of each word of a string with a capitalized letter.
+ * replaces lodash/startCase because it fails on `S3`
+ * @param {string} sentence - input string to capitalize
+ * @returns {string} input sentence with each first character capitalized.
+ */
+const startCase = (sentence) => sentence.split(' ').map((word) => word.charAt(0).toUpperCase() + word.substring(1)).join(' ');
 
 const traverseSchema = (schema, enums, fn, path = []) => {
   // eslint-disable-next-line guard-for-in

--- a/app/src/js/components/FormSchema/schema.js
+++ b/app/src/js/components/FormSchema/schema.js
@@ -13,17 +13,10 @@ import {
   isText,
 } from '../../utils/validate';
 import t from '../../utils/strings';
+import startCase from '../../utils/start-case';
 import ErrorReport from '../Errors/report';
 
 const { errors } = t;
-
-/**
- * Replace first character of each word of a string with a capitalized letter.
- * replaces lodash/startCase because it fails on `S3`
- * @param {string} sentence - input string to capitalize
- * @returns {string} input sentence with each first character capitalized.
- */
-const startCase = (sentence) => sentence.split(' ').map((word) => word.charAt(0).toUpperCase() + word.substring(1)).join(' ');
 
 const traverseSchema = (schema, enums, fn, path = []) => {
   // eslint-disable-next-line guard-for-in

--- a/app/src/js/utils/start-case.js
+++ b/app/src/js/utils/start-case.js
@@ -1,0 +1,9 @@
+/**
+ * Replace first character of each word of a string with a capitalized letter.
+ * replaces lodash/startCase because it fails on `S3`
+ * @param {string} sentence - input string to capitalize
+ * @returns {string} input sentence with each first character capitalized.
+ */
+const startCase = (sentence) => sentence.split(' ').map((word) => word.charAt(0).toUpperCase() + word.substring(1)).join(' ');
+
+export default startCase;

--- a/cypress/integration/providers_spec.js
+++ b/cypress/integration/providers_spec.js
@@ -46,7 +46,7 @@ describe('Dashboard Providers Page', () => {
         'Host',
       ];
       const expectedFieldsAuth = ['Port', 'Username', 'Password'];
-      const expectedFieldsHttp = ['Allowed Redirects', 'S 3 URI For Custom SSL Certificate'];
+      const expectedFieldsHttp = ['Allowed Redirects', 'S3 URI For Custom SSL Certificate'];
       const expectedFieldsSftp = ['Private Key', 'AWS KMS Customer Master Key ARN Or Alias'];
       it('should go to add providers page', () => {
         cy.visit('/providers');

--- a/test/utils/start-case.js
+++ b/test/utils/start-case.js
@@ -1,0 +1,23 @@
+import test from 'ava';
+import startCase from '../../app/src/js/utils/start-case';
+
+test('startCase does not split S3 into pieces', t => {
+  const testStr = 'S3 is from AWS';
+  const expected = 'S3 Is From AWS';
+  const actual = startCase(testStr);
+  t.is(actual, expected);
+});
+
+test('startCase retains allcap words', t => {
+  const testStr = 'there might be ALLCAPS.';
+  const expected = 'There Might Be ALLCAPS.';
+  const actual = startCase(testStr);
+  t.is(actual, expected);
+});
+
+test('startCase retains punctuation in words', t => {
+  const testStr = 'there-might_be ?punctuation?';
+  const expected = 'There-might_be ?punctuation?';
+  const actual = startCase(testStr);
+  t.is(actual, expected);
+});


### PR DESCRIPTION
**Summary:** 

replace lodash/startCase with custom .

Addresses [CUMULUS-2843: Fix dashboard schema converter that is changing 'S3 URI for custom SSL certificate’ to ’S 3…’](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2843)

## Changes

* adds startCase that caps first letter of each word of a string where each "word" is a series of non space tokens.


## PR Checklist

- [x ] Update CHANGELOG
- [ x] Unit tests
- [ x] Adhoc testing
- [ x] Integration tests