### PR TITLE
CUMULUS-3855: Dashboard: API Indicator not Displaying Information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,11 @@ This version of the dashboard requires Cumulus API >= v18.4.0
   - Updated the dashboard to use `@cumulus/api@18.4.0` and `@cumulus/aws-client@18.4.0`.
   - Upgraded postgres image to postgres:13.9-alpine
 
+### Fixed
+
+- **CUMULUS-3855**
+  - Fixed to show API indicator and tooltip details
+
 ## [v12.1.0] - 2023-10-27
 
 ### Breaking Changes

--- a/app/src/js/components/Header/header.js
+++ b/app/src/js/components/Header/header.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback } from 'react';
+import React, { useEffect, useCallback, useRef } from 'react';
 import c from 'classnames';
 import PropTypes from 'prop-types';
 import { withRouter, Link } from 'react-router-dom';
@@ -36,6 +36,8 @@ const Header = ({
   minimal,
   locationQueryParams,
 }) => {
+  const mounted = useRef(true);
+
   const handleLogout = useCallback(() => {
     dispatch(logout()).then(() => {
       if (get(window, 'location.reload')) {
@@ -45,11 +47,14 @@ const Header = ({
   }, [dispatch]);
 
   useEffect(() => {
-    if (api.authenticated) {
+    if (api.authenticated && mounted.current) {
       dispatch(getApiVersion());
       dispatch(getCMRInfo());
       dispatch(getCumulusInstanceMetadata());
     }
+    return () => {
+      mounted.current = false;
+    };
   }, [api.authenticated, dispatch]);
 
   const className = (path) => {

--- a/app/src/js/components/Header/header.js
+++ b/app/src/js/components/Header/header.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useCallback, useRef } from 'react';
+import React, { useEffect, useCallback } from 'react';
 import c from 'classnames';
 import PropTypes from 'prop-types';
 import { withRouter, Link } from 'react-router-dom';
@@ -36,8 +36,6 @@ const Header = ({
   minimal,
   locationQueryParams,
 }) => {
-  const mounted = useRef(false);
-
   const handleLogout = useCallback(() => {
     dispatch(logout()).then(() => {
       if (get(window, 'location.reload')) {
@@ -47,14 +45,11 @@ const Header = ({
   }, [dispatch]);
 
   useEffect(() => {
-    if (api.authenticated && mounted.current) {
+    if (api.authenticated) {
       dispatch(getApiVersion());
       dispatch(getCMRInfo());
       dispatch(getCumulusInstanceMetadata());
     }
-    return () => {
-      mounted.current = false;
-    };
   }, [api.authenticated, dispatch]);
 
   const className = (path) => {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-3855: Dashboard: API Indicator not Displaying Information](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3855)

## Changes

To ensure that API information is displayed and verified:
* Fix conditional for `useRef(mounted)`

## PR Checklist

- [x] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests