### PR TITLE
Axe Accessibility Fixes + Dependency Updates (from CUMULUS-2960)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
     + Specified title, level-one heading, and modal as main landmark on `/auth`
     + Increased link-background contrast in the header
     + Slight color adjustments for accessibility
+  - Updated dependencies with severe security vulnerabilities:
+    + `@cumulus/api` to `13.1.0`
+    + `moment` to `2.29.4`
+    + `terser-webpack-plugin` to `5.3.3`
 
 ## [v11.0.0] - 2022-04-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- **CUMULUS-2560**
+  - Fixed the following Axe accessibility issues:
+    + Specified title, level-one heading, and modal as main landmark on `/auth`
+    + Increased link-background contrast in the header
+    + Slight color adjustments for accessibility
 
 ## [v11.0.0] - 2022-04-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- **CUMULUS-2560**
+- **CUMULUS-2960**
   - Fixed the following Axe accessibility issues:
     + Specified title, level-one heading, and modal as main landmark on `/auth`
     + Increased link-background contrast in the header

--- a/app/src/css/utils/variables/_colors.scss
+++ b/app/src/css/utils/variables/_colors.scss
@@ -1,6 +1,6 @@
 /* EUI Colors */
 $light-green: #20ce6f;
-$ocean-blue: #2276ac;
+$ocean-blue: #2072a4;
 $midnight-blue: #2c3e50;
 $royal-purple: #673285;
 $dolphin-grey: #95a5a6;

--- a/app/src/js/components/Footer/footer.js
+++ b/app/src/js/components/Footer/footer.js
@@ -27,7 +27,7 @@ const Footer = ({
   if (warning) { versionWarning = <h5 className='api__warning'><span className="warning-icon"></span>Warning: { warning }</h5>; }
 
   return (
-    <div className='footer'>
+    <div className='footer' role='contentinfo'>
       <div className='api__summary'>
         {authenticated &&
           <ul className="footer__container">

--- a/app/src/js/components/Header/header.js
+++ b/app/src/js/components/Header/header.js
@@ -88,7 +88,7 @@ class Header extends React.Component {
         ? `${graphicsPath}${strings.logo}`
         : `${graphicsPath}/${strings.logo}`;
     return (
-      <div className="header">
+      <div className="header" role='banner'>
         <div className="row">
           <h1 className="logo">
             <Link to={{ pathname: '/', search: locationSearch }}>

--- a/app/src/js/components/oauth.js
+++ b/app/src/js/components/oauth.js
@@ -5,6 +5,7 @@ import { withRouter } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import Modal from 'react-bootstrap/Modal';
 import get from 'lodash/get';
+import { Helmet } from 'react-helmet';
 import { login, setTokenState } from '../actions';
 import { window } from '../utils/browser';
 import { buildRedirectUrl } from '../utils/format';
@@ -60,6 +61,9 @@ class OAuth extends React.Component {
 
     return (
       <div className='app'>
+        <Helmet>
+          <title>Cumulus Login</title>
+        </Helmet>
         <Header dispatch={dispatch} api={api} apiVersion={apiVersion} minimal={true}/>
         <main className='main' role='main'>
           <div className="modal-content">

--- a/app/src/js/components/oauth.js
+++ b/app/src/js/components/oauth.js
@@ -73,6 +73,7 @@ class OAuth extends React.Component {
               centered
               size="sm"
               aria-labelledby="modal__oauth-modal"
+              role="main"
             >
               <Modal.Header className="oauth-modal__header"></Modal.Header>
               <h1><Modal.Title id="modal__oauth-modal" className="oauth-modal__title">Welcome To Cumulus Dashboard</Modal.Title></h1>

--- a/app/src/js/components/oauth.js
+++ b/app/src/js/components/oauth.js
@@ -75,7 +75,7 @@ class OAuth extends React.Component {
               aria-labelledby="modal__oauth-modal"
             >
               <Modal.Header className="oauth-modal__header"></Modal.Header>
-              <Modal.Title id="modal__oauth-modal" className="oauth-modal__title">Welcome To Cumulus Dashboard</Modal.Title>
+              <h1><Modal.Title id="modal__oauth-modal" className="oauth-modal__title">Welcome To Cumulus Dashboard</Modal.Title></h1>
               <Modal.Body>
                 { api.inflight ? <h2 className='heading--medium'>Authenticating ... </h2> : null }
                 { api.error ? <ErrorReport report={api.error} /> : null }

--- a/app/src/js/main.js
+++ b/app/src/js/main.js
@@ -33,7 +33,7 @@ const Main = ({
   return (
     <div className='app'>
       {target !== 'cumulus' && (
-        <div className='app__target--container'>
+        <div className='app__target--container' role='region'>
           <h4 className='app__target'>{displayCase(target)} ({displayCase(environment)})</h4>
         </div>
       )}

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,12 +56,72 @@
       "integrity": "sha512-N7w4g+P/SUL8SF+HC4Z4e/ctV6nQ5AERC90K90r4xZQ8WVrJux9albvfyYAzygyU47CSqMWh6yJwFs8DYaeWmg==",
       "dev": true
     },
+    "@aws-crypto/crc32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-2.0.0.tgz",
+      "integrity": "sha512-TvE1r2CUueyXOuHdEigYjIZVesInd9KN+K/TFFNfkkxRThiNxO6i4ZqqAVMoEjAamZZ1AA8WXJkjCz7YShHPQA==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-crypto/crc32c": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-2.0.0.tgz",
+      "integrity": "sha512-vF0eMdMHx3O3MoOXUfBZry8Y4ZDtcuskjjKgJz8YfIDjLStxTZrYXk+kZqtl6A0uCmmiN/Eb/JbC/CndTV1MHg==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/util": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
+    },
     "@aws-crypto/ie11-detection": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.0.tgz",
       "integrity": "sha512-pkVXf/dq6PITJ0jzYZ69VhL8VFOFoPZLZqtU/12SGnzYuJOOGNfF41q9GxdI1yqC8R13Rq3jOLKDFpUJFT5eTA==",
       "dev": true,
       "requires": {
+        "tslib": "^1.11.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-crypto/sha1-browser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-2.0.0.tgz",
+      "integrity": "sha512-3fIVRjPFY8EG5HWXR+ZJZMdWNRpwbxGzJ9IH9q93FpbgCH8u8GHRi46mZXp3cYD7gealmyqpm3ThZwLKJjWJhA==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/ie11-detection": "^2.0.0",
+        "@aws-crypto/supports-web-crypto": "^2.0.0",
+        "@aws-sdk/types": "^3.1.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
         "tslib": "^1.11.1"
       },
       "dependencies": {
@@ -162,6 +222,644 @@
         "tslib": "^2.3.1"
       }
     },
+    "@aws-sdk/chunked-blob-reader": {
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader/-/chunked-blob-reader-3.55.0.tgz",
+      "integrity": "sha512-o/xjMCq81opAjSBjt7YdHJwIJcGVG5XIV9+C2KXcY5QwVimkOKPybWTv0mXPvSwSilSx+EhpLNhkcJuXdzhw4w==",
+      "dev": true,
+      "requires": {
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/chunked-blob-reader-native": {
+      "version": "3.109.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/chunked-blob-reader-native/-/chunked-blob-reader-native-3.109.0.tgz",
+      "integrity": "sha512-Ybn3vDZ3CqGyprL2qdF6QZqoqlx8lA3qOJepobjuKKDRw+KgGxjUY4NvWe0R2MdRoduyaDj6uvhIay0S1MOSJQ==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/util-base64-browser": "3.109.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.109.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.109.0.tgz",
+          "integrity": "sha512-lAZ6fyDGiRLaIsKT9qh7P9FGuNyZ4gAbr1YOSQk/5mHtaTuUvxlPptZuInNM/0MPQm6lpcot00D8IWTucn4PbA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        }
+      }
+    },
+    "@aws-sdk/client-api-gateway": {
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-api-gateway/-/client-api-gateway-3.131.0.tgz",
+      "integrity": "sha512-hEEe/UFUzJLgbq2WDgrk85cTPgEm5H5XLxwq3FNB7X/hfpc2f2zfnyTkDnM8TafC0yJxe3uQW1hD8aaIx5o8Vw==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.131.0",
+        "@aws-sdk/config-resolver": "3.130.0",
+        "@aws-sdk/credential-provider-node": "3.131.0",
+        "@aws-sdk/fetch-http-handler": "3.131.0",
+        "@aws-sdk/hash-node": "3.127.0",
+        "@aws-sdk/invalid-dependency": "3.127.0",
+        "@aws-sdk/middleware-content-length": "3.127.0",
+        "@aws-sdk/middleware-host-header": "3.127.0",
+        "@aws-sdk/middleware-logger": "3.127.0",
+        "@aws-sdk/middleware-recursion-detection": "3.127.0",
+        "@aws-sdk/middleware-retry": "3.127.0",
+        "@aws-sdk/middleware-sdk-api-gateway": "3.127.0",
+        "@aws-sdk/middleware-serde": "3.127.0",
+        "@aws-sdk/middleware-signing": "3.130.0",
+        "@aws-sdk/middleware-stack": "3.127.0",
+        "@aws-sdk/middleware-user-agent": "3.127.0",
+        "@aws-sdk/node-config-provider": "3.127.0",
+        "@aws-sdk/node-http-handler": "3.127.0",
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/smithy-client": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/url-parser": "3.127.0",
+        "@aws-sdk/util-base64-browser": "3.109.0",
+        "@aws-sdk/util-base64-node": "3.55.0",
+        "@aws-sdk/util-body-length-browser": "3.55.0",
+        "@aws-sdk/util-body-length-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.127.0",
+        "@aws-sdk/util-defaults-mode-node": "3.130.0",
+        "@aws-sdk/util-user-agent-browser": "3.127.0",
+        "@aws-sdk/util-user-agent-node": "3.127.0",
+        "@aws-sdk/util-utf8-browser": "3.109.0",
+        "@aws-sdk/util-utf8-node": "3.109.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/abort-controller": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.127.0.tgz",
+          "integrity": "sha512-G77FLYcl9egUoD3ZmR6TX94NMqBMeT53hBGrEE3uVUJV1CwfGKfaF007mPpRZnIB3avnJBQGEK6MrwlCfv2qAw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.131.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.131.0.tgz",
+          "integrity": "sha512-6fbjqLdVZF7mvGpHjWX5YsqBE/99MilNtGUFlwuf4/KnmYy49V16A6Dltnd43Hu6HVGxJ8caH9nCkIdNp3YZcQ==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.130.0",
+            "@aws-sdk/fetch-http-handler": "3.131.0",
+            "@aws-sdk/hash-node": "3.127.0",
+            "@aws-sdk/invalid-dependency": "3.127.0",
+            "@aws-sdk/middleware-content-length": "3.127.0",
+            "@aws-sdk/middleware-host-header": "3.127.0",
+            "@aws-sdk/middleware-logger": "3.127.0",
+            "@aws-sdk/middleware-recursion-detection": "3.127.0",
+            "@aws-sdk/middleware-retry": "3.127.0",
+            "@aws-sdk/middleware-serde": "3.127.0",
+            "@aws-sdk/middleware-stack": "3.127.0",
+            "@aws-sdk/middleware-user-agent": "3.127.0",
+            "@aws-sdk/node-config-provider": "3.127.0",
+            "@aws-sdk/node-http-handler": "3.127.0",
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/smithy-client": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/url-parser": "3.127.0",
+            "@aws-sdk/util-base64-browser": "3.109.0",
+            "@aws-sdk/util-base64-node": "3.55.0",
+            "@aws-sdk/util-body-length-browser": "3.55.0",
+            "@aws-sdk/util-body-length-node": "3.55.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.127.0",
+            "@aws-sdk/util-defaults-mode-node": "3.130.0",
+            "@aws-sdk/util-user-agent-browser": "3.127.0",
+            "@aws-sdk/util-user-agent-node": "3.127.0",
+            "@aws-sdk/util-utf8-browser": "3.109.0",
+            "@aws-sdk/util-utf8-node": "3.109.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.131.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.131.0.tgz",
+          "integrity": "sha512-D9GAnF8n3VwFhaE+jxXH035ZZ24WxpY36DUxszCRwXbA7qFazY1BTs1WoKFr8tDH4/iUUqCXd8NuA1l4RiwnqQ==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.130.0",
+            "@aws-sdk/credential-provider-node": "3.131.0",
+            "@aws-sdk/fetch-http-handler": "3.131.0",
+            "@aws-sdk/hash-node": "3.127.0",
+            "@aws-sdk/invalid-dependency": "3.127.0",
+            "@aws-sdk/middleware-content-length": "3.127.0",
+            "@aws-sdk/middleware-host-header": "3.127.0",
+            "@aws-sdk/middleware-logger": "3.127.0",
+            "@aws-sdk/middleware-recursion-detection": "3.127.0",
+            "@aws-sdk/middleware-retry": "3.127.0",
+            "@aws-sdk/middleware-sdk-sts": "3.130.0",
+            "@aws-sdk/middleware-serde": "3.127.0",
+            "@aws-sdk/middleware-signing": "3.130.0",
+            "@aws-sdk/middleware-stack": "3.127.0",
+            "@aws-sdk/middleware-user-agent": "3.127.0",
+            "@aws-sdk/node-config-provider": "3.127.0",
+            "@aws-sdk/node-http-handler": "3.127.0",
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/smithy-client": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/url-parser": "3.127.0",
+            "@aws-sdk/util-base64-browser": "3.109.0",
+            "@aws-sdk/util-base64-node": "3.55.0",
+            "@aws-sdk/util-body-length-browser": "3.55.0",
+            "@aws-sdk/util-body-length-node": "3.55.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.127.0",
+            "@aws-sdk/util-defaults-mode-node": "3.130.0",
+            "@aws-sdk/util-user-agent-browser": "3.127.0",
+            "@aws-sdk/util-user-agent-node": "3.127.0",
+            "@aws-sdk/util-utf8-browser": "3.109.0",
+            "@aws-sdk/util-utf8-node": "3.109.0",
+            "entities": "2.2.0",
+            "fast-xml-parser": "3.19.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.130.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.130.0.tgz",
+          "integrity": "sha512-7dkCHHI9kRcHW6YNr9/2Ub6XkvU9Fu6H/BnlKbaKlDR8jq7QpaFhPhctOVi5D/NDpxJgALifexFne0dvo3piTw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/signature-v4": "3.130.0",
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-config-provider": "3.109.0",
+            "@aws-sdk/util-middleware": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.127.0.tgz",
+          "integrity": "sha512-Ig7XhUikRBlnRTYT5JBGzWfYZp68X5vkFVIFCmsHHt/qVy0Nz9raZpmDHicdS1u67yxDkWgCPn/bNevWnM0GFg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.127.0.tgz",
+          "integrity": "sha512-I6KlIBBzmJn/U1KikiC50PK3SspT9G5lkVLBaW5a6YfOcijqVTXfAN3kYzqhfeS0j4IgfJEwKVsjsZfmprJO5A==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.127.0",
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/url-parser": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.131.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.131.0.tgz",
+          "integrity": "sha512-0hA2ZwRUDmG5Wp/1t5BLvju2kZft1T3b3KC068ZY3t1+t/O46R6R9vINKEodohKTbfmGddu+aGY58Ai+N7O5Xw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.127.0",
+            "@aws-sdk/credential-provider-imds": "3.127.0",
+            "@aws-sdk/credential-provider-sso": "3.131.0",
+            "@aws-sdk/credential-provider-web-identity": "3.127.0",
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/shared-ini-file-loader": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.131.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.131.0.tgz",
+          "integrity": "sha512-nVQ6P91nd7i/G+iEnKWVwRRsQZIdY0qfza2+v70fOphjv0vzgDN7Xbn1GiYQVbxBiuxMSjQqg1r/p9PdRmt6QA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.127.0",
+            "@aws-sdk/credential-provider-imds": "3.127.0",
+            "@aws-sdk/credential-provider-ini": "3.131.0",
+            "@aws-sdk/credential-provider-process": "3.127.0",
+            "@aws-sdk/credential-provider-sso": "3.131.0",
+            "@aws-sdk/credential-provider-web-identity": "3.127.0",
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/shared-ini-file-loader": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.127.0.tgz",
+          "integrity": "sha512-6v0m2lqkO9J5fNlTl+HjriQNIdfg8mjVST544+5y9EnC/FVmTnIz64vfHveWdNkP/fehFx7wTimNENtoSqCn3A==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/shared-ini-file-loader": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.131.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.131.0.tgz",
+          "integrity": "sha512-3LVan87e6NqnwUrpmjM5dbx8LbZyGG7Gdzf68YL0tZFptCFh1mR/kTJCToGX/hm7Jf3SRU3wtUWJ6G72yP72Sw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/client-sso": "3.131.0",
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/shared-ini-file-loader": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.127.0.tgz",
+          "integrity": "sha512-85ahDZnLYB3dqkW+cQ0bWt+NVqOoxomTrJoq3IC2q6muebeFrJ0pyf0JEW/RNRzBiUvvsZujzGdWifzWyQKfVg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.131.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.131.0.tgz",
+          "integrity": "sha512-eNxmPZQX2IUeBGWHNC7eNTekWn9VIPLYEMKJbKYUBJryxuTJ7TtLeyEK5oakUjMwP1AUvWT+CV7C+8L7uG1omQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/querystring-builder": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-base64-browser": "3.109.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.127.0.tgz",
+          "integrity": "sha512-wx7DKlXdKebH4JcMsOevdsm2oDNMVm36kuMm0XWRIrFWQ/oq7OquDpEMJzWvGqWF/IfFUpb7FhAWZZpALwlcwA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-buffer-from": "3.55.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.127.0.tgz",
+          "integrity": "sha512-bxvmtmJ6gIRfOHvh1jAPZBH2mzppEblPjEOFo4mOzXz4U3qPIxeuukCjboMnGK9QEpV2wObWcYYld0vxoRrfiA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.127.0.tgz",
+          "integrity": "sha512-AFmMaIEW3Rzg0TaKB9l/RENLowd7ZEEOpm0trYw1CgUUORWW/ydCsDT7pekPlC25CPbhUmWXCSA4xPFSYOVnDw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.127.0.tgz",
+          "integrity": "sha512-e2gTLJb5lYP9lRV7hN3rKY2l4jv8OygOoHElZJ3Z8KPZskjHelYPcQ8XbdfhSXXxC3vc/0QqN0ResFt3W3Pplg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.127.0.tgz",
+          "integrity": "sha512-jMNLcZB/ECA7OfkNBLNeAlrLRehyfnUeNQJHW3kcxs9h1+6VxaF6wY+WKozszLI7/3OBzQrFHBQCfRZV7ykSLg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.127.0.tgz",
+          "integrity": "sha512-ZSvg/AyGUacWnf3i8ZbyImtiCH+NyafF8uV7bITP7JkwPrG+VdNocJZOr88GRM0c1A0jfkOf7+oq+fInPwwiNA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/service-error-classification": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-middleware": "3.127.0",
+            "tslib": "^2.3.1",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.130.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.130.0.tgz",
+          "integrity": "sha512-FDfs7+ohbhEK3eH3Dshr6JDiL8P72bp3ffeNpPBXuURFqwt4pCmjHuX3SqQR0JIJ2cl3aIdxc17rKaZJfOjtPw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.130.0",
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/signature-v4": "3.130.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.127.0.tgz",
+          "integrity": "sha512-xmWMYV/t9M+b9yHjqaD1noDNJJViI2QwOH7TQZ9VbbrvdVtDrFuS9Sf9He80TBCJqeHShwQN9783W1I3Pu/8kw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.130.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.130.0.tgz",
+          "integrity": "sha512-JePq5XLR9TfRN3RQ0d7Za/bEW5D3xgtD1FNAwHeenWALeozMuQgRPjM5RroCnL/5jY3wuvCZI7cSXeqhawWqmA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/signature-v4": "3.130.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.127.0.tgz",
+          "integrity": "sha512-S1IoUE5o1vCmjsF5nIE8zlItNOM1UE+lhmZeigF7knXJ9+a6ewMB6POAj/s4eoi0wcn0eSnAGsqJCWMSUjOPLA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.127.0.tgz",
+          "integrity": "sha512-CHxgswoOzdkOEoIq7Oyob3Sx/4FYUv6BhUesAX7MNshaDDsTQPbSWjw5bqZDiL/gO+X/34fvqCVVpVD2GvxW/g==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.127.0.tgz",
+          "integrity": "sha512-bAHkASMhLZHT1yv2TX6OJGFV9Lc3t1gKfTMEKdXM2O2YhGfSx9A/qLeJm79oDfnILWQtSS2NicxlRDI2lYGf4g==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/shared-ini-file-loader": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.127.0.tgz",
+          "integrity": "sha512-pyMKvheK8eDwWLgYIRsWy8wiyhsbYYcqkZQs3Eh6upI4E8iCY7eMmhWvHYCibvsO+UjsOwa4cAMOfwnv/Z9s8A==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/abort-controller": "3.127.0",
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/querystring-builder": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.127.0.tgz",
+          "integrity": "sha512-JxenxlTEkWfLrtJqIjaXaJzAVQbbscoCb5bNjmdud07ESLVfWRKJx2nAJdecHKYp2M5NQyqBuFhQ1ELSFYQKCA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.127.0.tgz",
+          "integrity": "sha512-UG83PVuKX40wilG2uRU0Fvz4OY8Bt+bSPOG776DFjwIXYzK7BwpJm9H2XI2HLhS5WxrJHhwrLBRgW6UiykMnFw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.127.0.tgz",
+          "integrity": "sha512-tsoyp4lLPsASPDYWsezGAHD8VJsZbjUNATNAzTCFdH6p+4SKBK83Q5kfXCzxt13M+l3oKbxxIWLvS0kVQFyltQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-uri-escape": "3.55.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.127.0.tgz",
+          "integrity": "sha512-Vn/Dv+PqUSepp/DzLqq0LJJD8HdPefJCnLbO5WcHCARHSGlyGlZUFEM45k/oEHpTvgMXj/ORaP3A+tLwLu0AmA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.127.0.tgz",
+          "integrity": "sha512-wjZY9rnlA8SPrICUumTYicEKtK4/yKB62iadUk66hxe8MrH8JhuHH2NqIad0Pt/bK/YtNVhd3yb4pRapOeY5qQ==",
+          "dev": true
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.127.0.tgz",
+          "integrity": "sha512-S3Nn4KRTqoJsB/TbRZSWBBUrkckNMR0Juqz7bOB+wupVvddKP6IcpspSC/GX9zgJjVMV8iGisZ6AUsYsC5r+cA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.130.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.130.0.tgz",
+          "integrity": "sha512-g5G1a1NHL2uOoFfC2zQdZcj+wbjgBQPkx6xGdtqNKf9v2kS0n6ap5JUGEaqWE02lUlmWHsoMsS73hXtzwXaBRQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.55.0",
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-hex-encoding": "3.109.0",
+            "@aws-sdk/util-middleware": "3.127.0",
+            "@aws-sdk/util-uri-escape": "3.55.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.127.0.tgz",
+          "integrity": "sha512-sfcAJ+7a41CJMtsv6HRIjA91155Yk013RvMUdG2EMSo3cpLq/QmTJ1EGw4ByDZs5HLpXAaRoLI+bA2ovriGQnQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.127.0.tgz",
+          "integrity": "sha512-njZ7zn41JHRpNfr3BCesVXCLZE0zcWSfEdtRV0ICw0cU1FgYcKELSuY9+gLUB4ci6uc7gq7mPE8+w30FcM4QeA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.109.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.109.0.tgz",
+          "integrity": "sha512-lAZ6fyDGiRLaIsKT9qh7P9FGuNyZ4gAbr1YOSQk/5mHtaTuUvxlPptZuInNM/0MPQm6lpcot00D8IWTucn4PbA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-config-provider": {
+          "version": "3.109.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.109.0.tgz",
+          "integrity": "sha512-GrAZl/aBv0A28LkyNyq8SPJ5fmViCwz80fWLMeWx/6q5AbivuILogjlWwEZSvZ9zrlHOcFC0+AnCa5pQrjaslw==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.127.0.tgz",
+          "integrity": "sha512-e/vBm+EYSJ0R79591EPiCPE3aR5RKk5CjOkQjNxZIX8UPnIlo7xohTcebfR/iugSTxNrpfrFv+o4H5GjzAuhLA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+          "version": "3.130.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.130.0.tgz",
+          "integrity": "sha512-0BWx7C6GhHBrjPUuSgMnRA4InxYisX6MIGs5yIHk2OArYkQLJMdeORYXXz1y40ahMihmtjD/Ap5xQGBm2vyffA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/config-resolver": "3.130.0",
+            "@aws-sdk/credential-provider-imds": "3.127.0",
+            "@aws-sdk/node-config-provider": "3.127.0",
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.109.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.109.0.tgz",
+          "integrity": "sha512-s8CgTNrn3cLkrdiohfxLuOYPCanzvHn/aH5RW6DaMoeQiG5Hl9QUiP/WtdQ9QQx3xvpQFpmvxIaSBwSgFNLQxA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.127.0.tgz",
+          "integrity": "sha512-EwAPPed9TNqh+Wov2VStLn2NuJ/Wyt7IkZCbCsBuSNp3BFZ1V4gfwTjqtKCtB2LQgQ48MTgWgNCvrH0zjCSPGg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.127.0.tgz",
+          "integrity": "sha512-uO2oHmJswuYKJS+GiMdYI8izhpC9M7/jFFvnAmLlTEVwpEi1VX9KePAOF+u5AaBC2kzITo/7dg141XfRHZloIQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.127.0.tgz",
+          "integrity": "sha512-3P/M4ZDD2qMeeoCk7TE/Mw7cG5IjB87F6BP8nI8/oHuaz7j6fsI7D49SNpyjl8JApRynZ122Ad6hwQwRj3isYw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.109.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.109.0.tgz",
+          "integrity": "sha512-FmcGSz0v7Bqpl1SE8G1Gc0CtDpug+rvqNCG/szn86JApD/f5x8oByjbEiAyTU2ZH2VevUntx6EW68ulHyH+x+w==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.109.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.109.0.tgz",
+          "integrity": "sha512-Ti/ZBdvz2eSTElsucjzNmzpyg2MwfD1rXmxD0hZuIF8bPON/0+sZYnWd5CbDw9kgmhy28dmKue086tbZ1G0iLQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.55.0",
+            "tslib": "^2.3.1"
+          }
+        }
+      }
+    },
     "@aws-sdk/client-dynamodb": {
       "version": "3.58.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-dynamodb/-/client-dynamodb-3.58.0.tgz",
@@ -245,6 +943,644 @@
         "@aws-sdk/util-utf8-browser": "3.55.0",
         "@aws-sdk/util-utf8-node": "3.55.0",
         "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/client-s3": {
+      "version": "3.135.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.135.0.tgz",
+      "integrity": "sha512-bLcq00AFHAK2scTWGc+PmXciZwSgSZh0iJ4w+Jef8lqs5F8PbXDQcu4tgE3BCKZZo6RuFXKOrwJwktZQwLaOJA==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/sha1-browser": "2.0.0",
+        "@aws-crypto/sha256-browser": "2.0.0",
+        "@aws-crypto/sha256-js": "2.0.0",
+        "@aws-sdk/client-sts": "3.131.0",
+        "@aws-sdk/config-resolver": "3.130.0",
+        "@aws-sdk/credential-provider-node": "3.131.0",
+        "@aws-sdk/eventstream-serde-browser": "3.127.0",
+        "@aws-sdk/eventstream-serde-config-resolver": "3.127.0",
+        "@aws-sdk/eventstream-serde-node": "3.127.0",
+        "@aws-sdk/fetch-http-handler": "3.131.0",
+        "@aws-sdk/hash-blob-browser": "3.127.0",
+        "@aws-sdk/hash-node": "3.127.0",
+        "@aws-sdk/hash-stream-node": "3.127.0",
+        "@aws-sdk/invalid-dependency": "3.127.0",
+        "@aws-sdk/md5-js": "3.127.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.127.0",
+        "@aws-sdk/middleware-content-length": "3.127.0",
+        "@aws-sdk/middleware-expect-continue": "3.127.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.127.0",
+        "@aws-sdk/middleware-host-header": "3.127.0",
+        "@aws-sdk/middleware-location-constraint": "3.127.0",
+        "@aws-sdk/middleware-logger": "3.127.0",
+        "@aws-sdk/middleware-recursion-detection": "3.127.0",
+        "@aws-sdk/middleware-retry": "3.127.0",
+        "@aws-sdk/middleware-sdk-s3": "3.127.0",
+        "@aws-sdk/middleware-serde": "3.127.0",
+        "@aws-sdk/middleware-signing": "3.130.0",
+        "@aws-sdk/middleware-ssec": "3.127.0",
+        "@aws-sdk/middleware-stack": "3.127.0",
+        "@aws-sdk/middleware-user-agent": "3.127.0",
+        "@aws-sdk/node-config-provider": "3.127.0",
+        "@aws-sdk/node-http-handler": "3.127.0",
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/signature-v4-multi-region": "3.130.0",
+        "@aws-sdk/smithy-client": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/url-parser": "3.127.0",
+        "@aws-sdk/util-base64-browser": "3.109.0",
+        "@aws-sdk/util-base64-node": "3.55.0",
+        "@aws-sdk/util-body-length-browser": "3.55.0",
+        "@aws-sdk/util-body-length-node": "3.55.0",
+        "@aws-sdk/util-defaults-mode-browser": "3.127.0",
+        "@aws-sdk/util-defaults-mode-node": "3.130.0",
+        "@aws-sdk/util-stream-browser": "3.131.0",
+        "@aws-sdk/util-stream-node": "3.129.0",
+        "@aws-sdk/util-user-agent-browser": "3.127.0",
+        "@aws-sdk/util-user-agent-node": "3.127.0",
+        "@aws-sdk/util-utf8-browser": "3.109.0",
+        "@aws-sdk/util-utf8-node": "3.109.0",
+        "@aws-sdk/util-waiter": "3.127.0",
+        "@aws-sdk/xml-builder": "3.109.0",
+        "entities": "2.2.0",
+        "fast-xml-parser": "3.19.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/abort-controller": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.127.0.tgz",
+          "integrity": "sha512-G77FLYcl9egUoD3ZmR6TX94NMqBMeT53hBGrEE3uVUJV1CwfGKfaF007mPpRZnIB3avnJBQGEK6MrwlCfv2qAw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sso": {
+          "version": "3.131.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.131.0.tgz",
+          "integrity": "sha512-6fbjqLdVZF7mvGpHjWX5YsqBE/99MilNtGUFlwuf4/KnmYy49V16A6Dltnd43Hu6HVGxJ8caH9nCkIdNp3YZcQ==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.130.0",
+            "@aws-sdk/fetch-http-handler": "3.131.0",
+            "@aws-sdk/hash-node": "3.127.0",
+            "@aws-sdk/invalid-dependency": "3.127.0",
+            "@aws-sdk/middleware-content-length": "3.127.0",
+            "@aws-sdk/middleware-host-header": "3.127.0",
+            "@aws-sdk/middleware-logger": "3.127.0",
+            "@aws-sdk/middleware-recursion-detection": "3.127.0",
+            "@aws-sdk/middleware-retry": "3.127.0",
+            "@aws-sdk/middleware-serde": "3.127.0",
+            "@aws-sdk/middleware-stack": "3.127.0",
+            "@aws-sdk/middleware-user-agent": "3.127.0",
+            "@aws-sdk/node-config-provider": "3.127.0",
+            "@aws-sdk/node-http-handler": "3.127.0",
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/smithy-client": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/url-parser": "3.127.0",
+            "@aws-sdk/util-base64-browser": "3.109.0",
+            "@aws-sdk/util-base64-node": "3.55.0",
+            "@aws-sdk/util-body-length-browser": "3.55.0",
+            "@aws-sdk/util-body-length-node": "3.55.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.127.0",
+            "@aws-sdk/util-defaults-mode-node": "3.130.0",
+            "@aws-sdk/util-user-agent-browser": "3.127.0",
+            "@aws-sdk/util-user-agent-node": "3.127.0",
+            "@aws-sdk/util-utf8-browser": "3.109.0",
+            "@aws-sdk/util-utf8-node": "3.109.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/client-sts": {
+          "version": "3.131.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.131.0.tgz",
+          "integrity": "sha512-D9GAnF8n3VwFhaE+jxXH035ZZ24WxpY36DUxszCRwXbA7qFazY1BTs1WoKFr8tDH4/iUUqCXd8NuA1l4RiwnqQ==",
+          "dev": true,
+          "requires": {
+            "@aws-crypto/sha256-browser": "2.0.0",
+            "@aws-crypto/sha256-js": "2.0.0",
+            "@aws-sdk/config-resolver": "3.130.0",
+            "@aws-sdk/credential-provider-node": "3.131.0",
+            "@aws-sdk/fetch-http-handler": "3.131.0",
+            "@aws-sdk/hash-node": "3.127.0",
+            "@aws-sdk/invalid-dependency": "3.127.0",
+            "@aws-sdk/middleware-content-length": "3.127.0",
+            "@aws-sdk/middleware-host-header": "3.127.0",
+            "@aws-sdk/middleware-logger": "3.127.0",
+            "@aws-sdk/middleware-recursion-detection": "3.127.0",
+            "@aws-sdk/middleware-retry": "3.127.0",
+            "@aws-sdk/middleware-sdk-sts": "3.130.0",
+            "@aws-sdk/middleware-serde": "3.127.0",
+            "@aws-sdk/middleware-signing": "3.130.0",
+            "@aws-sdk/middleware-stack": "3.127.0",
+            "@aws-sdk/middleware-user-agent": "3.127.0",
+            "@aws-sdk/node-config-provider": "3.127.0",
+            "@aws-sdk/node-http-handler": "3.127.0",
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/smithy-client": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/url-parser": "3.127.0",
+            "@aws-sdk/util-base64-browser": "3.109.0",
+            "@aws-sdk/util-base64-node": "3.55.0",
+            "@aws-sdk/util-body-length-browser": "3.55.0",
+            "@aws-sdk/util-body-length-node": "3.55.0",
+            "@aws-sdk/util-defaults-mode-browser": "3.127.0",
+            "@aws-sdk/util-defaults-mode-node": "3.130.0",
+            "@aws-sdk/util-user-agent-browser": "3.127.0",
+            "@aws-sdk/util-user-agent-node": "3.127.0",
+            "@aws-sdk/util-utf8-browser": "3.109.0",
+            "@aws-sdk/util-utf8-node": "3.109.0",
+            "entities": "2.2.0",
+            "fast-xml-parser": "3.19.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/config-resolver": {
+          "version": "3.130.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.130.0.tgz",
+          "integrity": "sha512-7dkCHHI9kRcHW6YNr9/2Ub6XkvU9Fu6H/BnlKbaKlDR8jq7QpaFhPhctOVi5D/NDpxJgALifexFne0dvo3piTw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/signature-v4": "3.130.0",
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-config-provider": "3.109.0",
+            "@aws-sdk/util-middleware": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-env": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.127.0.tgz",
+          "integrity": "sha512-Ig7XhUikRBlnRTYT5JBGzWfYZp68X5vkFVIFCmsHHt/qVy0Nz9raZpmDHicdS1u67yxDkWgCPn/bNevWnM0GFg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-imds": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.127.0.tgz",
+          "integrity": "sha512-I6KlIBBzmJn/U1KikiC50PK3SspT9G5lkVLBaW5a6YfOcijqVTXfAN3kYzqhfeS0j4IgfJEwKVsjsZfmprJO5A==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.127.0",
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/url-parser": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-ini": {
+          "version": "3.131.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.131.0.tgz",
+          "integrity": "sha512-0hA2ZwRUDmG5Wp/1t5BLvju2kZft1T3b3KC068ZY3t1+t/O46R6R9vINKEodohKTbfmGddu+aGY58Ai+N7O5Xw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.127.0",
+            "@aws-sdk/credential-provider-imds": "3.127.0",
+            "@aws-sdk/credential-provider-sso": "3.131.0",
+            "@aws-sdk/credential-provider-web-identity": "3.127.0",
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/shared-ini-file-loader": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-node": {
+          "version": "3.131.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.131.0.tgz",
+          "integrity": "sha512-nVQ6P91nd7i/G+iEnKWVwRRsQZIdY0qfza2+v70fOphjv0vzgDN7Xbn1GiYQVbxBiuxMSjQqg1r/p9PdRmt6QA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/credential-provider-env": "3.127.0",
+            "@aws-sdk/credential-provider-imds": "3.127.0",
+            "@aws-sdk/credential-provider-ini": "3.131.0",
+            "@aws-sdk/credential-provider-process": "3.127.0",
+            "@aws-sdk/credential-provider-sso": "3.131.0",
+            "@aws-sdk/credential-provider-web-identity": "3.127.0",
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/shared-ini-file-loader": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-process": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.127.0.tgz",
+          "integrity": "sha512-6v0m2lqkO9J5fNlTl+HjriQNIdfg8mjVST544+5y9EnC/FVmTnIz64vfHveWdNkP/fehFx7wTimNENtoSqCn3A==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/shared-ini-file-loader": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-sso": {
+          "version": "3.131.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.131.0.tgz",
+          "integrity": "sha512-3LVan87e6NqnwUrpmjM5dbx8LbZyGG7Gdzf68YL0tZFptCFh1mR/kTJCToGX/hm7Jf3SRU3wtUWJ6G72yP72Sw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/client-sso": "3.131.0",
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/shared-ini-file-loader": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/credential-provider-web-identity": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.127.0.tgz",
+          "integrity": "sha512-85ahDZnLYB3dqkW+cQ0bWt+NVqOoxomTrJoq3IC2q6muebeFrJ0pyf0JEW/RNRzBiUvvsZujzGdWifzWyQKfVg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.131.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.131.0.tgz",
+          "integrity": "sha512-eNxmPZQX2IUeBGWHNC7eNTekWn9VIPLYEMKJbKYUBJryxuTJ7TtLeyEK5oakUjMwP1AUvWT+CV7C+8L7uG1omQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/querystring-builder": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-base64-browser": "3.109.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/hash-node": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.127.0.tgz",
+          "integrity": "sha512-wx7DKlXdKebH4JcMsOevdsm2oDNMVm36kuMm0XWRIrFWQ/oq7OquDpEMJzWvGqWF/IfFUpb7FhAWZZpALwlcwA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-buffer-from": "3.55.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/invalid-dependency": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.127.0.tgz",
+          "integrity": "sha512-bxvmtmJ6gIRfOHvh1jAPZBH2mzppEblPjEOFo4mOzXz4U3qPIxeuukCjboMnGK9QEpV2wObWcYYld0vxoRrfiA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-content-length": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.127.0.tgz",
+          "integrity": "sha512-AFmMaIEW3Rzg0TaKB9l/RENLowd7ZEEOpm0trYw1CgUUORWW/ydCsDT7pekPlC25CPbhUmWXCSA4xPFSYOVnDw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-host-header": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.127.0.tgz",
+          "integrity": "sha512-e2gTLJb5lYP9lRV7hN3rKY2l4jv8OygOoHElZJ3Z8KPZskjHelYPcQ8XbdfhSXXxC3vc/0QqN0ResFt3W3Pplg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-logger": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.127.0.tgz",
+          "integrity": "sha512-jMNLcZB/ECA7OfkNBLNeAlrLRehyfnUeNQJHW3kcxs9h1+6VxaF6wY+WKozszLI7/3OBzQrFHBQCfRZV7ykSLg==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-retry": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.127.0.tgz",
+          "integrity": "sha512-ZSvg/AyGUacWnf3i8ZbyImtiCH+NyafF8uV7bITP7JkwPrG+VdNocJZOr88GRM0c1A0jfkOf7+oq+fInPwwiNA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/service-error-classification": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-middleware": "3.127.0",
+            "tslib": "^2.3.1",
+            "uuid": "^8.3.2"
+          }
+        },
+        "@aws-sdk/middleware-sdk-sts": {
+          "version": "3.130.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.130.0.tgz",
+          "integrity": "sha512-FDfs7+ohbhEK3eH3Dshr6JDiL8P72bp3ffeNpPBXuURFqwt4pCmjHuX3SqQR0JIJ2cl3aIdxc17rKaZJfOjtPw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/middleware-signing": "3.130.0",
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/signature-v4": "3.130.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-serde": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.127.0.tgz",
+          "integrity": "sha512-xmWMYV/t9M+b9yHjqaD1noDNJJViI2QwOH7TQZ9VbbrvdVtDrFuS9Sf9He80TBCJqeHShwQN9783W1I3Pu/8kw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-signing": {
+          "version": "3.130.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.130.0.tgz",
+          "integrity": "sha512-JePq5XLR9TfRN3RQ0d7Za/bEW5D3xgtD1FNAwHeenWALeozMuQgRPjM5RroCnL/5jY3wuvCZI7cSXeqhawWqmA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/signature-v4": "3.130.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-stack": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.127.0.tgz",
+          "integrity": "sha512-S1IoUE5o1vCmjsF5nIE8zlItNOM1UE+lhmZeigF7knXJ9+a6ewMB6POAj/s4eoi0wcn0eSnAGsqJCWMSUjOPLA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/middleware-user-agent": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.127.0.tgz",
+          "integrity": "sha512-CHxgswoOzdkOEoIq7Oyob3Sx/4FYUv6BhUesAX7MNshaDDsTQPbSWjw5bqZDiL/gO+X/34fvqCVVpVD2GvxW/g==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-config-provider": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.127.0.tgz",
+          "integrity": "sha512-bAHkASMhLZHT1yv2TX6OJGFV9Lc3t1gKfTMEKdXM2O2YhGfSx9A/qLeJm79oDfnILWQtSS2NicxlRDI2lYGf4g==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/shared-ini-file-loader": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.127.0.tgz",
+          "integrity": "sha512-pyMKvheK8eDwWLgYIRsWy8wiyhsbYYcqkZQs3Eh6upI4E8iCY7eMmhWvHYCibvsO+UjsOwa4cAMOfwnv/Z9s8A==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/abort-controller": "3.127.0",
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/querystring-builder": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/property-provider": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.127.0.tgz",
+          "integrity": "sha512-JxenxlTEkWfLrtJqIjaXaJzAVQbbscoCb5bNjmdud07ESLVfWRKJx2nAJdecHKYp2M5NQyqBuFhQ1ELSFYQKCA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.127.0.tgz",
+          "integrity": "sha512-UG83PVuKX40wilG2uRU0Fvz4OY8Bt+bSPOG776DFjwIXYzK7BwpJm9H2XI2HLhS5WxrJHhwrLBRgW6UiykMnFw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.127.0.tgz",
+          "integrity": "sha512-tsoyp4lLPsASPDYWsezGAHD8VJsZbjUNATNAzTCFdH6p+4SKBK83Q5kfXCzxt13M+l3oKbxxIWLvS0kVQFyltQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-uri-escape": "3.55.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-parser": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.127.0.tgz",
+          "integrity": "sha512-Vn/Dv+PqUSepp/DzLqq0LJJD8HdPefJCnLbO5WcHCARHSGlyGlZUFEM45k/oEHpTvgMXj/ORaP3A+tLwLu0AmA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/service-error-classification": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.127.0.tgz",
+          "integrity": "sha512-wjZY9rnlA8SPrICUumTYicEKtK4/yKB62iadUk66hxe8MrH8JhuHH2NqIad0Pt/bK/YtNVhd3yb4pRapOeY5qQ==",
+          "dev": true
+        },
+        "@aws-sdk/shared-ini-file-loader": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.127.0.tgz",
+          "integrity": "sha512-S3Nn4KRTqoJsB/TbRZSWBBUrkckNMR0Juqz7bOB+wupVvddKP6IcpspSC/GX9zgJjVMV8iGisZ6AUsYsC5r+cA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.130.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.130.0.tgz",
+          "integrity": "sha512-g5G1a1NHL2uOoFfC2zQdZcj+wbjgBQPkx6xGdtqNKf9v2kS0n6ap5JUGEaqWE02lUlmWHsoMsS73hXtzwXaBRQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.55.0",
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-hex-encoding": "3.109.0",
+            "@aws-sdk/util-middleware": "3.127.0",
+            "@aws-sdk/util-uri-escape": "3.55.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.127.0.tgz",
+          "integrity": "sha512-sfcAJ+7a41CJMtsv6HRIjA91155Yk013RvMUdG2EMSo3cpLq/QmTJ1EGw4ByDZs5HLpXAaRoLI+bA2ovriGQnQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        },
+        "@aws-sdk/url-parser": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.127.0.tgz",
+          "integrity": "sha512-njZ7zn41JHRpNfr3BCesVXCLZE0zcWSfEdtRV0ICw0cU1FgYcKELSuY9+gLUB4ci6uc7gq7mPE8+w30FcM4QeA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/querystring-parser": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.109.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.109.0.tgz",
+          "integrity": "sha512-lAZ6fyDGiRLaIsKT9qh7P9FGuNyZ4gAbr1YOSQk/5mHtaTuUvxlPptZuInNM/0MPQm6lpcot00D8IWTucn4PbA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-config-provider": {
+          "version": "3.109.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.109.0.tgz",
+          "integrity": "sha512-GrAZl/aBv0A28LkyNyq8SPJ5fmViCwz80fWLMeWx/6q5AbivuILogjlWwEZSvZ9zrlHOcFC0+AnCa5pQrjaslw==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-browser": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.127.0.tgz",
+          "integrity": "sha512-e/vBm+EYSJ0R79591EPiCPE3aR5RKk5CjOkQjNxZIX8UPnIlo7xohTcebfR/iugSTxNrpfrFv+o4H5GjzAuhLA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-defaults-mode-node": {
+          "version": "3.130.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.130.0.tgz",
+          "integrity": "sha512-0BWx7C6GhHBrjPUuSgMnRA4InxYisX6MIGs5yIHk2OArYkQLJMdeORYXXz1y40ahMihmtjD/Ap5xQGBm2vyffA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/config-resolver": "3.130.0",
+            "@aws-sdk/credential-provider-imds": "3.127.0",
+            "@aws-sdk/node-config-provider": "3.127.0",
+            "@aws-sdk/property-provider": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.109.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.109.0.tgz",
+          "integrity": "sha512-s8CgTNrn3cLkrdiohfxLuOYPCanzvHn/aH5RW6DaMoeQiG5Hl9QUiP/WtdQ9QQx3xvpQFpmvxIaSBwSgFNLQxA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.127.0.tgz",
+          "integrity": "sha512-EwAPPed9TNqh+Wov2VStLn2NuJ/Wyt7IkZCbCsBuSNp3BFZ1V4gfwTjqtKCtB2LQgQ48MTgWgNCvrH0zjCSPGg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-browser": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.127.0.tgz",
+          "integrity": "sha512-uO2oHmJswuYKJS+GiMdYI8izhpC9M7/jFFvnAmLlTEVwpEi1VX9KePAOF+u5AaBC2kzITo/7dg141XfRHZloIQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "bowser": "^2.11.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-user-agent-node": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.127.0.tgz",
+          "integrity": "sha512-3P/M4ZDD2qMeeoCk7TE/Mw7cG5IjB87F6BP8nI8/oHuaz7j6fsI7D49SNpyjl8JApRynZ122Ad6hwQwRj3isYw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/node-config-provider": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.109.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.109.0.tgz",
+          "integrity": "sha512-FmcGSz0v7Bqpl1SE8G1Gc0CtDpug+rvqNCG/szn86JApD/f5x8oByjbEiAyTU2ZH2VevUntx6EW68ulHyH+x+w==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.109.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.109.0.tgz",
+          "integrity": "sha512-Ti/ZBdvz2eSTElsucjzNmzpyg2MwfD1rXmxD0hZuIF8bPON/0+sZYnWd5CbDw9kgmhy28dmKue086tbZ1G0iLQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.55.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-waiter": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-waiter/-/util-waiter-3.127.0.tgz",
+          "integrity": "sha512-E5qrRpBJS8dmClqSDW1pWVMKzCG/mxabG6jVUtlW/WLHnl/znxGaOQc6tnnwKik0nEq/4DpT9fEfPUz9JiLrkw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/abort-controller": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        }
       }
     },
     "@aws-sdk/client-sso": {
@@ -445,6 +1781,110 @@
         "tslib": "^2.3.1"
       }
     },
+    "@aws-sdk/eventstream-codec": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-codec/-/eventstream-codec-3.127.0.tgz",
+      "integrity": "sha512-+Tlujx3VkB4DK8tYzG0rwxIE0ee6hWItQgSEREEmi5CwHQFw7VpRLYAShYabEx9wIJmRFObWzhlKxWNRi+TfaA==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/crc32": "2.0.0",
+        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/util-hex-encoding": "3.109.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.109.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.109.0.tgz",
+          "integrity": "sha512-s8CgTNrn3cLkrdiohfxLuOYPCanzvHn/aH5RW6DaMoeQiG5Hl9QUiP/WtdQ9QQx3xvpQFpmvxIaSBwSgFNLQxA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        }
+      }
+    },
+    "@aws-sdk/eventstream-serde-browser": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-browser/-/eventstream-serde-browser-3.127.0.tgz",
+      "integrity": "sha512-d1rTK4ljEp3Y/BQ78/AJ7eqgGyI6TE0bxNosCmXWcUBv00Tr5cerPqPe7Zvw8XwIMPX5y8cjtd1/cOtB2ePaBw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/eventstream-serde-universal": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/eventstream-serde-config-resolver": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-3.127.0.tgz",
+      "integrity": "sha512-dYvLfQYcKLOFtZVgwLwKDCykAxNkDyDLQRWytJK9DHCyjRig66IKi1codts9vOy4j0CeYwnXWs5WDavrUaE05g==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/eventstream-serde-node": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-node/-/eventstream-serde-node-3.127.0.tgz",
+      "integrity": "sha512-Ie59jZYAIw3Kt6GePvEilp1k3JoYEQpY3WIyVZltm3dkVf0GmzhCZrPROH9vgF3qApzu1aGOWDV2wX91poXF8A==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/eventstream-serde-universal": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/eventstream-serde-universal": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/eventstream-serde-universal/-/eventstream-serde-universal-3.127.0.tgz",
+      "integrity": "sha512-cJLSTtYDGTevknMTykzHpcDNRbD6yGve8FBUKSAczuNVjXZOedj0GbHJqkASuLj0ZnojbKBdCx4uu1XGyvubng==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/eventstream-codec": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        }
+      }
+    },
     "@aws-sdk/fetch-http-handler": {
       "version": "3.58.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.58.0.tgz",
@@ -458,6 +1898,26 @@
         "tslib": "^2.3.1"
       }
     },
+    "@aws-sdk/hash-blob-browser": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-blob-browser/-/hash-blob-browser-3.127.0.tgz",
+      "integrity": "sha512-XH9s2w6GXCtDI+3/y+sDAzMWJRTvhRXJJtI1fVDsCiyq96SYUTNKLLaUSuR01uawEBiRDBqGDDPMT8qJPDXc/w==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/chunked-blob-reader": "3.55.0",
+        "@aws-sdk/chunked-blob-reader-native": "3.109.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        }
+      }
+    },
     "@aws-sdk/hash-node": {
       "version": "3.55.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.55.0.tgz",
@@ -467,6 +1927,24 @@
         "@aws-sdk/types": "3.55.0",
         "@aws-sdk/util-buffer-from": "3.55.0",
         "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/hash-stream-node": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/hash-stream-node/-/hash-stream-node-3.127.0.tgz",
+      "integrity": "sha512-ZCNqi+FJViYFCo8JfSx+YK0Hd/SC555gHqBe24GVBMCDqJ8UFIled7tF+GOQ8wTcKjxuwp/0EXDTXoaAb0K89g==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        }
       }
     },
     "@aws-sdk/invalid-dependency": {
@@ -498,6 +1976,142 @@
         "tslib": "^2.3.1"
       }
     },
+    "@aws-sdk/lib-storage": {
+      "version": "3.135.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/lib-storage/-/lib-storage-3.135.0.tgz",
+      "integrity": "sha512-cakqdih1SCrZHRj3fz+/EfM6I16Ryc+JOPm42ER01Ye/SReWTt2MLN/ZirAGd1NyBMwY8XcGr1MzEv3yh43ltQ==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/smithy-client": "3.127.0",
+        "buffer": "5.6.0",
+        "events": "3.3.0",
+        "stream-browserify": "3.0.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/middleware-stack": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.127.0.tgz",
+          "integrity": "sha512-S1IoUE5o1vCmjsF5nIE8zlItNOM1UE+lhmZeigF7knXJ9+a6ewMB6POAj/s4eoi0wcn0eSnAGsqJCWMSUjOPLA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.127.0.tgz",
+          "integrity": "sha512-sfcAJ+7a41CJMtsv6HRIjA91155Yk013RvMUdG2EMSo3cpLq/QmTJ1EGw4ByDZs5HLpXAaRoLI+bA2ovriGQnQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        },
+        "buffer": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+          "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.0.2",
+            "ieee754": "^1.1.4"
+          }
+        },
+        "events": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+          "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/md5-js": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/md5-js/-/md5-js-3.127.0.tgz",
+      "integrity": "sha512-9FzD++p2bvfZ56hbDxvGcLlA9JIMt9uZB/m4NEvbuvrpx1qnUpFv6HqthhGaVuhctkK25hONT5ZpOYHSisATrA==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/util-utf8-browser": "3.109.0",
+        "@aws-sdk/util-utf8-node": "3.109.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.109.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.109.0.tgz",
+          "integrity": "sha512-FmcGSz0v7Bqpl1SE8G1Gc0CtDpug+rvqNCG/szn86JApD/f5x8oByjbEiAyTU2ZH2VevUntx6EW68ulHyH+x+w==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-node": {
+          "version": "3.109.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.109.0.tgz",
+          "integrity": "sha512-Ti/ZBdvz2eSTElsucjzNmzpyg2MwfD1rXmxD0hZuIF8bPON/0+sZYnWd5CbDw9kgmhy28dmKue086tbZ1G0iLQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/util-buffer-from": "3.55.0",
+            "tslib": "^2.3.1"
+          }
+        }
+      }
+    },
+    "@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.127.0.tgz",
+      "integrity": "sha512-wJpXxWceBDhWktoxrRb4s6tMx0dWsEGYIaV0KkQPGhTPk2KMUgwa4xApfCXXVfYcE3THk486OKwHhPrR5jpe+g==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/util-arn-parser": "3.55.0",
+        "@aws-sdk/util-config-provider": "3.109.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/protocol-http": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.127.0.tgz",
+          "integrity": "sha512-UG83PVuKX40wilG2uRU0Fvz4OY8Bt+bSPOG776DFjwIXYzK7BwpJm9H2XI2HLhS5WxrJHhwrLBRgW6UiykMnFw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        },
+        "@aws-sdk/util-config-provider": {
+          "version": "3.109.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.109.0.tgz",
+          "integrity": "sha512-GrAZl/aBv0A28LkyNyq8SPJ5fmViCwz80fWLMeWx/6q5AbivuILogjlWwEZSvZ9zrlHOcFC0+AnCa5pQrjaslw==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        }
+      }
+    },
     "@aws-sdk/middleware-content-length": {
       "version": "3.58.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.58.0.tgz",
@@ -522,6 +2136,67 @@
         "tslib": "^2.3.1"
       }
     },
+    "@aws-sdk/middleware-expect-continue": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.127.0.tgz",
+      "integrity": "sha512-+X7mdgFqt9UqUDeGuMt+afR8CBX9nMecTxEIilAKdVOLx+fuXzHnC2mpddKMtiE9IGKMU4BI1Ahf7t32Odhs1Q==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/protocol-http": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.127.0.tgz",
+          "integrity": "sha512-UG83PVuKX40wilG2uRU0Fvz4OY8Bt+bSPOG776DFjwIXYzK7BwpJm9H2XI2HLhS5WxrJHhwrLBRgW6UiykMnFw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.127.0.tgz",
+      "integrity": "sha512-sXkAwhE9dikO72sEJ7DrUCo5mawauAxICCqipCCSGp0geSkptvtZHhySgJNMVSbUJQmu5bcS+zsFpFVwuJvGxg==",
+      "dev": true,
+      "requires": {
+        "@aws-crypto/crc32": "2.0.0",
+        "@aws-crypto/crc32c": "2.0.0",
+        "@aws-sdk/is-array-buffer": "3.55.0",
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/protocol-http": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.127.0.tgz",
+          "integrity": "sha512-UG83PVuKX40wilG2uRU0Fvz4OY8Bt+bSPOG776DFjwIXYzK7BwpJm9H2XI2HLhS5WxrJHhwrLBRgW6UiykMnFw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        }
+      }
+    },
     "@aws-sdk/middleware-host-header": {
       "version": "3.58.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.58.0.tgz",
@@ -533,6 +2208,24 @@
         "tslib": "^2.3.1"
       }
     },
+    "@aws-sdk/middleware-location-constraint": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.127.0.tgz",
+      "integrity": "sha512-UtPmbOKEVu+Ue7CwICFSOOOSePV8Piydco/v2IpdRkMO0e4bqQ3Tn0XprBlWWfSW4QCtAPzydrArLsUdk636GA==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        }
+      }
+    },
     "@aws-sdk/middleware-logger": {
       "version": "3.55.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.55.0.tgz",
@@ -541,6 +2234,35 @@
       "requires": {
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-recursion-detection": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.127.0.tgz",
+      "integrity": "sha512-tB6WX+Z1kUKTnn5h38XFrTCzoqPKjUZLUjN4Wb27/cbeSiTSKGAZcCXHOJm36Ukorl5arlybQTqGe689EU00Hw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/protocol-http": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.127.0.tgz",
+          "integrity": "sha512-UG83PVuKX40wilG2uRU0Fvz4OY8Bt+bSPOG776DFjwIXYzK7BwpJm9H2XI2HLhS5WxrJHhwrLBRgW6UiykMnFw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        }
       }
     },
     "@aws-sdk/middleware-retry": {
@@ -555,6 +2277,66 @@
         "@aws-sdk/util-middleware": "3.55.0",
         "tslib": "^2.3.1",
         "uuid": "^8.3.2"
+      }
+    },
+    "@aws-sdk/middleware-sdk-api-gateway": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-api-gateway/-/middleware-sdk-api-gateway-3.127.0.tgz",
+      "integrity": "sha512-RZeQ1n+DvVq1WPFUD6L01tuXJUOR5skwOZqkImWwUbFNZEmtvlhRBRMszmW8xJ55XHHZsuPfQ1yzMqfW/Z7iWg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/protocol-http": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.127.0.tgz",
+          "integrity": "sha512-UG83PVuKX40wilG2uRU0Fvz4OY8Bt+bSPOG776DFjwIXYzK7BwpJm9H2XI2HLhS5WxrJHhwrLBRgW6UiykMnFw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        }
+      }
+    },
+    "@aws-sdk/middleware-sdk-s3": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.127.0.tgz",
+      "integrity": "sha512-q1mkEN7kYYdQ3LOHIhaT56omYe8DCubyiCKOXuEo5ZiIkE5iq06K/BxWxj3f8bFZxSX80Ma1m8XA5jcOEMphSA==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/middleware-bucket-endpoint": "3.127.0",
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/util-arn-parser": "3.55.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/protocol-http": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.127.0.tgz",
+          "integrity": "sha512-UG83PVuKX40wilG2uRU0Fvz4OY8Bt+bSPOG776DFjwIXYzK7BwpJm9H2XI2HLhS5WxrJHhwrLBRgW6UiykMnFw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        }
       }
     },
     "@aws-sdk/middleware-sdk-sts": {
@@ -592,6 +2374,24 @@
         "@aws-sdk/signature-v4": "3.58.0",
         "@aws-sdk/types": "3.55.0",
         "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/middleware-ssec": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.127.0.tgz",
+      "integrity": "sha512-R5A13EvdYPdYD2Tq9eW5jqIdscyZlQykQXFEolBD2oi4pew7TZpc/5aazZC0zo9YKJ29qiUR1P4NvjcFJ7zFBg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        }
       }
     },
     "@aws-sdk/middleware-stack": {
@@ -680,6 +2480,60 @@
         "tslib": "^2.3.1"
       }
     },
+    "@aws-sdk/s3-request-presigner": {
+      "version": "3.135.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.135.0.tgz",
+      "integrity": "sha512-Fwm9Y65pvjzn++dVdkjypHs0VtNz4Rcn02A+a+uwgicmTsx//GIpp/xltOGDw3BsgsPMsQ8srsnegm4j7LW2qg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/middleware-sdk-s3": "3.127.0",
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/signature-v4-multi-region": "3.130.0",
+        "@aws-sdk/smithy-client": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/util-create-request": "3.127.0",
+        "@aws-sdk/util-format-url": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/middleware-stack": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.127.0.tgz",
+          "integrity": "sha512-S1IoUE5o1vCmjsF5nIE8zlItNOM1UE+lhmZeigF7knXJ9+a6ewMB6POAj/s4eoi0wcn0eSnAGsqJCWMSUjOPLA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.127.0.tgz",
+          "integrity": "sha512-UG83PVuKX40wilG2uRU0Fvz4OY8Bt+bSPOG776DFjwIXYzK7BwpJm9H2XI2HLhS5WxrJHhwrLBRgW6UiykMnFw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.127.0.tgz",
+          "integrity": "sha512-sfcAJ+7a41CJMtsv6HRIjA91155Yk013RvMUdG2EMSo3cpLq/QmTJ1EGw4ByDZs5HLpXAaRoLI+bA2ovriGQnQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        }
+      }
+    },
     "@aws-sdk/service-error-classification": {
       "version": "3.55.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.55.0.tgz",
@@ -709,6 +2563,135 @@
         "tslib": "^2.3.1"
       }
     },
+    "@aws-sdk/signature-v4-crt": {
+      "version": "3.130.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-crt/-/signature-v4-crt-3.130.0.tgz",
+      "integrity": "sha512-yKercmYfsnTnG6eyO4kzgwyBS9AZttWsYu/ZciOjc16ZyaDLYYDrO5dH+MSpOJZMDeyTIwT8/rZLYfroinI16w==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/is-array-buffer": "3.55.0",
+        "@aws-sdk/querystring-parser": "3.127.0",
+        "@aws-sdk/signature-v4": "3.130.0",
+        "@aws-sdk/util-hex-encoding": "3.109.0",
+        "@aws-sdk/util-middleware": "3.127.0",
+        "@aws-sdk/util-uri-escape": "3.55.0",
+        "aws-crt": "^1.12.5",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/querystring-parser": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.127.0.tgz",
+          "integrity": "sha512-Vn/Dv+PqUSepp/DzLqq0LJJD8HdPefJCnLbO5WcHCARHSGlyGlZUFEM45k/oEHpTvgMXj/ORaP3A+tLwLu0AmA==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.130.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.130.0.tgz",
+          "integrity": "sha512-g5G1a1NHL2uOoFfC2zQdZcj+wbjgBQPkx6xGdtqNKf9v2kS0n6ap5JUGEaqWE02lUlmWHsoMsS73hXtzwXaBRQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.55.0",
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-hex-encoding": "3.109.0",
+            "@aws-sdk/util-middleware": "3.127.0",
+            "@aws-sdk/util-uri-escape": "3.55.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.109.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.109.0.tgz",
+          "integrity": "sha512-s8CgTNrn3cLkrdiohfxLuOYPCanzvHn/aH5RW6DaMoeQiG5Hl9QUiP/WtdQ9QQx3xvpQFpmvxIaSBwSgFNLQxA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.127.0.tgz",
+          "integrity": "sha512-EwAPPed9TNqh+Wov2VStLn2NuJ/Wyt7IkZCbCsBuSNp3BFZ1V4gfwTjqtKCtB2LQgQ48MTgWgNCvrH0zjCSPGg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        }
+      }
+    },
+    "@aws-sdk/signature-v4-multi-region": {
+      "version": "3.130.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.130.0.tgz",
+      "integrity": "sha512-ZRRoPRoCVdkGDtjuog81pqHsSLfnXK6ELrWm4Dq8xdcHQGbEDNdYmeXARXG9yPAO42x9yIJXHNutMz5Y/P64cw==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/protocol-http": "3.127.0",
+        "@aws-sdk/signature-v4": "3.130.0",
+        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/util-arn-parser": "3.55.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/protocol-http": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.127.0.tgz",
+          "integrity": "sha512-UG83PVuKX40wilG2uRU0Fvz4OY8Bt+bSPOG776DFjwIXYzK7BwpJm9H2XI2HLhS5WxrJHhwrLBRgW6UiykMnFw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/signature-v4": {
+          "version": "3.130.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.130.0.tgz",
+          "integrity": "sha512-g5G1a1NHL2uOoFfC2zQdZcj+wbjgBQPkx6xGdtqNKf9v2kS0n6ap5JUGEaqWE02lUlmWHsoMsS73hXtzwXaBRQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/is-array-buffer": "3.55.0",
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-hex-encoding": "3.109.0",
+            "@aws-sdk/util-middleware": "3.127.0",
+            "@aws-sdk/util-uri-escape": "3.55.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.109.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.109.0.tgz",
+          "integrity": "sha512-s8CgTNrn3cLkrdiohfxLuOYPCanzvHn/aH5RW6DaMoeQiG5Hl9QUiP/WtdQ9QQx3xvpQFpmvxIaSBwSgFNLQxA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-middleware": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.127.0.tgz",
+          "integrity": "sha512-EwAPPed9TNqh+Wov2VStLn2NuJ/Wyt7IkZCbCsBuSNp3BFZ1V4gfwTjqtKCtB2LQgQ48MTgWgNCvrH0zjCSPGg==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        }
+      }
+    },
     "@aws-sdk/smithy-client": {
       "version": "3.55.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.55.0.tgz",
@@ -734,6 +2717,15 @@
       "requires": {
         "@aws-sdk/querystring-parser": "3.55.0",
         "@aws-sdk/types": "3.55.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-arn-parser": {
+      "version": "3.55.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.55.0.tgz",
+      "integrity": "sha512-76KJxp4MRWufHYWys7DFl64znr5yeJ3AIQNAPCKKw1sP0hzO7p6Kx0PaJnw9x+CPSzOrT4NbuApL6/srYhKDGg==",
+      "dev": true,
+      "requires": {
         "tslib": "^2.3.1"
       }
     },
@@ -793,6 +2785,46 @@
         "tslib": "^2.3.1"
       }
     },
+    "@aws-sdk/util-create-request": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-create-request/-/util-create-request-3.127.0.tgz",
+      "integrity": "sha512-jDSOgmgBiQp+LDl0pbaLw3m8iAvGIX5cY2x0zXfPa3rV1ChAaF+d70A5/KvR7seq0JPCXJBP+zRa11GbaCgQqg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/middleware-stack": "3.127.0",
+        "@aws-sdk/smithy-client": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/middleware-stack": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.127.0.tgz",
+          "integrity": "sha512-S1IoUE5o1vCmjsF5nIE8zlItNOM1UE+lhmZeigF7knXJ9+a6ewMB6POAj/s4eoi0wcn0eSnAGsqJCWMSUjOPLA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/smithy-client": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.127.0.tgz",
+          "integrity": "sha512-sfcAJ+7a41CJMtsv6HRIjA91155Yk013RvMUdG2EMSo3cpLq/QmTJ1EGw4ByDZs5HLpXAaRoLI+bA2ovriGQnQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/middleware-stack": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        }
+      }
+    },
     "@aws-sdk/util-defaults-mode-browser": {
       "version": "3.55.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.55.0.tgz",
@@ -828,6 +2860,36 @@
         "tslib": "^2.3.1"
       }
     },
+    "@aws-sdk/util-format-url": {
+      "version": "3.127.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.127.0.tgz",
+      "integrity": "sha512-leZeq6vxm6MSpu9Ruc5WKr7pzJ8kVXNJVerB4ixEk5KtFPPrJDw7MoEtnbnhVzhraLUnqHqYvrb6OlmkkISR+Q==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/querystring-builder": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/querystring-builder": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.127.0.tgz",
+          "integrity": "sha512-tsoyp4lLPsASPDYWsezGAHD8VJsZbjUNATNAzTCFdH6p+4SKBK83Q5kfXCzxt13M+l3oKbxxIWLvS0kVQFyltQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-uri-escape": "3.55.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        }
+      }
+    },
     "@aws-sdk/util-hex-encoding": {
       "version": "3.58.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.58.0.tgz",
@@ -853,6 +2915,153 @@
       "dev": true,
       "requires": {
         "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/util-stream-browser": {
+      "version": "3.131.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-browser/-/util-stream-browser-3.131.0.tgz",
+      "integrity": "sha512-1YFbBPDu+elIgp8z1woUfT7zM+2PAvgJiw6ljDBuAlJzsP5xMhwk0X9e+8aQ+Qe4XftA0e7y/PH0gqvjNgCx2A==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/fetch-http-handler": "3.131.0",
+        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/util-base64-browser": "3.109.0",
+        "@aws-sdk/util-hex-encoding": "3.109.0",
+        "@aws-sdk/util-utf8-browser": "3.109.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/fetch-http-handler": {
+          "version": "3.131.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.131.0.tgz",
+          "integrity": "sha512-eNxmPZQX2IUeBGWHNC7eNTekWn9VIPLYEMKJbKYUBJryxuTJ7TtLeyEK5oakUjMwP1AUvWT+CV7C+8L7uG1omQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/querystring-builder": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-base64-browser": "3.109.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.127.0.tgz",
+          "integrity": "sha512-UG83PVuKX40wilG2uRU0Fvz4OY8Bt+bSPOG776DFjwIXYzK7BwpJm9H2XI2HLhS5WxrJHhwrLBRgW6UiykMnFw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.127.0.tgz",
+          "integrity": "sha512-tsoyp4lLPsASPDYWsezGAHD8VJsZbjUNATNAzTCFdH6p+4SKBK83Q5kfXCzxt13M+l3oKbxxIWLvS0kVQFyltQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-uri-escape": "3.55.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        },
+        "@aws-sdk/util-base64-browser": {
+          "version": "3.109.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-base64-browser/-/util-base64-browser-3.109.0.tgz",
+          "integrity": "sha512-lAZ6fyDGiRLaIsKT9qh7P9FGuNyZ4gAbr1YOSQk/5mHtaTuUvxlPptZuInNM/0MPQm6lpcot00D8IWTucn4PbA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-hex-encoding": {
+          "version": "3.109.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.109.0.tgz",
+          "integrity": "sha512-s8CgTNrn3cLkrdiohfxLuOYPCanzvHn/aH5RW6DaMoeQiG5Hl9QUiP/WtdQ9QQx3xvpQFpmvxIaSBwSgFNLQxA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.109.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.109.0.tgz",
+          "integrity": "sha512-FmcGSz0v7Bqpl1SE8G1Gc0CtDpug+rvqNCG/szn86JApD/f5x8oByjbEiAyTU2ZH2VevUntx6EW68ulHyH+x+w==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        }
+      }
+    },
+    "@aws-sdk/util-stream-node": {
+      "version": "3.129.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-stream-node/-/util-stream-node-3.129.0.tgz",
+      "integrity": "sha512-1iWqsWvVXyP4JLPPPs8tBZKyzs7D5e7KctXuCtIjI+cnGOCeVLL+X4L/7KDZfV7sI2D6vONtIoTnUjMl5V/kEg==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/node-http-handler": "3.127.0",
+        "@aws-sdk/types": "3.127.0",
+        "@aws-sdk/util-buffer-from": "3.55.0",
+        "tslib": "^2.3.1"
+      },
+      "dependencies": {
+        "@aws-sdk/abort-controller": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.127.0.tgz",
+          "integrity": "sha512-G77FLYcl9egUoD3ZmR6TX94NMqBMeT53hBGrEE3uVUJV1CwfGKfaF007mPpRZnIB3avnJBQGEK6MrwlCfv2qAw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/node-http-handler": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.127.0.tgz",
+          "integrity": "sha512-pyMKvheK8eDwWLgYIRsWy8wiyhsbYYcqkZQs3Eh6upI4E8iCY7eMmhWvHYCibvsO+UjsOwa4cAMOfwnv/Z9s8A==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/abort-controller": "3.127.0",
+            "@aws-sdk/protocol-http": "3.127.0",
+            "@aws-sdk/querystring-builder": "3.127.0",
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/protocol-http": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.127.0.tgz",
+          "integrity": "sha512-UG83PVuKX40wilG2uRU0Fvz4OY8Bt+bSPOG776DFjwIXYzK7BwpJm9H2XI2HLhS5WxrJHhwrLBRgW6UiykMnFw==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/querystring-builder": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.127.0.tgz",
+          "integrity": "sha512-tsoyp4lLPsASPDYWsezGAHD8VJsZbjUNATNAzTCFdH6p+4SKBK83Q5kfXCzxt13M+l3oKbxxIWLvS0kVQFyltQ==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/types": "3.127.0",
+            "@aws-sdk/util-uri-escape": "3.55.0",
+            "tslib": "^2.3.1"
+          }
+        },
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        }
       }
     },
     "@aws-sdk/util-uri-escape": {
@@ -913,6 +3122,15 @@
       "requires": {
         "@aws-sdk/abort-controller": "3.55.0",
         "@aws-sdk/types": "3.55.0",
+        "tslib": "^2.3.1"
+      }
+    },
+    "@aws-sdk/xml-builder": {
+      "version": "3.109.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.109.0.tgz",
+      "integrity": "sha512-+aAXynnrqya1Eukz4Gxch4xIXCZolIMWGD4Ll/Q5yXT5uAjGh2HQWd9J0LWE+gYChpWetZbAVYZ3cEJ6F+SpZA==",
+      "dev": true,
+      "requires": {
         "tslib": "^2.3.1"
       }
     },
@@ -2248,31 +4466,31 @@
       "dev": true
     },
     "@cumulus/api": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/api/-/api-11.1.0.tgz",
-      "integrity": "sha512-DgyXNR0joSOyfCpdv4Ovo+T39Q6IWYqCrFu+3Ev58mRXrxcAVYF3QS8KLce7u1vTA4OkdGPNocRVf6OY7MXODA==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/api/-/api-13.1.0.tgz",
+      "integrity": "sha512-osu1vvBE/jHO8LTG9SKYtrLzvzNSWgazANzX0igzIRsDornETAG+NG7eYBt0VK290AuvOLW8tnx9so13w6OzGQ==",
       "dev": true,
       "requires": {
-        "@cumulus/api-client": "11.1.0",
-        "@cumulus/async-operations": "11.1.0",
-        "@cumulus/aws-client": "11.1.0",
-        "@cumulus/cmr-client": "11.1.0",
-        "@cumulus/cmrjs": "11.1.0",
-        "@cumulus/collection-config-store": "11.1.0",
-        "@cumulus/common": "11.1.0",
-        "@cumulus/db": "11.1.0",
-        "@cumulus/distribution-utils": "11.1.0",
-        "@cumulus/errors": "11.1.0",
-        "@cumulus/es-client": "11.1.0",
-        "@cumulus/ingest": "11.1.0",
-        "@cumulus/launchpad-auth": "11.1.0",
-        "@cumulus/logger": "11.1.0",
-        "@cumulus/message": "11.1.0",
-        "@cumulus/oauth-client": "11.1.0",
-        "@cumulus/object-store": "11.1.0",
-        "@cumulus/pvl": "11.1.0",
-        "@cumulus/sftp-client": "11.1.0",
-        "@cumulus/types": "11.1.0",
+        "@cumulus/api-client": "13.1.0",
+        "@cumulus/async-operations": "13.1.0",
+        "@cumulus/aws-client": "13.1.0",
+        "@cumulus/cmr-client": "13.1.0",
+        "@cumulus/cmrjs": "13.1.0",
+        "@cumulus/collection-config-store": "13.1.0",
+        "@cumulus/common": "13.1.0",
+        "@cumulus/db": "13.1.0",
+        "@cumulus/distribution-utils": "13.1.0",
+        "@cumulus/errors": "13.1.0",
+        "@cumulus/es-client": "13.1.0",
+        "@cumulus/ingest": "13.1.0",
+        "@cumulus/launchpad-auth": "13.1.0",
+        "@cumulus/logger": "13.1.0",
+        "@cumulus/message": "13.1.0",
+        "@cumulus/oauth-client": "13.1.0",
+        "@cumulus/object-store": "13.1.0",
+        "@cumulus/pvl": "13.1.0",
+        "@cumulus/sftp-client": "13.1.0",
+        "@cumulus/types": "13.1.0",
         "@mapbox/dyno": "^1.4.2",
         "aggregate-error": "^3.1.0",
         "ajv": "^6.12.3",
@@ -2288,7 +4506,7 @@
         "express-boom": "^3.0.0",
         "express-promise-router": "^3.0.3",
         "googleapis": "^49.0.0",
-        "got": "^11.7.0",
+        "got": "^11.8.5",
         "hsts": "^2.1.0",
         "is-valid-hostname": "1.0.2",
         "js-yaml": "^3.13.1",
@@ -2297,7 +4515,7 @@
         "jsonwebtoken": "^8.4.0",
         "knex": "0.95.15",
         "lodash": "^4.17.21",
-        "moment": "2.29.2",
+        "moment": "2.29.4",
         "morgan": "^1.9.1",
         "node-forge": "^1.3.0",
         "nodeify": "^1.0.1",
@@ -2317,19 +4535,30 @@
         "xml2js": "^0.4.22"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        },
         "@cumulus/aws-client": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-11.1.0.tgz",
-          "integrity": "sha512-bVr+axSh7QdgYhlCPg7DB0hpS3BiozQDj9piE8oxLTSvjA4HPIx8rW92PHJbwHD954XdpKOJPWHBxHUdmI2hrg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-13.1.0.tgz",
+          "integrity": "sha512-SRRRtovCDcK7j8Xfn7xlisdyy5CSFGr/SRmOnPDg9k4oivI+fd+WjylLD1oc1YkWPHEednOdL0dLn+GwfgEI+w==",
           "dev": true,
           "requires": {
-            "@aws-sdk/client-dynamodb": "^3.53.0",
-            "@aws-sdk/client-dynamodb-streams": "^3.53.0",
-            "@aws-sdk/lib-dynamodb": "^3.53.0",
-            "@aws-sdk/types": "^3.53.0",
-            "@cumulus/checksum": "11.1.0",
-            "@cumulus/errors": "11.1.0",
-            "@cumulus/logger": "11.1.0",
+            "@aws-sdk/client-api-gateway": "^3.58.0",
+            "@aws-sdk/client-dynamodb": "^3.58.0",
+            "@aws-sdk/client-dynamodb-streams": "^3.58.0",
+            "@aws-sdk/client-s3": "^3.58.0",
+            "@aws-sdk/lib-dynamodb": "^3.58.0",
+            "@aws-sdk/lib-storage": "^3.58.0",
+            "@aws-sdk/s3-request-presigner": "^3.58.0",
+            "@aws-sdk/signature-v4-crt": "^3.58.0",
+            "@aws-sdk/types": "^3.58.0",
+            "@cumulus/checksum": "13.1.0",
+            "@cumulus/errors": "13.1.0",
+            "@cumulus/logger": "13.1.0",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.21",
@@ -2338,7 +4567,8 @@
             "p-retry": "^4.2.0",
             "p-timeout": "^4.1.0",
             "p-wait-for": "^3.2.0",
-            "pump": "^3.0.0"
+            "pump": "^3.0.0",
+            "uuid": "^8.2.0"
           },
           "dependencies": {
             "p-map": {
@@ -2348,12 +4578,12 @@
               "dev": true
             },
             "p-retry": {
-              "version": "4.6.1",
-              "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
-              "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+              "version": "4.6.2",
+              "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+              "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
               "dev": true,
               "requires": {
-                "@types/retry": "^0.12.0",
+                "@types/retry": "0.12.0",
                 "retry": "^0.13.1"
               }
             },
@@ -2376,32 +4606,44 @@
                   }
                 }
               }
+            },
+            "uuid": {
+              "version": "8.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+              "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+              "dev": true
             }
           }
         },
         "@cumulus/checksum": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-11.1.0.tgz",
-          "integrity": "sha512-TlTpp5pzDwEPOxTNuF/WX5FugnY+EsS4xo3hjVUmHY40ftl5C1PyghrHPBU80Q5Nq43atsO1EcEqMtgllQMUqg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-13.1.0.tgz",
+          "integrity": "sha512-lq1CylBarr8wWChnT/gZVBDNtS2fEyBPipffjsT+3VfCXAT2muaTqO6dcw9nizRCHqhOcE0ojD911IzCl7JKLw==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-11.1.0.tgz",
-          "integrity": "sha512-iHWyBhFuKTK/wnAR77Nf0XST6WltPBSDiE54rE290E8WfamMeb5T9OASvKMkf4Mit3a/prscizImtxYbd1tnkg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-13.1.0.tgz",
+          "integrity": "sha512-DlxGN16b5V71KCNs/QEc5YObgK9MrGmS2tgxH2Bd7AYAoAXc/foNinBetHA4uH2/Z2/MZ5dsFaw3GlLCm6W63g==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-11.1.0.tgz",
-          "integrity": "sha512-5l9JR/daH5CE7IhrDm1iZJFtN6w3VLZ8O8bj+XQf9u56CNtciyUQpooScifd5RPKx4KotskPXq42JIrityhZOg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-13.1.0.tgz",
+          "integrity": "sha512-zExzgtxCe2BhoOvEJgcfffo5m60LQNM/ejJFZdNWR3dfsC16m7qkY3BCktKhyifsma6midIPSh3kXOYu0VVFCg==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
           }
+        },
+        "@types/retry": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+          "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+          "dev": true
         },
         "commander": {
           "version": "2.20.3",
@@ -2419,18 +4661,6 @@
             "jsonparse": "^1.3.1",
             "lodash.get": "^4.4.2"
           }
-        },
-        "lru-cache": {
-          "version": "7.8.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.8.0.tgz",
-          "integrity": "sha512-AmXqneQZL3KZMIgBpaPTeI6pfwh+xQ2vutMsyqOu1TBdEXFZgpG/80wuJ531w2ZN7TI0/oc8CPxzh/DKQudZqg==",
-          "dev": true
-        },
-        "moment": {
-          "version": "2.29.2",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-          "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
-          "dev": true
         },
         "p-limit": {
           "version": "1.3.0",
@@ -2450,16 +4680,16 @@
         "p-try": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
           "dev": true
         },
         "semver": {
-          "version": "7.3.6",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
-          "integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
           "dev": true,
           "requires": {
-            "lru-cache": "^7.4.0"
+            "lru-cache": "^6.0.0"
           }
         },
         "uuid": {
@@ -2471,29 +4701,40 @@
       }
     },
     "@cumulus/api-client": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/api-client/-/api-client-11.1.0.tgz",
-      "integrity": "sha512-d6QsFJI7DbyOKM6y2HBad3X1nPRnqE8lc1Yh5oj+bZ2uavup4eplZ35FlZzzoKH26LPHU2zTOXcnIOAmgsAHfA==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/api-client/-/api-client-13.1.0.tgz",
+      "integrity": "sha512-F10yhRKjF0TMqsQSB0SJpRa2ooEVLAQpNgNfTlao/UnpUfSiesus+xEu3yJ5aHyrKTldYYo5bhvX5wloFzqMNQ==",
       "dev": true,
       "requires": {
-        "@cumulus/aws-client": "11.1.0",
-        "@cumulus/logger": "11.1.0",
+        "@cumulus/aws-client": "13.1.0",
+        "@cumulus/logger": "13.1.0",
         "p-retry": "^2.0.0"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        },
         "@cumulus/aws-client": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-11.1.0.tgz",
-          "integrity": "sha512-bVr+axSh7QdgYhlCPg7DB0hpS3BiozQDj9piE8oxLTSvjA4HPIx8rW92PHJbwHD954XdpKOJPWHBxHUdmI2hrg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-13.1.0.tgz",
+          "integrity": "sha512-SRRRtovCDcK7j8Xfn7xlisdyy5CSFGr/SRmOnPDg9k4oivI+fd+WjylLD1oc1YkWPHEednOdL0dLn+GwfgEI+w==",
           "dev": true,
           "requires": {
-            "@aws-sdk/client-dynamodb": "^3.53.0",
-            "@aws-sdk/client-dynamodb-streams": "^3.53.0",
-            "@aws-sdk/lib-dynamodb": "^3.53.0",
-            "@aws-sdk/types": "^3.53.0",
-            "@cumulus/checksum": "11.1.0",
-            "@cumulus/errors": "11.1.0",
-            "@cumulus/logger": "11.1.0",
+            "@aws-sdk/client-api-gateway": "^3.58.0",
+            "@aws-sdk/client-dynamodb": "^3.58.0",
+            "@aws-sdk/client-dynamodb-streams": "^3.58.0",
+            "@aws-sdk/client-s3": "^3.58.0",
+            "@aws-sdk/lib-dynamodb": "^3.58.0",
+            "@aws-sdk/lib-storage": "^3.58.0",
+            "@aws-sdk/s3-request-presigner": "^3.58.0",
+            "@aws-sdk/signature-v4-crt": "^3.58.0",
+            "@aws-sdk/types": "^3.58.0",
+            "@cumulus/checksum": "13.1.0",
+            "@cumulus/errors": "13.1.0",
+            "@cumulus/logger": "13.1.0",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.21",
@@ -2502,44 +4743,51 @@
             "p-retry": "^4.2.0",
             "p-timeout": "^4.1.0",
             "p-wait-for": "^3.2.0",
-            "pump": "^3.0.0"
+            "pump": "^3.0.0",
+            "uuid": "^8.2.0"
           },
           "dependencies": {
             "p-retry": {
-              "version": "4.6.1",
-              "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
-              "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+              "version": "4.6.2",
+              "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+              "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
               "dev": true,
               "requires": {
-                "@types/retry": "^0.12.0",
+                "@types/retry": "0.12.0",
                 "retry": "^0.13.1"
               }
             }
           }
         },
         "@cumulus/checksum": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-11.1.0.tgz",
-          "integrity": "sha512-TlTpp5pzDwEPOxTNuF/WX5FugnY+EsS4xo3hjVUmHY40ftl5C1PyghrHPBU80Q5Nq43atsO1EcEqMtgllQMUqg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-13.1.0.tgz",
+          "integrity": "sha512-lq1CylBarr8wWChnT/gZVBDNtS2fEyBPipffjsT+3VfCXAT2muaTqO6dcw9nizRCHqhOcE0ojD911IzCl7JKLw==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-11.1.0.tgz",
-          "integrity": "sha512-iHWyBhFuKTK/wnAR77Nf0XST6WltPBSDiE54rE290E8WfamMeb5T9OASvKMkf4Mit3a/prscizImtxYbd1tnkg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-13.1.0.tgz",
+          "integrity": "sha512-DlxGN16b5V71KCNs/QEc5YObgK9MrGmS2tgxH2Bd7AYAoAXc/foNinBetHA4uH2/Z2/MZ5dsFaw3GlLCm6W63g==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-11.1.0.tgz",
-          "integrity": "sha512-5l9JR/daH5CE7IhrDm1iZJFtN6w3VLZ8O8bj+XQf9u56CNtciyUQpooScifd5RPKx4KotskPXq42JIrityhZOg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-13.1.0.tgz",
+          "integrity": "sha512-zExzgtxCe2BhoOvEJgcfffo5m60LQNM/ejJFZdNWR3dfsC16m7qkY3BCktKhyifsma6midIPSh3kXOYu0VVFCg==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
           }
+        },
+        "@types/retry": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+          "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+          "dev": true
         },
         "p-map": {
           "version": "1.2.0",
@@ -2576,33 +4824,44 @@
       }
     },
     "@cumulus/async-operations": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/async-operations/-/async-operations-11.1.0.tgz",
-      "integrity": "sha512-yZBocQYDSQA6Zc6Eku/ukAFiPd2L9nABTlGmduZVp97fgCdv33eaJch1Ai0UfOTvGoza1YzRUlY9/5r0pNF68g==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/async-operations/-/async-operations-13.1.0.tgz",
+      "integrity": "sha512-IPvQtk3sQTlzDZo11P0je5eH49pc7MSSQpLIIXaigHgUb5lfy6x8rjFg1PDVOYscpaww0gLSVj5PFmLQJZ3ZNg==",
       "dev": true,
       "requires": {
-        "@cumulus/aws-client": "11.1.0",
-        "@cumulus/db": "11.1.0",
-        "@cumulus/errors": "11.1.0",
-        "@cumulus/es-client": "11.1.0",
-        "@cumulus/types": "11.1.0",
+        "@cumulus/aws-client": "13.1.0",
+        "@cumulus/db": "13.1.0",
+        "@cumulus/errors": "13.1.0",
+        "@cumulus/es-client": "13.1.0",
+        "@cumulus/types": "13.1.0",
         "knex": "0.95.15",
         "uuid": "8.3.2"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        },
         "@cumulus/aws-client": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-11.1.0.tgz",
-          "integrity": "sha512-bVr+axSh7QdgYhlCPg7DB0hpS3BiozQDj9piE8oxLTSvjA4HPIx8rW92PHJbwHD954XdpKOJPWHBxHUdmI2hrg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-13.1.0.tgz",
+          "integrity": "sha512-SRRRtovCDcK7j8Xfn7xlisdyy5CSFGr/SRmOnPDg9k4oivI+fd+WjylLD1oc1YkWPHEednOdL0dLn+GwfgEI+w==",
           "dev": true,
           "requires": {
-            "@aws-sdk/client-dynamodb": "^3.53.0",
-            "@aws-sdk/client-dynamodb-streams": "^3.53.0",
-            "@aws-sdk/lib-dynamodb": "^3.53.0",
-            "@aws-sdk/types": "^3.53.0",
-            "@cumulus/checksum": "11.1.0",
-            "@cumulus/errors": "11.1.0",
-            "@cumulus/logger": "11.1.0",
+            "@aws-sdk/client-api-gateway": "^3.58.0",
+            "@aws-sdk/client-dynamodb": "^3.58.0",
+            "@aws-sdk/client-dynamodb-streams": "^3.58.0",
+            "@aws-sdk/client-s3": "^3.58.0",
+            "@aws-sdk/lib-dynamodb": "^3.58.0",
+            "@aws-sdk/lib-storage": "^3.58.0",
+            "@aws-sdk/s3-request-presigner": "^3.58.0",
+            "@aws-sdk/signature-v4-crt": "^3.58.0",
+            "@aws-sdk/types": "^3.58.0",
+            "@cumulus/checksum": "13.1.0",
+            "@cumulus/errors": "13.1.0",
+            "@cumulus/logger": "13.1.0",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.21",
@@ -2611,32 +4870,39 @@
             "p-retry": "^4.2.0",
             "p-timeout": "^4.1.0",
             "p-wait-for": "^3.2.0",
-            "pump": "^3.0.0"
+            "pump": "^3.0.0",
+            "uuid": "^8.2.0"
           }
         },
         "@cumulus/checksum": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-11.1.0.tgz",
-          "integrity": "sha512-TlTpp5pzDwEPOxTNuF/WX5FugnY+EsS4xo3hjVUmHY40ftl5C1PyghrHPBU80Q5Nq43atsO1EcEqMtgllQMUqg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-13.1.0.tgz",
+          "integrity": "sha512-lq1CylBarr8wWChnT/gZVBDNtS2fEyBPipffjsT+3VfCXAT2muaTqO6dcw9nizRCHqhOcE0ojD911IzCl7JKLw==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-11.1.0.tgz",
-          "integrity": "sha512-iHWyBhFuKTK/wnAR77Nf0XST6WltPBSDiE54rE290E8WfamMeb5T9OASvKMkf4Mit3a/prscizImtxYbd1tnkg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-13.1.0.tgz",
+          "integrity": "sha512-DlxGN16b5V71KCNs/QEc5YObgK9MrGmS2tgxH2Bd7AYAoAXc/foNinBetHA4uH2/Z2/MZ5dsFaw3GlLCm6W63g==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-11.1.0.tgz",
-          "integrity": "sha512-5l9JR/daH5CE7IhrDm1iZJFtN6w3VLZ8O8bj+XQf9u56CNtciyUQpooScifd5RPKx4KotskPXq42JIrityhZOg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-13.1.0.tgz",
+          "integrity": "sha512-zExzgtxCe2BhoOvEJgcfffo5m60LQNM/ejJFZdNWR3dfsC16m7qkY3BCktKhyifsma6midIPSh3kXOYu0VVFCg==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
           }
+        },
+        "@types/retry": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+          "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+          "dev": true
         },
         "p-map": {
           "version": "1.2.0",
@@ -2645,12 +4911,12 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.6.1",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
-          "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+          "version": "4.6.2",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+          "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
           "dev": true,
           "requires": {
-            "@types/retry": "^0.12.0",
+            "@types/retry": "0.12.0",
             "retry": "^0.13.1"
           }
         },
@@ -2760,33 +5026,44 @@
       }
     },
     "@cumulus/cmr-client": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/cmr-client/-/cmr-client-11.1.0.tgz",
-      "integrity": "sha512-N/+0WguWlrSul03RWulTeeJd5oLPMQtD4nFWQTkOu6yJG6xUkLIOQyNnJo7xYF4rL+HMFyB5h+qYnfskwq44aw==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/cmr-client/-/cmr-client-13.1.0.tgz",
+      "integrity": "sha512-WpEV+b7tqntDGxIGtw/qbMaT8Yv7baosrWpcY1aw0I60f7tXdbHUNQKb0WrQnd4k9g/xwhUgL5HdJlkDSlphcA==",
       "dev": true,
       "requires": {
-        "@cumulus/aws-client": "11.1.0",
-        "@cumulus/errors": "11.1.0",
-        "@cumulus/logger": "11.1.0",
-        "got": "^11.7.0",
+        "@cumulus/aws-client": "13.1.0",
+        "@cumulus/errors": "13.1.0",
+        "@cumulus/logger": "13.1.0",
+        "got": "^11.8.5",
         "lodash": "^4.17.21",
         "public-ip": "^3.0.0",
         "xml2js": "^0.4.19"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        },
         "@cumulus/aws-client": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-11.1.0.tgz",
-          "integrity": "sha512-bVr+axSh7QdgYhlCPg7DB0hpS3BiozQDj9piE8oxLTSvjA4HPIx8rW92PHJbwHD954XdpKOJPWHBxHUdmI2hrg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-13.1.0.tgz",
+          "integrity": "sha512-SRRRtovCDcK7j8Xfn7xlisdyy5CSFGr/SRmOnPDg9k4oivI+fd+WjylLD1oc1YkWPHEednOdL0dLn+GwfgEI+w==",
           "dev": true,
           "requires": {
-            "@aws-sdk/client-dynamodb": "^3.53.0",
-            "@aws-sdk/client-dynamodb-streams": "^3.53.0",
-            "@aws-sdk/lib-dynamodb": "^3.53.0",
-            "@aws-sdk/types": "^3.53.0",
-            "@cumulus/checksum": "11.1.0",
-            "@cumulus/errors": "11.1.0",
-            "@cumulus/logger": "11.1.0",
+            "@aws-sdk/client-api-gateway": "^3.58.0",
+            "@aws-sdk/client-dynamodb": "^3.58.0",
+            "@aws-sdk/client-dynamodb-streams": "^3.58.0",
+            "@aws-sdk/client-s3": "^3.58.0",
+            "@aws-sdk/lib-dynamodb": "^3.58.0",
+            "@aws-sdk/lib-storage": "^3.58.0",
+            "@aws-sdk/s3-request-presigner": "^3.58.0",
+            "@aws-sdk/signature-v4-crt": "^3.58.0",
+            "@aws-sdk/types": "^3.58.0",
+            "@cumulus/checksum": "13.1.0",
+            "@cumulus/errors": "13.1.0",
+            "@cumulus/logger": "13.1.0",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.21",
@@ -2795,32 +5072,39 @@
             "p-retry": "^4.2.0",
             "p-timeout": "^4.1.0",
             "p-wait-for": "^3.2.0",
-            "pump": "^3.0.0"
+            "pump": "^3.0.0",
+            "uuid": "^8.2.0"
           }
         },
         "@cumulus/checksum": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-11.1.0.tgz",
-          "integrity": "sha512-TlTpp5pzDwEPOxTNuF/WX5FugnY+EsS4xo3hjVUmHY40ftl5C1PyghrHPBU80Q5Nq43atsO1EcEqMtgllQMUqg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-13.1.0.tgz",
+          "integrity": "sha512-lq1CylBarr8wWChnT/gZVBDNtS2fEyBPipffjsT+3VfCXAT2muaTqO6dcw9nizRCHqhOcE0ojD911IzCl7JKLw==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-11.1.0.tgz",
-          "integrity": "sha512-iHWyBhFuKTK/wnAR77Nf0XST6WltPBSDiE54rE290E8WfamMeb5T9OASvKMkf4Mit3a/prscizImtxYbd1tnkg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-13.1.0.tgz",
+          "integrity": "sha512-DlxGN16b5V71KCNs/QEc5YObgK9MrGmS2tgxH2Bd7AYAoAXc/foNinBetHA4uH2/Z2/MZ5dsFaw3GlLCm6W63g==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-11.1.0.tgz",
-          "integrity": "sha512-5l9JR/daH5CE7IhrDm1iZJFtN6w3VLZ8O8bj+XQf9u56CNtciyUQpooScifd5RPKx4KotskPXq42JIrityhZOg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-13.1.0.tgz",
+          "integrity": "sha512-zExzgtxCe2BhoOvEJgcfffo5m60LQNM/ejJFZdNWR3dfsC16m7qkY3BCktKhyifsma6midIPSh3kXOYu0VVFCg==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
           }
+        },
+        "@types/retry": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+          "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+          "dev": true
         },
         "p-map": {
           "version": "1.2.0",
@@ -2829,12 +5113,12 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.6.1",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
-          "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+          "version": "4.6.2",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+          "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
           "dev": true,
           "requires": {
-            "@types/retry": "^0.12.0",
+            "@types/retry": "0.12.0",
             "retry": "^0.13.1"
           }
         },
@@ -2867,39 +5151,50 @@
       }
     },
     "@cumulus/cmrjs": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/cmrjs/-/cmrjs-11.1.0.tgz",
-      "integrity": "sha512-BtfKvkuwgFrLggKLnzhBblWP/qGVmsJmWNxj5rnOAR2bQ1++7xc8uqfFVT+jJJNal4daWERu+O+6PfOn8y6DEQ==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/cmrjs/-/cmrjs-13.1.0.tgz",
+      "integrity": "sha512-MwBEYokyPsb1L6AgSGQBbX6yrFpPOQTvhuWgXV1BGQM7EZ/qIbohQ2+I59Ch1uiS+B7ai5nIvTH6Iv6Q6BwNdw==",
       "dev": true,
       "requires": {
-        "@cumulus/aws-client": "11.1.0",
-        "@cumulus/cmr-client": "11.1.0",
-        "@cumulus/common": "11.1.0",
-        "@cumulus/distribution-utils": "11.1.0",
-        "@cumulus/errors": "11.1.0",
-        "@cumulus/launchpad-auth": "11.1.0",
-        "@cumulus/logger": "11.1.0",
+        "@cumulus/aws-client": "13.1.0",
+        "@cumulus/cmr-client": "13.1.0",
+        "@cumulus/common": "13.1.0",
+        "@cumulus/distribution-utils": "13.1.0",
+        "@cumulus/errors": "13.1.0",
+        "@cumulus/launchpad-auth": "13.1.0",
+        "@cumulus/logger": "13.1.0",
         "got": "^11.8.1",
         "js2xmlparser": "^4.0.0",
         "lodash": "^4.17.21",
-        "public-ip": "^3.0.0",
+        "public-ip": "^5.0.0",
         "url-join": "^1.0.0",
         "xml2js": "^0.4.19"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        },
         "@cumulus/aws-client": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-11.1.0.tgz",
-          "integrity": "sha512-bVr+axSh7QdgYhlCPg7DB0hpS3BiozQDj9piE8oxLTSvjA4HPIx8rW92PHJbwHD954XdpKOJPWHBxHUdmI2hrg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-13.1.0.tgz",
+          "integrity": "sha512-SRRRtovCDcK7j8Xfn7xlisdyy5CSFGr/SRmOnPDg9k4oivI+fd+WjylLD1oc1YkWPHEednOdL0dLn+GwfgEI+w==",
           "dev": true,
           "requires": {
-            "@aws-sdk/client-dynamodb": "^3.53.0",
-            "@aws-sdk/client-dynamodb-streams": "^3.53.0",
-            "@aws-sdk/lib-dynamodb": "^3.53.0",
-            "@aws-sdk/types": "^3.53.0",
-            "@cumulus/checksum": "11.1.0",
-            "@cumulus/errors": "11.1.0",
-            "@cumulus/logger": "11.1.0",
+            "@aws-sdk/client-api-gateway": "^3.58.0",
+            "@aws-sdk/client-dynamodb": "^3.58.0",
+            "@aws-sdk/client-dynamodb-streams": "^3.58.0",
+            "@aws-sdk/client-s3": "^3.58.0",
+            "@aws-sdk/lib-dynamodb": "^3.58.0",
+            "@aws-sdk/lib-storage": "^3.58.0",
+            "@aws-sdk/s3-request-presigner": "^3.58.0",
+            "@aws-sdk/signature-v4-crt": "^3.58.0",
+            "@aws-sdk/types": "^3.58.0",
+            "@cumulus/checksum": "13.1.0",
+            "@cumulus/errors": "13.1.0",
+            "@cumulus/logger": "13.1.0",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.21",
@@ -2908,32 +5203,103 @@
             "p-retry": "^4.2.0",
             "p-timeout": "^4.1.0",
             "p-wait-for": "^3.2.0",
-            "pump": "^3.0.0"
+            "pump": "^3.0.0",
+            "uuid": "^8.2.0"
           }
         },
         "@cumulus/checksum": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-11.1.0.tgz",
-          "integrity": "sha512-TlTpp5pzDwEPOxTNuF/WX5FugnY+EsS4xo3hjVUmHY40ftl5C1PyghrHPBU80Q5Nq43atsO1EcEqMtgllQMUqg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-13.1.0.tgz",
+          "integrity": "sha512-lq1CylBarr8wWChnT/gZVBDNtS2fEyBPipffjsT+3VfCXAT2muaTqO6dcw9nizRCHqhOcE0ojD911IzCl7JKLw==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-11.1.0.tgz",
-          "integrity": "sha512-iHWyBhFuKTK/wnAR77Nf0XST6WltPBSDiE54rE290E8WfamMeb5T9OASvKMkf4Mit3a/prscizImtxYbd1tnkg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-13.1.0.tgz",
+          "integrity": "sha512-DlxGN16b5V71KCNs/QEc5YObgK9MrGmS2tgxH2Bd7AYAoAXc/foNinBetHA4uH2/Z2/MZ5dsFaw3GlLCm6W63g==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-11.1.0.tgz",
-          "integrity": "sha512-5l9JR/daH5CE7IhrDm1iZJFtN6w3VLZ8O8bj+XQf9u56CNtciyUQpooScifd5RPKx4KotskPXq42JIrityhZOg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-13.1.0.tgz",
+          "integrity": "sha512-zExzgtxCe2BhoOvEJgcfffo5m60LQNM/ejJFZdNWR3dfsC16m7qkY3BCktKhyifsma6midIPSh3kXOYu0VVFCg==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
           }
+        },
+        "@sindresorhus/is": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.3.0.tgz",
+          "integrity": "sha512-CX6t4SYQ37lzxicAqsBtxA3OseeoVrh9cSJ5PFYam0GksYlupRfy1A+Q4aYD3zvcfECLc0zO2u+ZnR2UYKvCrw==",
+          "dev": true
+        },
+        "@szmarczak/http-timer": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+          "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
+          "dev": true,
+          "requires": {
+            "defer-to-connect": "^2.0.1"
+          }
+        },
+        "@types/retry": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+          "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+          "dev": true
+        },
+        "cacheable-lookup": {
+          "version": "6.0.4",
+          "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-6.0.4.tgz",
+          "integrity": "sha512-mbcDEZCkv2CZF4G01kr8eBd/5agkt9oCqz75tJMSIsquvRZ2sL6Hi5zGVKi/0OSC9oO1GHfJ2AV0ZIOY9vye0A==",
+          "dev": true
+        },
+        "decompress-response": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+          "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+          "dev": true,
+          "requires": {
+            "mimic-response": "^3.1.0"
+          }
+        },
+        "get-stream": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+          "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+          "dev": true
+        },
+        "http2-wrapper": {
+          "version": "2.1.11",
+          "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.1.11.tgz",
+          "integrity": "sha512-aNAk5JzLturWEUiuhAN73Jcbq96R7rTitAoXV54FYMatvihnpD2+6PUgU4ce3D/m5VDbw+F5CsyKSF176ptitQ==",
+          "dev": true,
+          "requires": {
+            "quick-lru": "^5.1.1",
+            "resolve-alpn": "^1.2.0"
+          }
+        },
+        "lowercase-keys": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+          "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+          "dev": true
+        },
+        "mimic-response": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+          "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+          "dev": true
+        },
+        "p-cancelable": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+          "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
+          "dev": true
         },
         "p-map": {
           "version": "1.2.0",
@@ -2942,12 +5308,12 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.6.1",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
-          "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+          "version": "4.6.2",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+          "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
           "dev": true,
           "requires": {
-            "@types/retry": "^0.12.0",
+            "@types/retry": "0.12.0",
             "retry": "^0.13.1"
           }
         },
@@ -2977,38 +5343,83 @@
             }
           }
         },
+        "public-ip": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/public-ip/-/public-ip-5.0.0.tgz",
+          "integrity": "sha512-xaH3pZMni/R2BG7ZXXaWS9Wc9wFlhyDVJF47IJ+3ali0TGv+2PsckKxbmo+rnx3ZxiV2wblVhtdS3bohAP6GGw==",
+          "dev": true,
+          "requires": {
+            "dns-socket": "^4.2.2",
+            "got": "^12.0.0",
+            "is-ip": "^3.1.0"
+          },
+          "dependencies": {
+            "got": {
+              "version": "12.2.0",
+              "resolved": "https://registry.npmjs.org/got/-/got-12.2.0.tgz",
+              "integrity": "sha512-A81ll5Z8wzeCmSdIlWVMDWFKDo82v2nmOaMZDQNHKGInNqDBcle+CSb6BBiZcn/Aiefz/kSpo520WBKi9QAO/A==",
+              "dev": true,
+              "requires": {
+                "@sindresorhus/is": "^5.2.0",
+                "@szmarczak/http-timer": "^5.0.1",
+                "@types/cacheable-request": "^6.0.2",
+                "@types/responselike": "^1.0.0",
+                "cacheable-lookup": "^6.0.4",
+                "cacheable-request": "^7.0.2",
+                "decompress-response": "^6.0.0",
+                "form-data-encoder": "^2.0.1",
+                "get-stream": "^6.0.1",
+                "http2-wrapper": "^2.1.10",
+                "lowercase-keys": "^3.0.0",
+                "p-cancelable": "^3.0.0",
+                "responselike": "^2.0.0"
+              }
+            }
+          }
+        },
         "url-join": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
-          "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=",
+          "integrity": "sha512-zz1wZk4Lb5PTVwZ3HWDmm8XnlPvmOof6/fjdDPA5yBrUcbtV64U6bV832Zf1BtU2WkBBWaUT46wCs+l0HP5nhg==",
           "dev": true
         }
       }
     },
     "@cumulus/collection-config-store": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/collection-config-store/-/collection-config-store-11.1.0.tgz",
-      "integrity": "sha512-vqinnDsCQtkNv6BylOr/6NJn2fn1vPu0UIGXht2Sznrcvrf5KWDfAglV9R+z4+rEIIPbytpCA+cKBv2rVB8cAg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/collection-config-store/-/collection-config-store-13.1.0.tgz",
+      "integrity": "sha512-zhdNaGju+Nb2w9kyEARkJc6pe7NZDPgEmTcYiMR6VfHjyenxoi5Ui43RynTQO4JcBAxCj9dTfnrB8gnLOfRLWg==",
       "dev": true,
       "requires": {
-        "@cumulus/aws-client": "11.1.0",
-        "@cumulus/common": "11.1.0",
-        "@cumulus/message": "11.1.0"
+        "@cumulus/aws-client": "13.1.0",
+        "@cumulus/common": "13.1.0",
+        "@cumulus/message": "13.1.0"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        },
         "@cumulus/aws-client": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-11.1.0.tgz",
-          "integrity": "sha512-bVr+axSh7QdgYhlCPg7DB0hpS3BiozQDj9piE8oxLTSvjA4HPIx8rW92PHJbwHD954XdpKOJPWHBxHUdmI2hrg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-13.1.0.tgz",
+          "integrity": "sha512-SRRRtovCDcK7j8Xfn7xlisdyy5CSFGr/SRmOnPDg9k4oivI+fd+WjylLD1oc1YkWPHEednOdL0dLn+GwfgEI+w==",
           "dev": true,
           "requires": {
-            "@aws-sdk/client-dynamodb": "^3.53.0",
-            "@aws-sdk/client-dynamodb-streams": "^3.53.0",
-            "@aws-sdk/lib-dynamodb": "^3.53.0",
-            "@aws-sdk/types": "^3.53.0",
-            "@cumulus/checksum": "11.1.0",
-            "@cumulus/errors": "11.1.0",
-            "@cumulus/logger": "11.1.0",
+            "@aws-sdk/client-api-gateway": "^3.58.0",
+            "@aws-sdk/client-dynamodb": "^3.58.0",
+            "@aws-sdk/client-dynamodb-streams": "^3.58.0",
+            "@aws-sdk/client-s3": "^3.58.0",
+            "@aws-sdk/lib-dynamodb": "^3.58.0",
+            "@aws-sdk/lib-storage": "^3.58.0",
+            "@aws-sdk/s3-request-presigner": "^3.58.0",
+            "@aws-sdk/signature-v4-crt": "^3.58.0",
+            "@aws-sdk/types": "^3.58.0",
+            "@cumulus/checksum": "13.1.0",
+            "@cumulus/errors": "13.1.0",
+            "@cumulus/logger": "13.1.0",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.21",
@@ -3017,32 +5428,39 @@
             "p-retry": "^4.2.0",
             "p-timeout": "^4.1.0",
             "p-wait-for": "^3.2.0",
-            "pump": "^3.0.0"
+            "pump": "^3.0.0",
+            "uuid": "^8.2.0"
           }
         },
         "@cumulus/checksum": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-11.1.0.tgz",
-          "integrity": "sha512-TlTpp5pzDwEPOxTNuF/WX5FugnY+EsS4xo3hjVUmHY40ftl5C1PyghrHPBU80Q5Nq43atsO1EcEqMtgllQMUqg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-13.1.0.tgz",
+          "integrity": "sha512-lq1CylBarr8wWChnT/gZVBDNtS2fEyBPipffjsT+3VfCXAT2muaTqO6dcw9nizRCHqhOcE0ojD911IzCl7JKLw==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-11.1.0.tgz",
-          "integrity": "sha512-iHWyBhFuKTK/wnAR77Nf0XST6WltPBSDiE54rE290E8WfamMeb5T9OASvKMkf4Mit3a/prscizImtxYbd1tnkg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-13.1.0.tgz",
+          "integrity": "sha512-DlxGN16b5V71KCNs/QEc5YObgK9MrGmS2tgxH2Bd7AYAoAXc/foNinBetHA4uH2/Z2/MZ5dsFaw3GlLCm6W63g==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-11.1.0.tgz",
-          "integrity": "sha512-5l9JR/daH5CE7IhrDm1iZJFtN6w3VLZ8O8bj+XQf9u56CNtciyUQpooScifd5RPKx4KotskPXq42JIrityhZOg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-13.1.0.tgz",
+          "integrity": "sha512-zExzgtxCe2BhoOvEJgcfffo5m60LQNM/ejJFZdNWR3dfsC16m7qkY3BCktKhyifsma6midIPSh3kXOYu0VVFCg==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
           }
+        },
+        "@types/retry": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+          "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+          "dev": true
         },
         "p-map": {
           "version": "1.2.0",
@@ -3051,12 +5469,12 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.6.1",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
-          "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+          "version": "4.6.2",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+          "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
           "dev": true,
           "requires": {
-            "@types/retry": "^0.12.0",
+            "@types/retry": "0.12.0",
             "retry": "^0.13.1"
           }
         },
@@ -3089,13 +5507,16 @@
       }
     },
     "@cumulus/common": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/common/-/common-11.1.0.tgz",
-      "integrity": "sha512-pBY4x9m4FqQ9Apj5XOIScmQUiJUl49sG5M9foflnXBHTbUOUIEVTM2fg+tG/jxUnTLfy8+oiKIAUVmpRJh7/Xg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/common/-/common-13.1.0.tgz",
+      "integrity": "sha512-7idOKtahWB7fr++XAwJfsugoKWRN2Ffjnxaa1W+CHCWvEOhO40K6/xS7Dq44oQJlZypqhAyHjeNA/caYstBiOA==",
       "dev": true,
       "requires": {
-        "@cumulus/errors": "11.1.0",
-        "@cumulus/logger": "11.1.0",
+        "@aws-sdk/client-s3": "^3.58.0",
+        "@aws-sdk/signature-v4-crt": "^3.58.0",
+        "@cumulus/aws-client": "13.1.0",
+        "@cumulus/errors": "13.1.0",
+        "@cumulus/logger": "13.1.0",
         "ajv": "^6.12.3",
         "aws-sdk": "^2.585.0",
         "follow-redirects": "^1.2.4",
@@ -3113,20 +5534,85 @@
         "uuid": "^3.2.1"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        },
+        "@cumulus/aws-client": {
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-13.1.0.tgz",
+          "integrity": "sha512-SRRRtovCDcK7j8Xfn7xlisdyy5CSFGr/SRmOnPDg9k4oivI+fd+WjylLD1oc1YkWPHEednOdL0dLn+GwfgEI+w==",
+          "dev": true,
+          "requires": {
+            "@aws-sdk/client-api-gateway": "^3.58.0",
+            "@aws-sdk/client-dynamodb": "^3.58.0",
+            "@aws-sdk/client-dynamodb-streams": "^3.58.0",
+            "@aws-sdk/client-s3": "^3.58.0",
+            "@aws-sdk/lib-dynamodb": "^3.58.0",
+            "@aws-sdk/lib-storage": "^3.58.0",
+            "@aws-sdk/s3-request-presigner": "^3.58.0",
+            "@aws-sdk/signature-v4-crt": "^3.58.0",
+            "@aws-sdk/types": "^3.58.0",
+            "@cumulus/checksum": "13.1.0",
+            "@cumulus/errors": "13.1.0",
+            "@cumulus/logger": "13.1.0",
+            "aws-sdk": "^2.585.0",
+            "jsonpath-plus": "^1.1.0",
+            "lodash": "~4.17.21",
+            "mem": "^8.0.2",
+            "p-map": "^1.2.0",
+            "p-retry": "^4.2.0",
+            "p-timeout": "^4.1.0",
+            "p-wait-for": "^3.2.0",
+            "pump": "^3.0.0",
+            "uuid": "^8.2.0"
+          },
+          "dependencies": {
+            "jsonpath-plus": {
+              "version": "1.1.0",
+              "resolved": "https://registry.npmjs.org/jsonpath-plus/-/jsonpath-plus-1.1.0.tgz",
+              "integrity": "sha512-ydqTBOuLcFCUr9e7AxJlKCFgxzEQ03HjnIim0hJSdk2NxD8MOsaMOrRgP6XWEm5q3VuDY5+cRT1DM9vLlGo/qA==",
+              "dev": true
+            },
+            "uuid": {
+              "version": "8.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+              "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+              "dev": true
+            }
+          }
+        },
+        "@cumulus/checksum": {
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-13.1.0.tgz",
+          "integrity": "sha512-lq1CylBarr8wWChnT/gZVBDNtS2fEyBPipffjsT+3VfCXAT2muaTqO6dcw9nizRCHqhOcE0ojD911IzCl7JKLw==",
+          "dev": true,
+          "requires": {
+            "cksum": "^1.3.0"
+          }
+        },
         "@cumulus/errors": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-11.1.0.tgz",
-          "integrity": "sha512-iHWyBhFuKTK/wnAR77Nf0XST6WltPBSDiE54rE290E8WfamMeb5T9OASvKMkf4Mit3a/prscizImtxYbd1tnkg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-13.1.0.tgz",
+          "integrity": "sha512-DlxGN16b5V71KCNs/QEc5YObgK9MrGmS2tgxH2Bd7AYAoAXc/foNinBetHA4uH2/Z2/MZ5dsFaw3GlLCm6W63g==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-11.1.0.tgz",
-          "integrity": "sha512-5l9JR/daH5CE7IhrDm1iZJFtN6w3VLZ8O8bj+XQf9u56CNtciyUQpooScifd5RPKx4KotskPXq42JIrityhZOg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-13.1.0.tgz",
+          "integrity": "sha512-zExzgtxCe2BhoOvEJgcfffo5m60LQNM/ejJFZdNWR3dfsC16m7qkY3BCktKhyifsma6midIPSh3kXOYu0VVFCg==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
           }
+        },
+        "@types/retry": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+          "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+          "dev": true
         },
         "fs-extra": {
           "version": "5.0.0",
@@ -3142,7 +5628,7 @@
         "jsonfile": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6"
@@ -3170,13 +5656,39 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.6.1",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
-          "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+          "version": "4.6.2",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+          "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
           "dev": true,
           "requires": {
-            "@types/retry": "^0.12.0",
+            "@types/retry": "0.12.0",
             "retry": "^0.13.1"
+          }
+        },
+        "p-timeout": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-4.1.0.tgz",
+          "integrity": "sha512-+/wmHtzJuWii1sXn3HCuH/FTwGhrp4tmJTxSKJbfS+vkipci6osxXM5mY0jUiRzWKMTgUT8l7HFbeSwZAynqHw==",
+          "dev": true
+        },
+        "p-wait-for": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/p-wait-for/-/p-wait-for-3.2.0.tgz",
+          "integrity": "sha512-wpgERjNkLrBiFmkMEjuZJEWKKDrNfHCKA1OhyN1wg1FrLkULbviEy6py1AyJUgZ72YWFbZ38FIpnqvVqAlDUwA==",
+          "dev": true,
+          "requires": {
+            "p-timeout": "^3.0.0"
+          },
+          "dependencies": {
+            "p-timeout": {
+              "version": "3.2.0",
+              "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+              "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+              "dev": true,
+              "requires": {
+                "p-finally": "^1.0.0"
+              }
+            }
           }
         },
         "universalify": {
@@ -3194,17 +5706,17 @@
       }
     },
     "@cumulus/db": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/db/-/db-11.1.0.tgz",
-      "integrity": "sha512-kNPWF9mmlVYjG+OMXaYvgSq8VMppu9+2wYhvQ60it6AeMtM71Tyj6Pc8fMneQJhvcbuBdni5hsuETUwO9WeWNQ==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/db/-/db-13.1.0.tgz",
+      "integrity": "sha512-tYMbHHNyz/FbHXvnYGlz1kSzN4YtYwA8AXCgr5ZBfdpWETvonLqMQyBWq2eZ+3WVq6MtzS9swNdfwW9CbtcUOw==",
       "dev": true,
       "requires": {
-        "@cumulus/aws-client": "11.1.0",
-        "@cumulus/common": "11.1.0",
-        "@cumulus/errors": "11.1.0",
-        "@cumulus/logger": "11.1.0",
-        "@cumulus/message": "11.1.0",
-        "@cumulus/types": "11.1.0",
+        "@cumulus/aws-client": "13.1.0",
+        "@cumulus/common": "13.1.0",
+        "@cumulus/errors": "13.1.0",
+        "@cumulus/logger": "13.1.0",
+        "@cumulus/message": "13.1.0",
+        "@cumulus/types": "13.1.0",
         "crypto-random-string": "^3.2.0",
         "is-valid-hostname": "1.0.2",
         "knex": "0.95.15",
@@ -3214,19 +5726,30 @@
         "uuid": "8.3.2"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        },
         "@cumulus/aws-client": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-11.1.0.tgz",
-          "integrity": "sha512-bVr+axSh7QdgYhlCPg7DB0hpS3BiozQDj9piE8oxLTSvjA4HPIx8rW92PHJbwHD954XdpKOJPWHBxHUdmI2hrg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-13.1.0.tgz",
+          "integrity": "sha512-SRRRtovCDcK7j8Xfn7xlisdyy5CSFGr/SRmOnPDg9k4oivI+fd+WjylLD1oc1YkWPHEednOdL0dLn+GwfgEI+w==",
           "dev": true,
           "requires": {
-            "@aws-sdk/client-dynamodb": "^3.53.0",
-            "@aws-sdk/client-dynamodb-streams": "^3.53.0",
-            "@aws-sdk/lib-dynamodb": "^3.53.0",
-            "@aws-sdk/types": "^3.53.0",
-            "@cumulus/checksum": "11.1.0",
-            "@cumulus/errors": "11.1.0",
-            "@cumulus/logger": "11.1.0",
+            "@aws-sdk/client-api-gateway": "^3.58.0",
+            "@aws-sdk/client-dynamodb": "^3.58.0",
+            "@aws-sdk/client-dynamodb-streams": "^3.58.0",
+            "@aws-sdk/client-s3": "^3.58.0",
+            "@aws-sdk/lib-dynamodb": "^3.58.0",
+            "@aws-sdk/lib-storage": "^3.58.0",
+            "@aws-sdk/s3-request-presigner": "^3.58.0",
+            "@aws-sdk/signature-v4-crt": "^3.58.0",
+            "@aws-sdk/types": "^3.58.0",
+            "@cumulus/checksum": "13.1.0",
+            "@cumulus/errors": "13.1.0",
+            "@cumulus/logger": "13.1.0",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.21",
@@ -3235,32 +5758,39 @@
             "p-retry": "^4.2.0",
             "p-timeout": "^4.1.0",
             "p-wait-for": "^3.2.0",
-            "pump": "^3.0.0"
+            "pump": "^3.0.0",
+            "uuid": "^8.2.0"
           }
         },
         "@cumulus/checksum": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-11.1.0.tgz",
-          "integrity": "sha512-TlTpp5pzDwEPOxTNuF/WX5FugnY+EsS4xo3hjVUmHY40ftl5C1PyghrHPBU80Q5Nq43atsO1EcEqMtgllQMUqg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-13.1.0.tgz",
+          "integrity": "sha512-lq1CylBarr8wWChnT/gZVBDNtS2fEyBPipffjsT+3VfCXAT2muaTqO6dcw9nizRCHqhOcE0ojD911IzCl7JKLw==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-11.1.0.tgz",
-          "integrity": "sha512-iHWyBhFuKTK/wnAR77Nf0XST6WltPBSDiE54rE290E8WfamMeb5T9OASvKMkf4Mit3a/prscizImtxYbd1tnkg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-13.1.0.tgz",
+          "integrity": "sha512-DlxGN16b5V71KCNs/QEc5YObgK9MrGmS2tgxH2Bd7AYAoAXc/foNinBetHA4uH2/Z2/MZ5dsFaw3GlLCm6W63g==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-11.1.0.tgz",
-          "integrity": "sha512-5l9JR/daH5CE7IhrDm1iZJFtN6w3VLZ8O8bj+XQf9u56CNtciyUQpooScifd5RPKx4KotskPXq42JIrityhZOg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-13.1.0.tgz",
+          "integrity": "sha512-zExzgtxCe2BhoOvEJgcfffo5m60LQNM/ejJFZdNWR3dfsC16m7qkY3BCktKhyifsma6midIPSh3kXOYu0VVFCg==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
           }
+        },
+        "@types/retry": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+          "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+          "dev": true
         },
         "p-map": {
           "version": "1.2.0",
@@ -3269,12 +5799,12 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.6.1",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
-          "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+          "version": "4.6.2",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+          "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
           "dev": true,
           "requires": {
-            "@types/retry": "^0.12.0",
+            "@types/retry": "0.12.0",
             "retry": "^0.13.1"
           }
         },
@@ -3307,30 +5837,41 @@
       }
     },
     "@cumulus/distribution-utils": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/distribution-utils/-/distribution-utils-11.1.0.tgz",
-      "integrity": "sha512-2td2TTv06hAdhls5gPP8DdTv2vX7iKgwcLAhf2/bytW+822BtKKR2EFIXg/gtXMEKBlAwS1IpWejRzGYyX1i3g==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/distribution-utils/-/distribution-utils-13.1.0.tgz",
+      "integrity": "sha512-qzhXGtM0mSxZtE9GZErezZvW6z4AD37eylbNjBOCHQyEX6Mko9hSMt3OEkSksNqnI5oOz7kJoV7BpgKrxwPi6Q==",
       "dev": true,
       "requires": {
-        "@cumulus/aws-client": "11.1.0",
-        "@cumulus/common": "11.1.0",
-        "@cumulus/errors": "11.1.0",
+        "@cumulus/aws-client": "13.1.0",
+        "@cumulus/common": "13.1.0",
+        "@cumulus/errors": "13.1.0",
         "url-join": "^1.1.0"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        },
         "@cumulus/aws-client": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-11.1.0.tgz",
-          "integrity": "sha512-bVr+axSh7QdgYhlCPg7DB0hpS3BiozQDj9piE8oxLTSvjA4HPIx8rW92PHJbwHD954XdpKOJPWHBxHUdmI2hrg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-13.1.0.tgz",
+          "integrity": "sha512-SRRRtovCDcK7j8Xfn7xlisdyy5CSFGr/SRmOnPDg9k4oivI+fd+WjylLD1oc1YkWPHEednOdL0dLn+GwfgEI+w==",
           "dev": true,
           "requires": {
-            "@aws-sdk/client-dynamodb": "^3.53.0",
-            "@aws-sdk/client-dynamodb-streams": "^3.53.0",
-            "@aws-sdk/lib-dynamodb": "^3.53.0",
-            "@aws-sdk/types": "^3.53.0",
-            "@cumulus/checksum": "11.1.0",
-            "@cumulus/errors": "11.1.0",
-            "@cumulus/logger": "11.1.0",
+            "@aws-sdk/client-api-gateway": "^3.58.0",
+            "@aws-sdk/client-dynamodb": "^3.58.0",
+            "@aws-sdk/client-dynamodb-streams": "^3.58.0",
+            "@aws-sdk/client-s3": "^3.58.0",
+            "@aws-sdk/lib-dynamodb": "^3.58.0",
+            "@aws-sdk/lib-storage": "^3.58.0",
+            "@aws-sdk/s3-request-presigner": "^3.58.0",
+            "@aws-sdk/signature-v4-crt": "^3.58.0",
+            "@aws-sdk/types": "^3.58.0",
+            "@cumulus/checksum": "13.1.0",
+            "@cumulus/errors": "13.1.0",
+            "@cumulus/logger": "13.1.0",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.21",
@@ -3339,32 +5880,39 @@
             "p-retry": "^4.2.0",
             "p-timeout": "^4.1.0",
             "p-wait-for": "^3.2.0",
-            "pump": "^3.0.0"
+            "pump": "^3.0.0",
+            "uuid": "^8.2.0"
           }
         },
         "@cumulus/checksum": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-11.1.0.tgz",
-          "integrity": "sha512-TlTpp5pzDwEPOxTNuF/WX5FugnY+EsS4xo3hjVUmHY40ftl5C1PyghrHPBU80Q5Nq43atsO1EcEqMtgllQMUqg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-13.1.0.tgz",
+          "integrity": "sha512-lq1CylBarr8wWChnT/gZVBDNtS2fEyBPipffjsT+3VfCXAT2muaTqO6dcw9nizRCHqhOcE0ojD911IzCl7JKLw==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-11.1.0.tgz",
-          "integrity": "sha512-iHWyBhFuKTK/wnAR77Nf0XST6WltPBSDiE54rE290E8WfamMeb5T9OASvKMkf4Mit3a/prscizImtxYbd1tnkg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-13.1.0.tgz",
+          "integrity": "sha512-DlxGN16b5V71KCNs/QEc5YObgK9MrGmS2tgxH2Bd7AYAoAXc/foNinBetHA4uH2/Z2/MZ5dsFaw3GlLCm6W63g==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-11.1.0.tgz",
-          "integrity": "sha512-5l9JR/daH5CE7IhrDm1iZJFtN6w3VLZ8O8bj+XQf9u56CNtciyUQpooScifd5RPKx4KotskPXq42JIrityhZOg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-13.1.0.tgz",
+          "integrity": "sha512-zExzgtxCe2BhoOvEJgcfffo5m60LQNM/ejJFZdNWR3dfsC16m7qkY3BCktKhyifsma6midIPSh3kXOYu0VVFCg==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
           }
+        },
+        "@types/retry": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+          "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+          "dev": true
         },
         "p-map": {
           "version": "1.2.0",
@@ -3373,12 +5921,12 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.6.1",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
-          "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+          "version": "4.6.2",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+          "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
           "dev": true,
           "requires": {
-            "@types/retry": "^0.12.0",
+            "@types/retry": "0.12.0",
             "retry": "^0.13.1"
           }
         },
@@ -3411,7 +5959,7 @@
         "url-join": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/url-join/-/url-join-1.1.0.tgz",
-          "integrity": "sha1-dBxsL0WWxIMNZxhGCSDQySIC3Hg=",
+          "integrity": "sha512-zz1wZk4Lb5PTVwZ3HWDmm8XnlPvmOof6/fjdDPA5yBrUcbtV64U6bV832Zf1BtU2WkBBWaUT46wCs+l0HP5nhg==",
           "dev": true
         }
       }
@@ -3423,43 +5971,37 @@
       "dev": true
     },
     "@cumulus/es-client": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/es-client/-/es-client-11.1.0.tgz",
-      "integrity": "sha512-+EBBAweaQIEmIYh2FWte9bXKne7HsYhRhRDxZcQ6Qf95T/7ivnDUG1YO5A/nw/5K5eW4mRuM2f9P6lyFBLuU9w==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/es-client/-/es-client-13.1.0.tgz",
+      "integrity": "sha512-A6ncL7+vjwszy3IUIf8/GwEJflseMIpvmMN50O8DmvLFmncaygp8DbKsz7ZsVLZuHVyJofp+0kepOrhzG1yxHA==",
       "dev": true,
       "requires": {
-        "@cumulus/common": "11.1.0",
-        "@cumulus/errors": "11.1.0",
-        "@cumulus/logger": "11.1.0",
-        "@cumulus/message": "11.1.0",
+        "@cumulus/common": "13.1.0",
+        "@cumulus/errors": "13.1.0",
+        "@cumulus/logger": "13.1.0",
+        "@cumulus/message": "13.1.0",
         "@elastic/elasticsearch": "^5.6.20",
         "aws-elasticsearch-connector": "8.2.0",
         "aws-sdk": "^2.585.0",
         "lodash": "~4.17.21",
-        "moment": "2.29.2",
+        "moment": "2.29.4",
         "p-limit": "^1.2.0"
       },
       "dependencies": {
         "@cumulus/errors": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-11.1.0.tgz",
-          "integrity": "sha512-iHWyBhFuKTK/wnAR77Nf0XST6WltPBSDiE54rE290E8WfamMeb5T9OASvKMkf4Mit3a/prscizImtxYbd1tnkg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-13.1.0.tgz",
+          "integrity": "sha512-DlxGN16b5V71KCNs/QEc5YObgK9MrGmS2tgxH2Bd7AYAoAXc/foNinBetHA4uH2/Z2/MZ5dsFaw3GlLCm6W63g==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-11.1.0.tgz",
-          "integrity": "sha512-5l9JR/daH5CE7IhrDm1iZJFtN6w3VLZ8O8bj+XQf9u56CNtciyUQpooScifd5RPKx4KotskPXq42JIrityhZOg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-13.1.0.tgz",
+          "integrity": "sha512-zExzgtxCe2BhoOvEJgcfffo5m60LQNM/ejJFZdNWR3dfsC16m7qkY3BCktKhyifsma6midIPSh3kXOYu0VVFCg==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
           }
-        },
-        "moment": {
-          "version": "2.29.2",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-          "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
-          "dev": true
         },
         "p-limit": {
           "version": "1.3.0",
@@ -3473,53 +6015,64 @@
         "p-try": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
-          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "integrity": "sha512-U1etNYuMJoIz3ZXSrrySFjsXQTWOx2/jdi86L+2pRvph/qMKL6sbcCYdH23fqsbm8TH2Gn0OybpT4eSFlCVHww==",
           "dev": true
         }
       }
     },
     "@cumulus/ingest": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/ingest/-/ingest-11.1.0.tgz",
-      "integrity": "sha512-DZI1T8N7GUKPWQOII7jVsYpRWyTPiILE5lccy3qDQSY4+QdmpDomJa8hEnJLOTygPr546nGqeNMkpEVY0lLuqg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/ingest/-/ingest-13.1.0.tgz",
+      "integrity": "sha512-dR6WvPpkgKkgcEZZlIwqe28YtzONjLYJ7LbUuJooS1oPoVnWMCYekQU87axuiUiHWD2n5iig34hxVbl8Wk2dNg==",
       "dev": true,
       "requires": {
-        "@cumulus/aws-client": "11.1.0",
-        "@cumulus/common": "11.1.0",
-        "@cumulus/db": "11.1.0",
-        "@cumulus/errors": "11.1.0",
-        "@cumulus/logger": "11.1.0",
-        "@cumulus/message": "11.1.0",
-        "@cumulus/sftp-client": "11.1.0",
+        "@cumulus/aws-client": "13.1.0",
+        "@cumulus/common": "13.1.0",
+        "@cumulus/db": "13.1.0",
+        "@cumulus/errors": "13.1.0",
+        "@cumulus/logger": "13.1.0",
+        "@cumulus/message": "13.1.0",
+        "@cumulus/sftp-client": "13.1.0",
         "aws-sdk": "^2.585.0",
         "cksum": "^1.3.0",
         "delay": "^4.3.0",
         "encodeurl": "^1.0.2",
         "fs-extra": "^5.0.0",
-        "got": "^11.7.0",
+        "got": "^11.8.5",
         "is-ip": "^2.0.0",
         "is-valid-hostname": "^0.1.1",
         "jsftp": "git+https://github.com/jkovarik/jsftp.git#add_288",
         "lodash": "^4.17.21",
         "mime-types": "^2.1.22",
-        "moment": "2.29.2",
+        "moment": "2.29.4",
         "simplecrawler": "^1.1.9",
         "tough-cookie": "^4.0.0"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        },
         "@cumulus/aws-client": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-11.1.0.tgz",
-          "integrity": "sha512-bVr+axSh7QdgYhlCPg7DB0hpS3BiozQDj9piE8oxLTSvjA4HPIx8rW92PHJbwHD954XdpKOJPWHBxHUdmI2hrg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-13.1.0.tgz",
+          "integrity": "sha512-SRRRtovCDcK7j8Xfn7xlisdyy5CSFGr/SRmOnPDg9k4oivI+fd+WjylLD1oc1YkWPHEednOdL0dLn+GwfgEI+w==",
           "dev": true,
           "requires": {
-            "@aws-sdk/client-dynamodb": "^3.53.0",
-            "@aws-sdk/client-dynamodb-streams": "^3.53.0",
-            "@aws-sdk/lib-dynamodb": "^3.53.0",
-            "@aws-sdk/types": "^3.53.0",
-            "@cumulus/checksum": "11.1.0",
-            "@cumulus/errors": "11.1.0",
-            "@cumulus/logger": "11.1.0",
+            "@aws-sdk/client-api-gateway": "^3.58.0",
+            "@aws-sdk/client-dynamodb": "^3.58.0",
+            "@aws-sdk/client-dynamodb-streams": "^3.58.0",
+            "@aws-sdk/client-s3": "^3.58.0",
+            "@aws-sdk/lib-dynamodb": "^3.58.0",
+            "@aws-sdk/lib-storage": "^3.58.0",
+            "@aws-sdk/s3-request-presigner": "^3.58.0",
+            "@aws-sdk/signature-v4-crt": "^3.58.0",
+            "@aws-sdk/types": "^3.58.0",
+            "@cumulus/checksum": "13.1.0",
+            "@cumulus/errors": "13.1.0",
+            "@cumulus/logger": "13.1.0",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.21",
@@ -3528,32 +6081,39 @@
             "p-retry": "^4.2.0",
             "p-timeout": "^4.1.0",
             "p-wait-for": "^3.2.0",
-            "pump": "^3.0.0"
+            "pump": "^3.0.0",
+            "uuid": "^8.2.0"
           }
         },
         "@cumulus/checksum": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-11.1.0.tgz",
-          "integrity": "sha512-TlTpp5pzDwEPOxTNuF/WX5FugnY+EsS4xo3hjVUmHY40ftl5C1PyghrHPBU80Q5Nq43atsO1EcEqMtgllQMUqg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-13.1.0.tgz",
+          "integrity": "sha512-lq1CylBarr8wWChnT/gZVBDNtS2fEyBPipffjsT+3VfCXAT2muaTqO6dcw9nizRCHqhOcE0ojD911IzCl7JKLw==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-11.1.0.tgz",
-          "integrity": "sha512-iHWyBhFuKTK/wnAR77Nf0XST6WltPBSDiE54rE290E8WfamMeb5T9OASvKMkf4Mit3a/prscizImtxYbd1tnkg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-13.1.0.tgz",
+          "integrity": "sha512-DlxGN16b5V71KCNs/QEc5YObgK9MrGmS2tgxH2Bd7AYAoAXc/foNinBetHA4uH2/Z2/MZ5dsFaw3GlLCm6W63g==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-11.1.0.tgz",
-          "integrity": "sha512-5l9JR/daH5CE7IhrDm1iZJFtN6w3VLZ8O8bj+XQf9u56CNtciyUQpooScifd5RPKx4KotskPXq42JIrityhZOg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-13.1.0.tgz",
+          "integrity": "sha512-zExzgtxCe2BhoOvEJgcfffo5m60LQNM/ejJFZdNWR3dfsC16m7qkY3BCktKhyifsma6midIPSh3kXOYu0VVFCg==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
           }
+        },
+        "@types/retry": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+          "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+          "dev": true
         },
         "fs-extra": {
           "version": "5.0.0",
@@ -3569,13 +6129,13 @@
         "ip-regex": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
-          "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=",
+          "integrity": "sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw==",
           "dev": true
         },
         "is-ip": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-ip/-/is-ip-2.0.0.tgz",
-          "integrity": "sha1-aO6gfooKCpTC0IDdZ0xzGrKkYas=",
+          "integrity": "sha512-9MTn0dteHETtyUx8pxqMwg5hMBi3pvlyglJ+b79KOCca0po23337LbVV2Hl4xmMvfw++ljnO0/+5G6G+0Szh6g==",
           "dev": true,
           "requires": {
             "ip-regex": "^2.0.0"
@@ -3590,17 +6150,11 @@
         "jsonfile": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-          "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+          "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
           "dev": true,
           "requires": {
             "graceful-fs": "^4.1.6"
           }
-        },
-        "moment": {
-          "version": "2.29.2",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-          "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
-          "dev": true
         },
         "p-map": {
           "version": "1.2.0",
@@ -3609,12 +6163,12 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.6.1",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
-          "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+          "version": "4.6.2",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+          "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
           "dev": true,
           "requires": {
-            "@types/retry": "^0.12.0",
+            "@types/retry": "0.12.0",
             "retry": "^0.13.1"
           }
         },
@@ -3664,31 +6218,42 @@
       }
     },
     "@cumulus/launchpad-auth": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/launchpad-auth/-/launchpad-auth-11.1.0.tgz",
-      "integrity": "sha512-lCVB/1eIpLghzojovY9mcp1w6EJcF+ZmdtnqNG63Qld3jpjuosfYuXlzP+Bcs6dUYJkqiAS4IVXE8e76Z9dWTw==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/launchpad-auth/-/launchpad-auth-13.1.0.tgz",
+      "integrity": "sha512-drb9UBoRDk00YOPosJWZwU9rwBMMpcwbsctu2lBoD5KmH60Ox0mZd9Tn3Q3IUyUSpzfFdXf6E4gHYJIBohxMIQ==",
       "dev": true,
       "requires": {
-        "@cumulus/aws-client": "11.1.0",
-        "@cumulus/logger": "11.1.0",
-        "got": "^11.7.0",
+        "@cumulus/aws-client": "13.1.0",
+        "@cumulus/logger": "13.1.0",
+        "got": "^11.8.5",
         "lodash": "^4.17.21",
         "uuid": "^3.2.1"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        },
         "@cumulus/aws-client": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-11.1.0.tgz",
-          "integrity": "sha512-bVr+axSh7QdgYhlCPg7DB0hpS3BiozQDj9piE8oxLTSvjA4HPIx8rW92PHJbwHD954XdpKOJPWHBxHUdmI2hrg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-13.1.0.tgz",
+          "integrity": "sha512-SRRRtovCDcK7j8Xfn7xlisdyy5CSFGr/SRmOnPDg9k4oivI+fd+WjylLD1oc1YkWPHEednOdL0dLn+GwfgEI+w==",
           "dev": true,
           "requires": {
-            "@aws-sdk/client-dynamodb": "^3.53.0",
-            "@aws-sdk/client-dynamodb-streams": "^3.53.0",
-            "@aws-sdk/lib-dynamodb": "^3.53.0",
-            "@aws-sdk/types": "^3.53.0",
-            "@cumulus/checksum": "11.1.0",
-            "@cumulus/errors": "11.1.0",
-            "@cumulus/logger": "11.1.0",
+            "@aws-sdk/client-api-gateway": "^3.58.0",
+            "@aws-sdk/client-dynamodb": "^3.58.0",
+            "@aws-sdk/client-dynamodb-streams": "^3.58.0",
+            "@aws-sdk/client-s3": "^3.58.0",
+            "@aws-sdk/lib-dynamodb": "^3.58.0",
+            "@aws-sdk/lib-storage": "^3.58.0",
+            "@aws-sdk/s3-request-presigner": "^3.58.0",
+            "@aws-sdk/signature-v4-crt": "^3.58.0",
+            "@aws-sdk/types": "^3.58.0",
+            "@cumulus/checksum": "13.1.0",
+            "@cumulus/errors": "13.1.0",
+            "@cumulus/logger": "13.1.0",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.21",
@@ -3697,32 +6262,47 @@
             "p-retry": "^4.2.0",
             "p-timeout": "^4.1.0",
             "p-wait-for": "^3.2.0",
-            "pump": "^3.0.0"
+            "pump": "^3.0.0",
+            "uuid": "^8.2.0"
+          },
+          "dependencies": {
+            "uuid": {
+              "version": "8.3.2",
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+              "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+              "dev": true
+            }
           }
         },
         "@cumulus/checksum": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-11.1.0.tgz",
-          "integrity": "sha512-TlTpp5pzDwEPOxTNuF/WX5FugnY+EsS4xo3hjVUmHY40ftl5C1PyghrHPBU80Q5Nq43atsO1EcEqMtgllQMUqg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-13.1.0.tgz",
+          "integrity": "sha512-lq1CylBarr8wWChnT/gZVBDNtS2fEyBPipffjsT+3VfCXAT2muaTqO6dcw9nizRCHqhOcE0ojD911IzCl7JKLw==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-11.1.0.tgz",
-          "integrity": "sha512-iHWyBhFuKTK/wnAR77Nf0XST6WltPBSDiE54rE290E8WfamMeb5T9OASvKMkf4Mit3a/prscizImtxYbd1tnkg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-13.1.0.tgz",
+          "integrity": "sha512-DlxGN16b5V71KCNs/QEc5YObgK9MrGmS2tgxH2Bd7AYAoAXc/foNinBetHA4uH2/Z2/MZ5dsFaw3GlLCm6W63g==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-11.1.0.tgz",
-          "integrity": "sha512-5l9JR/daH5CE7IhrDm1iZJFtN6w3VLZ8O8bj+XQf9u56CNtciyUQpooScifd5RPKx4KotskPXq42JIrityhZOg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-13.1.0.tgz",
+          "integrity": "sha512-zExzgtxCe2BhoOvEJgcfffo5m60LQNM/ejJFZdNWR3dfsC16m7qkY3BCktKhyifsma6midIPSh3kXOYu0VVFCg==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
           }
+        },
+        "@types/retry": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+          "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+          "dev": true
         },
         "p-map": {
           "version": "1.2.0",
@@ -3731,12 +6311,12 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.6.1",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
-          "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+          "version": "4.6.2",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+          "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
           "dev": true,
           "requires": {
-            "@types/retry": "^0.12.0",
+            "@types/retry": "0.12.0",
             "retry": "^0.13.1"
           }
         },
@@ -3784,34 +6364,45 @@
       }
     },
     "@cumulus/message": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/message/-/message-11.1.0.tgz",
-      "integrity": "sha512-Ai16iKRZv2raKcGewoO0urnOIpSDisR84zcVSawdIJ03AYO+1z0Vm/Vvcb62vWAULDtj+8ifsF8TUIs+SRAT1A==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/message/-/message-13.1.0.tgz",
+      "integrity": "sha512-wVkhnUDxBr3IjdTe+J2Q/vDnPypdiSCjQ345GI0T9zSYZk06LXfN/YkmVG8Zxoziw6UfdmbXYdOoQ03pxOf83w==",
       "dev": true,
       "requires": {
-        "@cumulus/aws-client": "11.1.0",
-        "@cumulus/common": "11.1.0",
-        "@cumulus/errors": "11.1.0",
-        "@cumulus/logger": "11.1.0",
-        "@cumulus/types": "11.1.0",
+        "@cumulus/aws-client": "13.1.0",
+        "@cumulus/common": "13.1.0",
+        "@cumulus/errors": "13.1.0",
+        "@cumulus/logger": "13.1.0",
+        "@cumulus/types": "13.1.0",
         "jsonpath-plus": "^3.0.0",
         "lodash": "^4.17.21",
         "uuid": "^8.2.0"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        },
         "@cumulus/aws-client": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-11.1.0.tgz",
-          "integrity": "sha512-bVr+axSh7QdgYhlCPg7DB0hpS3BiozQDj9piE8oxLTSvjA4HPIx8rW92PHJbwHD954XdpKOJPWHBxHUdmI2hrg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-13.1.0.tgz",
+          "integrity": "sha512-SRRRtovCDcK7j8Xfn7xlisdyy5CSFGr/SRmOnPDg9k4oivI+fd+WjylLD1oc1YkWPHEednOdL0dLn+GwfgEI+w==",
           "dev": true,
           "requires": {
-            "@aws-sdk/client-dynamodb": "^3.53.0",
-            "@aws-sdk/client-dynamodb-streams": "^3.53.0",
-            "@aws-sdk/lib-dynamodb": "^3.53.0",
-            "@aws-sdk/types": "^3.53.0",
-            "@cumulus/checksum": "11.1.0",
-            "@cumulus/errors": "11.1.0",
-            "@cumulus/logger": "11.1.0",
+            "@aws-sdk/client-api-gateway": "^3.58.0",
+            "@aws-sdk/client-dynamodb": "^3.58.0",
+            "@aws-sdk/client-dynamodb-streams": "^3.58.0",
+            "@aws-sdk/client-s3": "^3.58.0",
+            "@aws-sdk/lib-dynamodb": "^3.58.0",
+            "@aws-sdk/lib-storage": "^3.58.0",
+            "@aws-sdk/s3-request-presigner": "^3.58.0",
+            "@aws-sdk/signature-v4-crt": "^3.58.0",
+            "@aws-sdk/types": "^3.58.0",
+            "@cumulus/checksum": "13.1.0",
+            "@cumulus/errors": "13.1.0",
+            "@cumulus/logger": "13.1.0",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.21",
@@ -3820,7 +6411,8 @@
             "p-retry": "^4.2.0",
             "p-timeout": "^4.1.0",
             "p-wait-for": "^3.2.0",
-            "pump": "^3.0.0"
+            "pump": "^3.0.0",
+            "uuid": "^8.2.0"
           },
           "dependencies": {
             "jsonpath-plus": {
@@ -3832,28 +6424,34 @@
           }
         },
         "@cumulus/checksum": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-11.1.0.tgz",
-          "integrity": "sha512-TlTpp5pzDwEPOxTNuF/WX5FugnY+EsS4xo3hjVUmHY40ftl5C1PyghrHPBU80Q5Nq43atsO1EcEqMtgllQMUqg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-13.1.0.tgz",
+          "integrity": "sha512-lq1CylBarr8wWChnT/gZVBDNtS2fEyBPipffjsT+3VfCXAT2muaTqO6dcw9nizRCHqhOcE0ojD911IzCl7JKLw==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-11.1.0.tgz",
-          "integrity": "sha512-iHWyBhFuKTK/wnAR77Nf0XST6WltPBSDiE54rE290E8WfamMeb5T9OASvKMkf4Mit3a/prscizImtxYbd1tnkg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-13.1.0.tgz",
+          "integrity": "sha512-DlxGN16b5V71KCNs/QEc5YObgK9MrGmS2tgxH2Bd7AYAoAXc/foNinBetHA4uH2/Z2/MZ5dsFaw3GlLCm6W63g==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-11.1.0.tgz",
-          "integrity": "sha512-5l9JR/daH5CE7IhrDm1iZJFtN6w3VLZ8O8bj+XQf9u56CNtciyUQpooScifd5RPKx4KotskPXq42JIrityhZOg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-13.1.0.tgz",
+          "integrity": "sha512-zExzgtxCe2BhoOvEJgcfffo5m60LQNM/ejJFZdNWR3dfsC16m7qkY3BCktKhyifsma6midIPSh3kXOYu0VVFCg==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
           }
+        },
+        "@types/retry": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+          "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+          "dev": true
         },
         "jsonpath-plus": {
           "version": "3.0.0",
@@ -3868,12 +6466,12 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.6.1",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
-          "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+          "version": "4.6.2",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+          "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
           "dev": true,
           "requires": {
-            "@types/retry": "^0.12.0",
+            "@types/retry": "0.12.0",
             "retry": "^0.13.1"
           }
         },
@@ -3906,36 +6504,47 @@
       }
     },
     "@cumulus/oauth-client": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/oauth-client/-/oauth-client-11.1.0.tgz",
-      "integrity": "sha512-f3r8b5S+PYgiYRxtsfbhQEx4dV+jDVpj0RARYludM+TS3ifBzHa8pKm2QbCjUZbJW/yHXLHFZnL8bkZDEQLbpQ==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/oauth-client/-/oauth-client-13.1.0.tgz",
+      "integrity": "sha512-x36PwckNXPyzyjip1qoNVV9wXS5SEnWEL+FUoqSH+iT+8Yd3aPKM+q6b2j5xAPEjhfEfIwMvpxb6XQae3EfeeA==",
       "dev": true,
       "requires": {
         "got": "^11.7.0"
       }
     },
     "@cumulus/object-store": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/object-store/-/object-store-11.1.0.tgz",
-      "integrity": "sha512-xSgAKsmI2NAKqsvLVqsqGjxhHr2rDyWih+XATUAoUBHnVBTHxNduNbNP3oW7cLCtx9OWbONKDjM1Nz+GaZLZiQ==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/object-store/-/object-store-13.1.0.tgz",
+      "integrity": "sha512-IMUgyhlNifd/iP9vTpTPjnBdoDDXd91qPc89WnRBfkvo2F9U6pdjbJ1Ipcwyna57rCi5bV+/1pl2I/sdl44AEA==",
       "dev": true,
       "requires": {
-        "@cumulus/aws-client": "11.1.0"
+        "@cumulus/aws-client": "13.1.0"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        },
         "@cumulus/aws-client": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-11.1.0.tgz",
-          "integrity": "sha512-bVr+axSh7QdgYhlCPg7DB0hpS3BiozQDj9piE8oxLTSvjA4HPIx8rW92PHJbwHD954XdpKOJPWHBxHUdmI2hrg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-13.1.0.tgz",
+          "integrity": "sha512-SRRRtovCDcK7j8Xfn7xlisdyy5CSFGr/SRmOnPDg9k4oivI+fd+WjylLD1oc1YkWPHEednOdL0dLn+GwfgEI+w==",
           "dev": true,
           "requires": {
-            "@aws-sdk/client-dynamodb": "^3.53.0",
-            "@aws-sdk/client-dynamodb-streams": "^3.53.0",
-            "@aws-sdk/lib-dynamodb": "^3.53.0",
-            "@aws-sdk/types": "^3.53.0",
-            "@cumulus/checksum": "11.1.0",
-            "@cumulus/errors": "11.1.0",
-            "@cumulus/logger": "11.1.0",
+            "@aws-sdk/client-api-gateway": "^3.58.0",
+            "@aws-sdk/client-dynamodb": "^3.58.0",
+            "@aws-sdk/client-dynamodb-streams": "^3.58.0",
+            "@aws-sdk/client-s3": "^3.58.0",
+            "@aws-sdk/lib-dynamodb": "^3.58.0",
+            "@aws-sdk/lib-storage": "^3.58.0",
+            "@aws-sdk/s3-request-presigner": "^3.58.0",
+            "@aws-sdk/signature-v4-crt": "^3.58.0",
+            "@aws-sdk/types": "^3.58.0",
+            "@cumulus/checksum": "13.1.0",
+            "@cumulus/errors": "13.1.0",
+            "@cumulus/logger": "13.1.0",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.21",
@@ -3944,32 +6553,39 @@
             "p-retry": "^4.2.0",
             "p-timeout": "^4.1.0",
             "p-wait-for": "^3.2.0",
-            "pump": "^3.0.0"
+            "pump": "^3.0.0",
+            "uuid": "^8.2.0"
           }
         },
         "@cumulus/checksum": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-11.1.0.tgz",
-          "integrity": "sha512-TlTpp5pzDwEPOxTNuF/WX5FugnY+EsS4xo3hjVUmHY40ftl5C1PyghrHPBU80Q5Nq43atsO1EcEqMtgllQMUqg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-13.1.0.tgz",
+          "integrity": "sha512-lq1CylBarr8wWChnT/gZVBDNtS2fEyBPipffjsT+3VfCXAT2muaTqO6dcw9nizRCHqhOcE0ojD911IzCl7JKLw==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-11.1.0.tgz",
-          "integrity": "sha512-iHWyBhFuKTK/wnAR77Nf0XST6WltPBSDiE54rE290E8WfamMeb5T9OASvKMkf4Mit3a/prscizImtxYbd1tnkg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-13.1.0.tgz",
+          "integrity": "sha512-DlxGN16b5V71KCNs/QEc5YObgK9MrGmS2tgxH2Bd7AYAoAXc/foNinBetHA4uH2/Z2/MZ5dsFaw3GlLCm6W63g==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-11.1.0.tgz",
-          "integrity": "sha512-5l9JR/daH5CE7IhrDm1iZJFtN6w3VLZ8O8bj+XQf9u56CNtciyUQpooScifd5RPKx4KotskPXq42JIrityhZOg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-13.1.0.tgz",
+          "integrity": "sha512-zExzgtxCe2BhoOvEJgcfffo5m60LQNM/ejJFZdNWR3dfsC16m7qkY3BCktKhyifsma6midIPSh3kXOYu0VVFCg==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
           }
+        },
+        "@types/retry": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+          "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+          "dev": true
         },
         "p-map": {
           "version": "1.2.0",
@@ -3978,12 +6594,12 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.6.1",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
-          "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+          "version": "4.6.2",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+          "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
           "dev": true,
           "requires": {
-            "@types/retry": "^0.12.0",
+            "@types/retry": "0.12.0",
             "retry": "^0.13.1"
           }
         },
@@ -4016,41 +6632,52 @@
       }
     },
     "@cumulus/pvl": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/pvl/-/pvl-11.1.0.tgz",
-      "integrity": "sha512-HPq2sx6ua08CIzLB8/XsF/LD+nkyp1kHIMyqaqjCfmPJ5J7m538OjK6i876hCT2xyq/gXTQUVRoGScDXXVUA5A==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/pvl/-/pvl-13.1.0.tgz",
+      "integrity": "sha512-62mjXhgwLadiJAWu0h0ViB6Tlfp2yLSjU/oZJqFrMcN1CW0e3RNHKaXH4mhP+tzPSpsRRL2334OqfKJal9wHOQ==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.21"
       }
     },
     "@cumulus/sftp-client": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/sftp-client/-/sftp-client-11.1.0.tgz",
-      "integrity": "sha512-XoaGNG1n3bRdZSsLuqbPrwPX6Db7x17Ati2dbG6WlvF9SKXrEpf/l4m9+PdOMCq+ntXWNV6OyEmwfT/wapwxDg==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/sftp-client/-/sftp-client-13.1.0.tgz",
+      "integrity": "sha512-Jk3ABs/Q00kGPx1A9ZYrJLQdb4D/ieqgVI4q9tQxuO64HLekW4Yxvs51iIbeQhQ46Lufh20NpPHcJfJN+OcLTw==",
       "dev": true,
       "requires": {
-        "@cumulus/aws-client": "11.1.0",
-        "@cumulus/common": "11.1.0",
+        "@cumulus/aws-client": "13.1.0",
+        "@cumulus/common": "13.1.0",
         "lodash": "^4.17.21",
         "mime-types": "^2.1.27",
         "ssh2": "^1.0.0",
         "ssh2-sftp-client": "^7.0.4"
       },
       "dependencies": {
+        "@aws-sdk/types": {
+          "version": "3.127.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.127.0.tgz",
+          "integrity": "sha512-e0wtx2IkOl7rwfKfLH5pPTzQ+d45V7b1WrjeL0WDI8kOu6w+sXmhNxI6uM2kf0k4NiTLN84lW290AEWupey9Og==",
+          "dev": true
+        },
         "@cumulus/aws-client": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-11.1.0.tgz",
-          "integrity": "sha512-bVr+axSh7QdgYhlCPg7DB0hpS3BiozQDj9piE8oxLTSvjA4HPIx8rW92PHJbwHD954XdpKOJPWHBxHUdmI2hrg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/aws-client/-/aws-client-13.1.0.tgz",
+          "integrity": "sha512-SRRRtovCDcK7j8Xfn7xlisdyy5CSFGr/SRmOnPDg9k4oivI+fd+WjylLD1oc1YkWPHEednOdL0dLn+GwfgEI+w==",
           "dev": true,
           "requires": {
-            "@aws-sdk/client-dynamodb": "^3.53.0",
-            "@aws-sdk/client-dynamodb-streams": "^3.53.0",
-            "@aws-sdk/lib-dynamodb": "^3.53.0",
-            "@aws-sdk/types": "^3.53.0",
-            "@cumulus/checksum": "11.1.0",
-            "@cumulus/errors": "11.1.0",
-            "@cumulus/logger": "11.1.0",
+            "@aws-sdk/client-api-gateway": "^3.58.0",
+            "@aws-sdk/client-dynamodb": "^3.58.0",
+            "@aws-sdk/client-dynamodb-streams": "^3.58.0",
+            "@aws-sdk/client-s3": "^3.58.0",
+            "@aws-sdk/lib-dynamodb": "^3.58.0",
+            "@aws-sdk/lib-storage": "^3.58.0",
+            "@aws-sdk/s3-request-presigner": "^3.58.0",
+            "@aws-sdk/signature-v4-crt": "^3.58.0",
+            "@aws-sdk/types": "^3.58.0",
+            "@cumulus/checksum": "13.1.0",
+            "@cumulus/errors": "13.1.0",
+            "@cumulus/logger": "13.1.0",
             "aws-sdk": "^2.585.0",
             "jsonpath-plus": "^1.1.0",
             "lodash": "~4.17.21",
@@ -4059,32 +6686,39 @@
             "p-retry": "^4.2.0",
             "p-timeout": "^4.1.0",
             "p-wait-for": "^3.2.0",
-            "pump": "^3.0.0"
+            "pump": "^3.0.0",
+            "uuid": "^8.2.0"
           }
         },
         "@cumulus/checksum": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-11.1.0.tgz",
-          "integrity": "sha512-TlTpp5pzDwEPOxTNuF/WX5FugnY+EsS4xo3hjVUmHY40ftl5C1PyghrHPBU80Q5Nq43atsO1EcEqMtgllQMUqg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/checksum/-/checksum-13.1.0.tgz",
+          "integrity": "sha512-lq1CylBarr8wWChnT/gZVBDNtS2fEyBPipffjsT+3VfCXAT2muaTqO6dcw9nizRCHqhOcE0ojD911IzCl7JKLw==",
           "dev": true,
           "requires": {
             "cksum": "^1.3.0"
           }
         },
         "@cumulus/errors": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-11.1.0.tgz",
-          "integrity": "sha512-iHWyBhFuKTK/wnAR77Nf0XST6WltPBSDiE54rE290E8WfamMeb5T9OASvKMkf4Mit3a/prscizImtxYbd1tnkg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/errors/-/errors-13.1.0.tgz",
+          "integrity": "sha512-DlxGN16b5V71KCNs/QEc5YObgK9MrGmS2tgxH2Bd7AYAoAXc/foNinBetHA4uH2/Z2/MZ5dsFaw3GlLCm6W63g==",
           "dev": true
         },
         "@cumulus/logger": {
-          "version": "11.1.0",
-          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-11.1.0.tgz",
-          "integrity": "sha512-5l9JR/daH5CE7IhrDm1iZJFtN6w3VLZ8O8bj+XQf9u56CNtciyUQpooScifd5RPKx4KotskPXq42JIrityhZOg==",
+          "version": "13.1.0",
+          "resolved": "https://registry.npmjs.org/@cumulus/logger/-/logger-13.1.0.tgz",
+          "integrity": "sha512-zExzgtxCe2BhoOvEJgcfffo5m60LQNM/ejJFZdNWR3dfsC16m7qkY3BCktKhyifsma6midIPSh3kXOYu0VVFCg==",
           "dev": true,
           "requires": {
             "lodash.iserror": "^3.1.1"
           }
+        },
+        "@types/retry": {
+          "version": "0.12.0",
+          "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+          "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+          "dev": true
         },
         "p-map": {
           "version": "1.2.0",
@@ -4093,12 +6727,12 @@
           "dev": true
         },
         "p-retry": {
-          "version": "4.6.1",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.1.tgz",
-          "integrity": "sha512-e2xXGNhZOZ0lfgR9kL34iGlU8N/KO0xZnQxVEwdeOvpqNDQfdnxIYizvWtK8RglUa3bGqI8g0R/BdfzLMxRkiA==",
+          "version": "4.6.2",
+          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+          "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
           "dev": true,
           "requires": {
-            "@types/retry": "^0.12.0",
+            "@types/retry": "0.12.0",
             "retry": "^0.13.1"
           }
         },
@@ -4131,9 +6765,9 @@
       }
     },
     "@cumulus/types": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/@cumulus/types/-/types-11.1.0.tgz",
-      "integrity": "sha512-AXI3st1F+zr0f4l0axAnIMBh7vabQDTATem9aQkUNpd2u3rRDtiCnMhhdkQceCeQoba7ojkAhhT5tB1wzHVKbw==",
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/@cumulus/types/-/types-13.1.0.tgz",
+      "integrity": "sha512-ShPk5ld/ZgNF/Tm5KGeoI9PMT8SiStWY4bLMZynDKCgeuc9I39WtlG1+wrM0mktTDXu59jWfI/26WqUl1D5/Zg==",
       "dev": true
     },
     "@cypress/request": {
@@ -4378,6 +7012,70 @@
         "prop-types": "^15.8.1"
       }
     },
+    "@httptoolkit/websocket-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@httptoolkit/websocket-stream/-/websocket-stream-6.0.1.tgz",
+      "integrity": "sha512-A0NOZI+Glp3Xgcz6Na7i7o09+/+xm2m0UCU8gdtM2nIv6/cjLmhMZMqehSpTlgbx9omtLmV8LVqOskPEyWnmZQ==",
+      "dev": true,
+      "requires": {
+        "@types/ws": "*",
+        "duplexify": "^3.5.1",
+        "inherits": "^2.0.1",
+        "isomorphic-ws": "^4.0.1",
+        "readable-stream": "^2.3.3",
+        "safe-buffer": "^5.1.2",
+        "ws": "*",
+        "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          },
+          "dependencies": {
+            "safe-buffer": {
+              "version": "5.1.2",
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+              "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+              "dev": true
+            }
+          }
+        }
+      }
+    },
     "@humanwhocodes/config-array": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.5.0.tgz",
@@ -4427,21 +7125,21 @@
       }
     },
     "@leichtgewicht/ip-codec": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.3.tgz",
-      "integrity": "sha512-nkalE/f1RvRGChwBnEIoBfSEYOXnCRdleKuv6+lePbMDrMZXeDQnqak5XDOeBgrPPyPfAdcCu/B5z+v3VhplGg==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.4.tgz",
+      "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "dev": true
     },
     "@mapbox/dyno": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@mapbox/dyno/-/dyno-1.5.0.tgz",
-      "integrity": "sha512-lK7QzxKCT/3KvvjqXeQzprE0SkaqjJEkmMXPIL6p5mR/i740WpKdYEWmz82ubjaPFSW6WGMZ8iP1qqIcftMZBw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@mapbox/dyno/-/dyno-1.5.1.tgz",
+      "integrity": "sha512-AwOx7g/2cuKPIsJlsAB9AQO+Vmg2CGtDAs0pQNRRN3Zbh+zgOYWdVgS75qiSSK/zZ24WNSTMAV6gsT7U+4aXRw==",
       "dev": true,
       "requires": {
         "aws-sdk": "^2.7.2",
         "big.js": "^3.1.3",
         "event-stream": "3.3.4",
-        "minimist": "^1.2.5",
+        "minimist": "^1.2.6",
         "parallel-stream": "^1.1.2",
         "queue-async": "~1.0.7",
         "underscore": "^1.13.1"
@@ -5529,7 +8227,7 @@
     "asap": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
       "dev": true
     },
     "asn1": {
@@ -5774,6 +8472,30 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz",
       "integrity": "sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw=="
+    },
+    "aws-crt": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/aws-crt/-/aws-crt-1.13.2.tgz",
+      "integrity": "sha512-DtdfvVEmjgHtfT9cya2UDuPAwPlYwNbp4pJNP4UB0iJ0rbWdAVb5sgC7KmXbOzhYuB0/qoR/B2s2YZ/xZbZZaQ==",
+      "dev": true,
+      "requires": {
+        "@aws-sdk/util-utf8-browser": "^3.109.0",
+        "@httptoolkit/websocket-stream": "^6.0.0",
+        "axios": "^0.24.0",
+        "crypto-js": "^4.0.0",
+        "mqtt": "^4.3.7"
+      },
+      "dependencies": {
+        "@aws-sdk/util-utf8-browser": {
+          "version": "3.109.0",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.109.0.tgz",
+          "integrity": "sha512-FmcGSz0v7Bqpl1SE8G1Gc0CtDpug+rvqNCG/szn86JApD/f5x8oByjbEiAyTU2ZH2VevUntx6EW68ulHyH+x+w==",
+          "dev": true,
+          "requires": {
+            "tslib": "^2.3.1"
+          }
+        }
+      }
     },
     "aws-elasticsearch-connector": {
       "version": "8.2.0",
@@ -7303,6 +10025,16 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
       "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
     },
+    "commist": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/commist/-/commist-1.1.0.tgz",
+      "integrity": "sha512-rraC8NXWOEjhADbZe9QBNzLAN5Q3fsTPQtBV+fEVj6xKIgDgNiEVE6ZNfHpZOqfQ21YUzfVNUXLOEZquYvQPPg==",
+      "dev": true,
+      "requires": {
+        "leven": "^2.1.0",
+        "minimist": "^1.1.0"
+      }
+    },
     "common-path-prefix": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/common-path-prefix/-/common-path-prefix-3.0.0.tgz",
@@ -7327,9 +10059,9 @@
       "integrity": "sha512-WQfnbDcrYnGr55UwbxKiQKASnTtNnaAWVi8jZyy8NTpVAXWACSne8lMD1iaIo9AiU6mnuLvSVshCzewVuWxHUg=="
     },
     "compress-brotli": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/compress-brotli/-/compress-brotli-1.3.6.tgz",
-      "integrity": "sha512-au99/GqZtUtiCBliqLFbWlhnCxn+XSYjwZ77q6mKN4La4qOXDoLVPZ50iXr0WmAyMxl8yqoq3Yq4OeQNPPkyeQ==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/compress-brotli/-/compress-brotli-1.3.8.tgz",
+      "integrity": "sha512-lVcQsjhxhIXsuupfy9fmZUFtAIdBmXA7EGY6GBdgZ++qkM9zG4YFT8iU7FoBxzryNDMOpD1HIFHUSX4D87oqhQ==",
       "dev": true,
       "requires": {
         "@types/json-buffer": "~3.0.0",
@@ -7764,6 +10496,12 @@
         "randombytes": "^2.0.0",
         "randomfill": "^1.0.3"
       }
+    },
+    "crypto-js": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+      "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==",
+      "dev": true
     },
     "crypto-random-string": {
       "version": "3.3.1",
@@ -9148,9 +11886,9 @@
       "dev": true
     },
     "dns-packet": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.3.1.tgz",
-      "integrity": "sha512-spBwIj0TK0Ey3666GwIdWVfUpLyubpU53BTCu8iPn4r4oXd9O14Hjg3EHw3ts2oed77/SeckunUYCyRlSngqHw==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.4.0.tgz",
+      "integrity": "sha512-EgqGeaBB8hLiHLZtp/IbaDQTL8pZ0+IvwzSHA6d7VyMDM+B9hgddEMa9xjK5oYnw0ci0JQ6g2XCD7/f6cafU6g==",
       "dev": true,
       "requires": {
         "@leichtgewicht/ip-codec": "^2.0.1"
@@ -9296,6 +12034,56 @@
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
       "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
       "dev": true
+    },
+    "duplexify": {
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
+      "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.0.0",
+        "inherits": "^2.0.1",
+        "readable-stream": "^2.0.0",
+        "stream-shift": "^1.0.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+          "dev": true
+        },
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "dev": true,
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "dev": true,
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
     },
     "dynamodb-data-types": {
       "version": "3.0.3",
@@ -10229,7 +13017,7 @@
     "event-stream": {
       "version": "3.3.4",
       "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
-      "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
+      "integrity": "sha512-QHpkERcGsR0T7Qm3HNJSyXKEEj8AHNxkY3PK8TS2KJvQ7NiSHe3DDpwVKKtoYprL/AreyzFBeIkBIWChAqn60g==",
       "dev": true,
       "requires": {
         "duplexer": "~0.1.1",
@@ -10244,7 +13032,7 @@
         "stream-combiner": {
           "version": "0.0.4",
           "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
-          "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
+          "integrity": "sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==",
           "dev": true,
           "requires": {
             "duplexer": "~0.1.1"
@@ -10390,7 +13178,7 @@
     "express-promise-router": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/express-promise-router/-/express-promise-router-3.0.3.tgz",
-      "integrity": "sha1-Xm0ipaPwE9cYMxcv6NereAw/a3A=",
+      "integrity": "sha512-8snG4aFod7CaJyxOU4or0o1xxfzv6dTeVn2HFWvhIy+eR6BKsJeNUTEdIQn2+UcMqbss+DKMPGhmpwvHChwodw==",
       "dev": true,
       "requires": {
         "is-promise": "^2.1.0",
@@ -10457,9 +13245,9 @@
       "dev": true
     },
     "fast-text-encoding": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
-      "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.4.tgz",
+      "integrity": "sha512-x6lDDm/tBAzX9kmsPcZsNbvDs3Zey3+scsxaZElS8xWLgUMAg/oFLeewfUz0mu1CblHhhsu15jGkraldkFh8KQ==",
       "dev": true
     },
     "fast-xml-parser": {
@@ -10692,6 +13480,12 @@
         "mime-types": "^2.1.12"
       }
     },
+    "form-data-encoder": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.0.1.tgz",
+      "integrity": "sha512-Oy+P9w5mnO4TWXVgUiQvggNKPI9/ummcSt5usuIV6HkaLKigwzPpoenhEqmGmx3zHqm6ZLJ+CR/99N8JLinaEw==",
+      "dev": true
+    },
     "forwarded": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
@@ -10719,7 +13513,7 @@
     "from2": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
-      "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+      "integrity": "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==",
       "dev": true,
       "requires": {
         "inherits": "^2.0.1",
@@ -10729,7 +13523,7 @@
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
           "dev": true
         },
         "readable-stream": {
@@ -10796,7 +13590,7 @@
     "ftp-response-parser": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ftp-response-parser/-/ftp-response-parser-1.0.1.tgz",
-      "integrity": "sha1-O50z+O3V+45HALj3eMRi5bFYH4k=",
+      "integrity": "sha512-++Ahlo2hs/IC7UVQzjcSAfeUpCwTTzs4uvG5XfGnsinIFkWUYF4xWwPd5qZuK8MJrmUIxFMuHcfqaosCDjvIWw==",
       "dev": true,
       "requires": {
         "readable-stream": "^1.0.31"
@@ -10805,7 +13599,7 @@
         "readable-stream": {
           "version": "1.1.14",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
           "dev": true,
           "requires": {
             "core-util-is": "~1.0.0",
@@ -10817,7 +13611,7 @@
         "string_decoder": {
           "version": "0.10.31",
           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
           "dev": true
         }
       }
@@ -10852,16 +13646,16 @@
       "dev": true
     },
     "gaxios": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.2.tgz",
-      "integrity": "sha512-T+ap6GM6UZ0c4E6yb1y/hy2UB6hTrqhglp3XfmU9qbLCGRYhLVV5aRPpC4EmoG8N8zOnkYCgoBz+ScvGAARY6Q==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.3.3.tgz",
+      "integrity": "sha512-gSaYYIO1Y3wUtdfHmjDUZ8LWaxJQpiavzbF5Kq53akSzvmVg0RfyOcFDbO1KJ/KCGRFz2qG+lS81F0nkr7cRJA==",
       "dev": true,
       "requires": {
         "abort-controller": "^3.0.0",
         "extend": "^3.0.2",
         "https-proxy-agent": "^5.0.0",
         "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.1"
+        "node-fetch": "^2.6.7"
       }
     },
     "gcp-metadata": {
@@ -11050,12 +13844,20 @@
       }
     },
     "google-p12-pem": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.3.tgz",
-      "integrity": "sha512-MC0jISvzymxePDVembypNefkAQp+DRP7dBE+zNUPaIjEspIlYg0++OrsNr248V9tPbz6iqtZ7rX1hxWA5B8qBQ==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.1.4.tgz",
+      "integrity": "sha512-HHuHmkLgwjdmVRngf5+gSmpkyaRI6QmOg77J8tkNBHhNEI62sGHyw4/+UkgyZEI7h84NbWprXDJ+sa3xOYFvTg==",
       "dev": true,
       "requires": {
-        "node-forge": "^1.0.0"
+        "node-forge": "^1.3.1"
+      },
+      "dependencies": {
+        "node-forge": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.1.tgz",
+          "integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
+          "dev": true
+        }
       }
     },
     "googleapis": {
@@ -11083,9 +13885,9 @@
       },
       "dependencies": {
         "qs": {
-          "version": "6.10.3",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.3.tgz",
-          "integrity": "sha512-wr7M2E0OFRfIfJZjKGieI8lBKb7fRCH4Fv5KNPEs7gJ8jadvotdsS08PzOKR7opXhZ/Xkjtt3WF9g38drmyRqQ==",
+          "version": "6.11.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+          "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
           "dev": true,
           "requires": {
             "side-channel": "^1.0.4"
@@ -11094,9 +13896,9 @@
       }
     },
     "got": {
-      "version": "11.8.3",
-      "resolved": "https://registry.npmjs.org/got/-/got-11.8.3.tgz",
-      "integrity": "sha512-7gtQ5KiPh1RtGS9/Jbv1ofDpBFuq42gyfEib+ejaRBJuj/3tQFeR5+gw57e4ipaU8c/rCjvX6fkQz2lyDlGAOg==",
+      "version": "11.8.5",
+      "resolved": "https://registry.npmjs.org/got/-/got-11.8.5.tgz",
+      "integrity": "sha512-o0Je4NvQObAuZPHLFoRSkdG2lTgtcynqymzg2Vupdx6PorhaT5MCbIyXG6d4D94kk8ZG57QeosgdiqfJWhEhlQ==",
       "dev": true,
       "requires": {
         "@sindresorhus/is": "^4.0.0",
@@ -11308,6 +14110,16 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
+    },
+    "help-me": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/help-me/-/help-me-3.0.0.tgz",
+      "integrity": "sha512-hx73jClhyk910sidBB7ERlnhMlFsJJIBqSVMFDwPN8o2v9nmp5KgLq1Xz1Bf1fCMMZ6mPrX159iG0VLy/fPMtQ==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.6",
+        "readable-stream": "^3.6.0"
+      }
     },
     "history": {
       "version": "4.10.1",
@@ -11647,9 +14459,9 @@
       }
     },
     "https-proxy-agent": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
-      "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "dev": true,
       "requires": {
         "agent-base": "6",
@@ -12242,6 +15054,12 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
+    "isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "dev": true
+    },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
@@ -12279,6 +15097,12 @@
       "version": "2.6.4",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.6.4.tgz",
       "integrity": "sha512-pZe//GGmwJndub7ZghVHz7vjb2LgC1m8B07Au3eYqeqv9emhESByMXxaEgkUkEqJe87oBbSniGYoQNIBklc7IQ==",
+      "dev": true
+    },
+    "js-sdsl": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-2.1.4.tgz",
+      "integrity": "sha512-/Ew+CJWHNddr7sjwgxaVeIORIH4AMVC9dy0hPf540ZGMVgS9d3ajwuVdyhDt6/QUvT8ATjR3yuYBKsS79F+H4A==",
       "dev": true
     },
     "js-string-escape": {
@@ -12558,12 +15382,12 @@
       }
     },
     "keyv": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.2.2.tgz",
-      "integrity": "sha512-uYS0vKTlBIjNCAUqrjlxmruxOEiZxZIHXyp32sdcGmP+ukFrmWUnE//RcPXJH3Vxrni1H2gsQbjHE0bH7MtMQQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.3.3.tgz",
+      "integrity": "sha512-AcysI17RvakTh8ir03+a3zJr5r0ovnAH/XTXei/4HIv3bL2K/jzvgivLK9UuI/JbU1aJjM3NSAnVvVVd3n+4DQ==",
       "dev": true,
       "requires": {
-        "compress-brotli": "^1.3.6",
+        "compress-brotli": "^1.3.8",
         "json-buffer": "3.0.1"
       }
     },
@@ -12652,6 +15476,12 @@
       "resolved": "https://registry.npmjs.org/lazy-ass/-/lazy-ass-1.6.0.tgz",
       "integrity": "sha1-eZllXoZGwX8In90YfRUNMyTVRRM=",
       "optional": true
+    },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha512-nvVPLpIHUxCUoRLrFqTgSxXJ614d8AgQoWl7zPe/2VadE8+1dpU3LBhowRuBAcuwruWtOdD8oYC9jDNJjXDPyA==",
+      "dev": true
     },
     "levn": {
       "version": "0.3.0",
@@ -13065,7 +15895,7 @@
     "map-stream": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.1.0.tgz",
-      "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
+      "integrity": "sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==",
       "dev": true
     },
     "matcher": {
@@ -13387,9 +16217,74 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
           "dev": true
         }
+      }
+    },
+    "mqtt": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/mqtt/-/mqtt-4.3.7.tgz",
+      "integrity": "sha512-ew3qwG/TJRorTz47eW46vZ5oBw5MEYbQZVaEji44j5lAUSQSqIEoul7Kua/BatBW0H0kKQcC9kwUHa1qzaWHSw==",
+      "dev": true,
+      "requires": {
+        "commist": "^1.0.0",
+        "concat-stream": "^2.0.0",
+        "debug": "^4.1.1",
+        "duplexify": "^4.1.1",
+        "help-me": "^3.0.0",
+        "inherits": "^2.0.3",
+        "lru-cache": "^6.0.0",
+        "minimist": "^1.2.5",
+        "mqtt-packet": "^6.8.0",
+        "number-allocator": "^1.0.9",
+        "pump": "^3.0.0",
+        "readable-stream": "^3.6.0",
+        "reinterval": "^1.1.0",
+        "rfdc": "^1.3.0",
+        "split2": "^3.1.0",
+        "ws": "^7.5.5",
+        "xtend": "^4.0.2"
+      },
+      "dependencies": {
+        "duplexify": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+          "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+          "dev": true,
+          "requires": {
+            "end-of-stream": "^1.4.1",
+            "inherits": "^2.0.3",
+            "readable-stream": "^3.1.1",
+            "stream-shift": "^1.0.0"
+          }
+        },
+        "split2": {
+          "version": "3.2.2",
+          "resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+          "integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+          "dev": true,
+          "requires": {
+            "readable-stream": "^3.0.0"
+          }
+        },
+        "ws": {
+          "version": "7.5.9",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+          "dev": true
+        }
+      }
+    },
+    "mqtt-packet": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/mqtt-packet/-/mqtt-packet-6.10.0.tgz",
+      "integrity": "sha512-ja8+mFKIHdB1Tpl6vac+sktqy3gA8t9Mduom1BA75cI+R9AHnZOiaBQwpGiWnaVJLDGRdNhQmFaAqd7tkKSMGA==",
+      "dev": true,
+      "requires": {
+        "bl": "^4.0.2",
+        "debug": "^4.1.1",
+        "process-nextick-args": "^2.0.1"
       }
     },
     "mrmime": {
@@ -13432,9 +16327,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.16.0.tgz",
+      "integrity": "sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==",
       "dev": true,
       "optional": true
     },
@@ -13556,7 +16451,7 @@
     "nodeify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/nodeify/-/nodeify-1.0.1.tgz",
-      "integrity": "sha1-ZKtpp7268DzhB7TwM1yHwLnpGx0=",
+      "integrity": "sha512-n7C2NyEze8GCo/z73KdbjRsBiLbv6eBn1FxwYKQ23IqGo7pQY3mhQan61Sv7eEDJCiyUjTVrVkXTzJCo1dW7Aw==",
       "dev": true,
       "requires": {
         "is-promise": "~1.0.0",
@@ -13566,7 +16461,7 @@
         "is-promise": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
-          "integrity": "sha1-MVc3YcBX4zwukaq56W2gjO++duU=",
+          "integrity": "sha512-mjWH5XxnhMA8cFnDchr6qRP9S/kLntKuEfIYku+PaN1CnS8v+OG9O/BKpRCVRJvpIkgAZm0Pf5Is3iSSOILlcg==",
           "dev": true
         }
       }
@@ -13633,6 +16528,16 @@
       "resolved": "https://registry.npmjs.org/num2fraction/-/num2fraction-1.2.2.tgz",
       "integrity": "sha1-b2gragJ6Tp3fpFZM0lidHU5mnt4=",
       "dev": true
+    },
+    "number-allocator": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/number-allocator/-/number-allocator-1.0.10.tgz",
+      "integrity": "sha512-K4AvNGKo9lP6HqsZyfSr9KDaqnwFzW203inhQEOwFrmFaYevpdX4VNwdOLk197aHujzbT//z6pCBrCOUYSM5iw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.3.1",
+        "js-sdsl": "^2.1.2"
+      }
     },
     "numeral": {
       "version": "2.0.6",
@@ -13931,7 +16836,7 @@
         "retry": {
           "version": "0.12.0",
           "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-          "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+          "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
           "dev": true
         }
       }
@@ -14149,7 +17054,7 @@
     "parallel-stream": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/parallel-stream/-/parallel-stream-1.1.2.tgz",
-      "integrity": "sha1-EsGWM455sk5OqIdCmDVMoazcZBs=",
+      "integrity": "sha512-qKaFRMDPnH9VXuAic8sgLgzZxG9CIxKJDJhlZI8dGGqZ+4ivSDasudYZ1Tx1How8QiuwZLipr1PK+S62LXLSIA==",
       "dev": true
     },
     "param-case": {
@@ -14196,7 +17101,7 @@
     "parse-listing": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/parse-listing/-/parse-listing-1.1.3.tgz",
-      "integrity": "sha1-qlRvV/3BKc+/mUXNS3V7FLBhgt0=",
+      "integrity": "sha512-a1p1i+9Qyc8pJNwdrSvW1g5TPxRH0sywVi6OzVvYHRo6xwF9bDWBxtH0KkxeOOvhUE8vAMtiSfsYQFOuK901eA==",
       "dev": true
     },
     "parse-ms": {
@@ -16427,7 +19332,7 @@
     "postgres-bytea": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
-      "integrity": "sha1-AntTPAqokOJtFy1Hz5zOzFIazTU=",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
       "dev": true
     },
     "postgres-date": {
@@ -16553,7 +19458,7 @@
     "promise": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/promise/-/promise-1.3.0.tgz",
-      "integrity": "sha1-5cyaTIJ45GZP/twBx9qEhCsEAXU=",
+      "integrity": "sha512-R9WrbTF3EPkVtWjp7B7umQGVndpsi+rsDAfrR4xAALQpFLa/+2OriecLhawxzvii2gd9+DZFwROWDuUUaqS5yA==",
       "dev": true,
       "requires": {
         "is-promise": "~1"
@@ -16562,7 +19467,7 @@
         "is-promise": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-1.0.1.tgz",
-          "integrity": "sha1-MVc3YcBX4zwukaq56W2gjO++duU=",
+          "integrity": "sha512-mjWH5XxnhMA8cFnDchr6qRP9S/kLntKuEfIYku+PaN1CnS8v+OG9O/BKpRCVRJvpIkgAZm0Pf5Is3iSSOILlcg==",
           "dev": true
         }
       }
@@ -16580,7 +19485,7 @@
         "retry": {
           "version": "0.12.0",
           "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-          "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
+          "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
           "dev": true
         }
       }
@@ -16712,7 +19617,7 @@
         "decompress-response": {
           "version": "3.3.0",
           "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-          "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+          "integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
           "dev": true,
           "requires": {
             "mimic-response": "^1.0.0"
@@ -16755,7 +19660,7 @@
         "json-buffer": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-          "integrity": "sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=",
+          "integrity": "sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==",
           "dev": true
         },
         "keyv": {
@@ -16788,7 +19693,7 @@
         "responselike": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
-          "integrity": "sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=",
+          "integrity": "sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==",
           "dev": true,
           "requires": {
             "lowercase-keys": "^1.0.0"
@@ -16843,7 +19748,7 @@
     "queue-async": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/queue-async/-/queue-async-1.0.7.tgz",
-      "integrity": "sha1-Iq4KHaxKkvW81GNPmTxoKiqBCUU=",
+      "integrity": "sha512-V52kIzNbnCsKw0ezR1zuDWnd3o2CsIloZzPP7pvgxeRRo7f6E+HzMfePecZKolqHi30xEZQhfOpGQ7VWqEYFaQ==",
       "dev": true
     },
     "queue-microtask": {
@@ -17538,6 +20443,12 @@
         }
       }
     },
+    "reinterval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
+      "integrity": "sha512-QIRet3SYrGp0HUHO88jVskiG6seqUGC5iAG7AwI/BV4ypGcuqk9Du6YQBUOUqm9c8pw1eyLoIaONifRua1lsEQ==",
+      "dev": true
+    },
     "relateurl": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
@@ -17796,9 +20707,9 @@
       }
     },
     "responselike": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.0.tgz",
-      "integrity": "sha512-xH48u3FTB9VsZw7R+vvgaKeLKzT6jOogbQhEe/jewwnZgzPcnyWui2Av6JpoYZF/91uueC+lqhWqeURw5/qhCw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/responselike/-/responselike-2.0.1.tgz",
+      "integrity": "sha512-4gl03wn3hj1HP3yzgdI7d3lCkF95F21Pz4BPGvKHinyQzALR5CapwC8yIi0Rh58DEMQ/SguC03wFj2k0M/mHhw==",
       "dev": true,
       "requires": {
         "lowercase-keys": "^2.0.0"
@@ -17834,8 +20745,7 @@
     "rfdc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.3.0.tgz",
-      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA==",
-      "optional": true
+      "integrity": "sha512-V2hovdzFbOi77/WajaSMXk2OLm+xNIeQdMMuB7icj7bk6zi2F8GGAxigcnDFpJHbNyNcgyJDiP+8nOrY5cZGrA=="
     },
     "rimraf": {
       "version": "3.0.2",
@@ -18464,7 +21374,7 @@
     "split": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
-      "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
+      "integrity": "sha512-wD2AeVmxXRBoX44wAycgjVpMhvbwdI2aZjCkvfNcH1YqHQvJVa1duWc73OyVGJUc05fhFaTZeQ/PYsrmyH0JVA==",
       "dev": true,
       "requires": {
         "through": "2"
@@ -18491,15 +21401,15 @@
       "dev": true
     },
     "ssh2": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.9.0.tgz",
-      "integrity": "sha512-rhhIZT0eMPvCBSOG8CpqZZ7gre2vgXaIqmb3Jb83t88rjsxIsFzDanqBJM9Ns8BmP1835A5IbQ199io4EUZwOA==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-1.11.0.tgz",
+      "integrity": "sha512-nfg0wZWGSsfUe/IBJkXVll3PEZ//YH2guww+mP88gTpuSU4FtZN7zu9JoeTGOyCNx2dTDtT9fOpWwlzyj4uOOw==",
       "dev": true,
       "requires": {
         "asn1": "^0.2.4",
         "bcrypt-pbkdf": "^1.0.2",
         "cpu-features": "~0.0.4",
-        "nan": "^2.15.0"
+        "nan": "^2.16.0"
       }
     },
     "ssh2-sftp-client": {
@@ -18588,6 +21498,12 @@
         "duplexer": "~0.1.1",
         "through": "~2.3.4"
       }
+    },
+    "stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
+      "dev": true
     },
     "strict-uri-encode": {
       "version": "2.0.0",
@@ -19054,7 +21970,7 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "dev": true
     },
     "trim-off-newlines": {
@@ -19149,7 +22065,7 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
       "dev": true
     },
     "typedarray-to-buffer": {
@@ -19184,9 +22100,9 @@
       }
     },
     "underscore": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
-      "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.4.tgz",
+      "integrity": "sha512-BQFnUDuAQ4Yf/cYY5LNrK9NCJFKriaRbD9uR1fTeXnBeoa97W0i41qkZfGO9pSo8I5KzjAcSY2XYtdf0oKd7KQ==",
       "dev": true
     },
     "unicode-canonical-property-names-ecmascript": {
@@ -19374,7 +22290,7 @@
     "url-template": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
-      "integrity": "sha1-/FZaPMy/93MMd19WQflVV5FDnyE=",
+      "integrity": "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw==",
       "dev": true
     },
     "util": {
@@ -19616,7 +22532,7 @@
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "dev": true
     },
     "webpack": {
@@ -20003,7 +22919,7 @@
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "dev": true,
       "requires": {
         "tr46": "~0.0.3",
@@ -20116,9 +23032,9 @@
       "dev": true
     },
     "xml-crypto": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.1.3.tgz",
-      "integrity": "sha512-MpXZwnn9JK0mNPZ5mnFIbNnQa+8lMGK4NtnX2FlJMfMWR60sJdFO9X72yO6ji068pxixzk53O7x0/iSKh6IhyQ==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.1.4.tgz",
+      "integrity": "sha512-ModFeGOy67L/XXHcuepnYGF7DASEDw7fhvy+qIs1ORoH55G1IIr+fN0kaMtttwvmNFFMskD9AHro8wx352/mUg==",
       "dev": true,
       "requires": {
         "@xmldom/xmldom": "^0.7.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7102,11 +7102,62 @@
         "warning": "^4.0.3"
       }
     },
+    "@jridgewell/gen-mapping": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
+      "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/set-array": "^1.0.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "dependencies": {
+        "@jridgewell/trace-mapping": {
+          "version": "0.3.14",
+          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+          "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/resolve-uri": "^3.0.3",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+          }
+        }
+      }
+    },
     "@jridgewell/resolve-uri": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.0.5.tgz",
       "integrity": "sha512-VPeQ7+wH0itvQxnG+lIzWgkysKIr3L9sslimFW55rHMdGu/qCQ5z5h9zq4gI8uBtqkpHhsF4Z/OwExufUCThew==",
       "dev": true
+    },
+    "@jridgewell/set-array": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+      "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+      "dev": true
+    },
+    "@jridgewell/source-map": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
+      "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+      "dev": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      },
+      "dependencies": {
+        "@jridgewell/trace-mapping": {
+          "version": "0.3.14",
+          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+          "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/resolve-uri": "^3.0.3",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+          }
+        }
+      }
     },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.11",
@@ -21761,13 +21812,14 @@
       "dev": true
     },
     "terser": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-5.10.0.tgz",
-      "integrity": "sha512-AMmF99DMfEDiRJfxfY5jj5wNH/bYO09cniSqhfoyxc8sFoYIgkJy86G04UoZU5VjlpnplVu0K6Tx6E9b5+DlHA==",
+      "version": "5.14.2",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.14.2.tgz",
+      "integrity": "sha512-oL0rGeM/WFQCUd0y2QrWxYnq7tfSuKBiqTjRPWrRgB46WD/kiwHwF8T23z78H6Q6kGCuuHcPB+KULHRdxvVGQA==",
       "dev": true,
       "requires": {
+        "@jridgewell/source-map": "^0.3.2",
+        "acorn": "^8.5.0",
         "commander": "^2.20.0",
-        "source-map": "~0.7.2",
         "source-map-support": "~0.5.20"
       },
       "dependencies": {
@@ -21776,28 +21828,32 @@
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
           "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true
-        },
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-          "dev": true
         }
       }
     },
     "terser-webpack-plugin": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.1.tgz",
-      "integrity": "sha512-GvlZdT6wPQKbDNW/GDQzZFg/j4vKU96yl2q6mcUkzKOgW4gwf1Z8cZToUCrz31XHlPWH8MVb1r2tFtdDtTGJ7g==",
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-5.3.3.tgz",
+      "integrity": "sha512-Fx60G5HNYknNTNQnzQ1VePRuu89ZVYWfjRAeT5rITuCY/1b08s49e5kSQwHDirKZWuoKOBRFS98EUUoZ9kLEwQ==",
       "dev": true,
       "requires": {
+        "@jridgewell/trace-mapping": "^0.3.7",
         "jest-worker": "^27.4.5",
         "schema-utils": "^3.1.1",
         "serialize-javascript": "^6.0.0",
-        "source-map": "^0.6.1",
         "terser": "^5.7.2"
       },
       "dependencies": {
+        "@jridgewell/trace-mapping": {
+          "version": "0.3.14",
+          "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.14.tgz",
+          "integrity": "sha512-bJWEfQ9lPTvm3SneWwRFVLzrh6nhjwqw7TUFFBEMzwvg7t7PCDenf2lDwqo4NQXzdpgBXyFgDWnQA+2vkruksQ==",
+          "dev": true,
+          "requires": {
+            "@jridgewell/resolve-uri": "^3.0.3",
+            "@jridgewell/sourcemap-codec": "^1.4.10"
+          }
+        },
         "schema-utils": {
           "version": "3.1.1",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-3.1.1.tgz",
@@ -21808,12 +21864,6 @@
             "ajv": "^6.12.5",
             "ajv-keywords": "^3.5.2"
           }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cumulus-dashboard",
-  "version": "10.0.0",
+  "version": "11.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2426,6 +2426,12 @@
           "integrity": "sha512-AmXqneQZL3KZMIgBpaPTeI6pfwh+xQ2vutMsyqOu1TBdEXFZgpG/80wuJ531w2ZN7TI0/oc8CPxzh/DKQudZqg==",
           "dev": true
         },
+        "moment": {
+          "version": "2.29.2",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
+          "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
+          "dev": true
+        },
         "p-limit": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
@@ -3449,6 +3455,12 @@
             "lodash.iserror": "^3.1.1"
           }
         },
+        "moment": {
+          "version": "2.29.2",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
+          "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
+          "dev": true
+        },
         "p-limit": {
           "version": "1.3.0",
           "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
@@ -3583,6 +3595,12 @@
           "requires": {
             "graceful-fs": "^4.1.6"
           }
+        },
+        "moment": {
+          "version": "2.29.2",
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
+          "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg==",
+          "dev": true
         },
         "p-map": {
           "version": "1.2.0",
@@ -13328,9 +13346,9 @@
       }
     },
     "moment": {
-      "version": "2.29.2",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.2.tgz",
-      "integrity": "sha512-UgzG4rvxYpN15jgCmVJwac49h9ly9NurikMWGPdVxm8GZD6XjkKPxDTjQQ43gtGgnV3X0cAyWDdP2Wexoquifg=="
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w=="
     },
     "moo": {
       "version": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@babel/preset-react": "^7.16.5",
     "@babel/register": "^7.16.5",
     "@babel/runtime": "^7.16.5",
-    "@cumulus/api": "11.1.0",
+    "@cumulus/api": "^13.1.0",
     "@cumulus/aws-client": "11.1.0",
     "@cypress/webpack-preprocessor": "^5.11.0",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.6",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "sass-resources-loader": "^2.1.1",
     "sinon": "^12.0.1",
     "style-loader": "^3.3.1",
-    "terser-webpack-plugin": "^5.3.0",
+    "terser-webpack-plugin": "^5.3.3",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^2.0.0",
     "webpack": "^5.65.0",

--- a/package.json
+++ b/package.json
@@ -162,7 +162,7 @@
     "jsonwebtoken": "^8.4.0",
     "localized-strings": "^0.2.4",
     "lodash": "^4.17.21",
-    "moment": "^2.29.2",
+    "moment": "^2.29.4",
     "normalize-opentype.css": "^0.2.4",
     "normalize.css": "^8.0.1",
     "numeral": "^2.0.4",


### PR DESCRIPTION
**Summary:** A few Axe accessibility error fixes.

Addresses [CUMULUS-2960: Dashboard: Groom Front-end Dependencies & Errors](https://bugs.earthdata.nasa.gov/browse/CUMULUS-2960)

## Changes
- Fixed the following Axe accessibility issues:
    + Specified title, level-one heading, and modal as main landmark on `/auth`
    + Increased link-background contrast in the header
    + Slight color adjustments for accessibility
- Updated dependencies with severe security vulnerabilities:
    + `@cumulus/api` to `13.1.0`
    + `moment` to `2.29.4`
    + `terser-webpack-plugin` to `5.3.3`

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests