### PR TITLE
Jk/cumulus 3092

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Changed
 
-- **CUMULUS-3072**
+- **CUMULUS-3092**
 
-  - Updated all PUT /granules/${granuleId} actions to use PATCH and supply the 
-  required `Cumulus-API-Version` headers
+  - Updated all PUT /granules/${granuleId} actions to use PATCH and supply the
+  required `Cumulus-API-Version` headers implemented in CUMULUS-3072
   - Removed unused `reprocessGranule` action method
 
 ## [v12.0.0] - 2023-01-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- **CUMULUS-3072**
+
+  - Updated all PUT /granules/${granuleId} actions to use PATCH and supply the 
+  required `Cumulus-API-Version` headers
+  - Removed unused `reprocessGranule` action method
+
 ## [v12.0.0] - 2023-01-23
 
 ## Breaking Changes

--- a/app/src/js/actions/index.js
+++ b/app/src/js/actions/index.js
@@ -205,18 +205,6 @@ export const listGranules = (options) => (dispatch, getState) => {
   });
 };
 
-export const reprocessGranule = (granuleId) => ({
-  [CALL_API]: {
-    type: types.GRANULE_REPROCESS,
-    method: 'PUT',
-    id: granuleId,
-    path: `granules/${granuleId}`,
-    data: {
-      action: 'reprocess'
-    }
-  }
-});
-
 export const applyWorkflowToCollection = (name, version, workflow) => ({
   [CALL_API]: {
     type: types.COLLECTION_APPLYWORKFLOW,
@@ -252,13 +240,16 @@ export const applyRecoveryWorkflowToCollection = (collectionId) => (dispatch) =>
 export const applyWorkflowToGranule = (granuleId, workflow, meta) => ({
   [CALL_API]: {
     type: types.GRANULE_APPLYWORKFLOW,
-    method: 'PUT',
+    method: 'PATCH',
     id: granuleId,
     path: `granules/${granuleId}`,
     data: {
       action: 'applyWorkflow',
       workflow,
       meta
+    },
+    headers: {
+      'Cumulus-API-Version': 2,
     }
   }
 });
@@ -293,12 +284,15 @@ export const applyRecoveryWorkflowToGranule = (granuleId) => (dispatch) => dispa
 export const reingestGranule = (granuleId, meta) => ({
   [CALL_API]: {
     type: types.GRANULE_REINGEST,
-    method: 'PUT',
+    method: 'PATCH',
     id: granuleId,
     path: `granules/${granuleId}`,
     data: {
       action: 'reingest',
       ...meta,
+    },
+    headers: {
+      'Cumulus-API-Version': 2,
     }
   }
 });
@@ -311,11 +305,14 @@ export const reingestGranuleClearError = (granuleId) => ({
 export const removeGranule = (granuleId) => ({
   [CALL_API]: {
     type: types.GRANULE_REMOVE,
-    method: 'PUT',
+    method: 'PATCH',
     id: granuleId,
     path: `granules/${granuleId}`,
     data: {
       action: 'removeFromCmr'
+    },
+    headers: {
+      'Cumulus-API-Version': 2,
     }
   }
 });


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3092](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3092)

## Changes

  - Updated all PUT /granules/${granuleId} actions to use PATCH and supply the required `Cumulus-API-Version` headers
  - Removed unused `reprocessGranule` action method

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests