### PR TITLE
CUMULUS-3862 - Updated documentation to account for short term React upgrade version dependency issues that arise using npm during install.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ This version of the dashboard requires Cumulus API >= v19.2.0-alpha.1 (TBD API r
 
 ### Changed
 
+- **CUMULUS-3862**
+  - Updated documentation to account for short term React upgrade version dependency issues that arise using npm.
+
 - **GitHub Issue 1162**
   - Added documentation for beginners starting from scratch.
 

--- a/README.md
+++ b/README.md
@@ -102,20 +102,18 @@ The dashboard uses node v20.12.2. To build/run the dashboard on your local machi
 #### install requirements
 We use npm for local package management. To install the requirements:
 ```bash
-  nvm use
-  npm ci
+  nvm use 
 ```
 
 When package.json is updated.
 
 ```bash
-npm install
+ npm install --legacy-peer-deps
 ```
 
 ```bash
 npm install connected-react-router@6.9.3 --legacy-peer-deps
 ```
-
 
 To build a dashboard bundle<sup>[1](#bundlefootnote)</sup>:
 


### PR DESCRIPTION
**Summary:** 
Updated documentation to account for short term React upgrade version dependency issues that arise using npm during install.

Addresses CUMULUS-3862: Dashboard: Upgrade React Router to v6 (https://bugs.earthdata.nasa.gov/browse/CUMULUS-3862)

## Changes

* Detailed list or prose of changes
Updated the readme and changelog.

## PR Checklist

- [*] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests