### PR TITLE
CUMULUS-3862: Upgrade React Router to v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- **CUMULUS-3862**
+  - Upgraded React Router to v6.26.2
+
 ## [v12.2.0] - 2024-09-04
 
 This version of the dashboard requires Cumulus API >= v18.4.0


### PR DESCRIPTION
**Summary:** React Router from v5 to v6

Addresses [CUMULUS-3862: Develop amazing new feature](https://bugs.earthdata.nasa.gov/browse/CUMULUS-3862)

## Changes

* Detailed list or prose of changes
* React v18
* React Router v6
* Update route code to new v6 standard in App.js

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests