### PR TITLE
downgrade ssh2 to prevent optional build error with node-gyp

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17487,9 +17487,9 @@
       "dev": true
     },
     "ssh2": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.7.0.tgz",
-      "integrity": "sha512-u1gdFfqKV1PTGR2szS5FImhFii40o+8FOUpg1M//iimNaS4BkTyUVfVdoydXS93M1SquOU02Z4KFhYDBNqQO+g==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.6.0.tgz",
+      "integrity": "sha512-lxc+uvXqOxyQ99N2M7k5o4pkYDO5GptOTYduWw7hIM41icxvoBcCNHcj+LTKrjkL0vFcAl+qfZekthoSFRJn2Q==",
       "dev": true,
       "requires": {
         "asn1": "^0.2.4",


### PR DESCRIPTION
fixes build issue