### PR TITLE
CUMULUS-3265: Fixed bulk granule modal to correctly pass selected granules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- **CUMULUS-3265**
+  - Fixed bulk granule operation modal to correctly pass selected granules into bulk operation
+
 ## [v12.0.1] - 2023-05-25
+
 ### Breaking Changes
 
 This version of the dashboard requires Cumulus API v2 (Core version >= v16.0.0)

--- a/app/src/js/components/Granules/bulk-granule-modal.js
+++ b/app/src/js/components/Granules/bulk-granule-modal.js
@@ -61,21 +61,17 @@ const BulkGranuleModal = ({
     if (!inflight) {
       try {
         json = JSON.parse(query);
-        const granuleIds = json.ids.map((granule) => granule.granuleId);
-        json.ids = granuleIds;
       } catch (jsonError) {
-        return setErrorState('Syntax error in JSON');
+        return setErrorState(`Syntax error in JSON ${jsonError.message}`);
       }
       dispatch(bulkRequestAction({ requestId, json }));
     }
   }
 
   function queryGranulesWorkflows(queryParams) {
-    const { ids, index, query: esQuery } = queryParams;
-    if ((index && esQuery) || ids.length > 0) {
-      const granuleWorkflowsQuery = { ...queryParams, granules: ids };
-      delete granuleWorkflowsQuery[ids];
-      dispatch(getGranulesWorkflows(granuleWorkflowsQuery));
+    const { granules, index, query: esQuery } = queryParams;
+    if ((index && esQuery) || granules.length > 0) {
+      dispatch(getGranulesWorkflows(queryParams));
     }
   }
 
@@ -100,7 +96,7 @@ const BulkGranuleModal = ({
   }
 
   useEffect(() => {
-    const queryParams = { ...JSON.parse(query), ids: selected };
+    const queryParams = { ...JSON.parse(query), granules: selected };
     setQuery(JSON.stringify(queryParams, null, 2));
 
     if (showModal && queryWorkflowOptions) {
@@ -158,7 +154,7 @@ const BulkGranuleModal = ({
           {selected &&
             <>
               <p>Selected granules:</p>
-              <p>[{selected.map((selection) => `"${selection.granuleId}"`).join(', ')}]</p>
+              <p>[{selected.map((selection) => `{"granuleId": "${selection.granuleId}", "collectionId": "${selection.collectionId}"}`).join(', ')}]</p>
             </>
           }
           <br/>

--- a/app/src/js/components/Granules/bulk.js
+++ b/app/src/js/components/Granules/bulk.js
@@ -33,7 +33,7 @@ const bulkOperationsDefaultQuery = {
   workflowName: '',
   index: '',
   query: '',
-  granules: '',
+  granules: [],
   meta: {}
 };
 


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3265: Bulk Delete not working from Cumulus dashboard](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3265)

## Changes

* Detailed list or prose of changes
* ...

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [x] Adhoc testing
- [ ] Integration tests