### PR TITLE
CUMULUS-4028 Rename cumulus-dashboard package name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "cumulus-dashboard",
+  "name": "@cumulus/cumulus-dashboard",
   "version": "13.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "cumulus-dashboard",
+      "name": "@cumulus/cumulus-dashboard",
       "version": "13.0.0",
       "license": "Apache-2.0",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cumulus-dashboard",
+  "name": "@cumulus/cumulus-dashboard",
   "version": "13.0.0",
   "description": "A dashboard for Cumulus API",
   "repository": {


### PR DESCRIPTION
**Summary:** Summary of changes

Addresses [CUMULUS-4028: Rename cumulus-dashboard package name](https://bugs.earthdata.nasa.gov/browse/CUMULUS-4028)

## Changes

* Rename cumulus-dashboard package name

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests