### PR TITLE
CUMULUS-4021: Release dashboard version 13.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [v13.1.0] - 2025-03-25
 
 ### Changed
 
@@ -24,7 +24,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - **CUMULUS-4008**
   - Updated the Dockerfile with improved NPM install command to prevent error messages.
 
-## [v13.0.0] - 2024-02-19
+## [v13.0.0] - 2025-02-19
 This version of the dashboard requires Cumulus API >= v20.0.0
 
 ### Changed
@@ -1462,7 +1462,8 @@ Fix for serving the dashboard through the Cumulus API.
 ### Added
 
 - Versioning and changelog [CUMULUS-197] by @kkelly51
-  [Unreleased]: https://github.com/nasa/cumulus-dashboard/compare/v13.0.0...HEAD
+  [Unreleased]: https://github.com/nasa/cumulus-dashboard/compare/v13.1.0...HEAD
+  [v13.1.0]: https://github.com/nasa/cumulus-dashboard/compare/v13.0.0...v13.1.0
   [v13.0.0]: https://github.com/nasa/cumulus-dashboard/compare/v12.2.0...v13.0.0
   [v12.2.0]: https://github.com/nasa/cumulus-dashboard/compare/v12.1.0...v12.2.0
   [v12.1.0]: https://github.com/nasa/cumulus-dashboard/compare/v12.0.2...v12.1.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cumulus/cumulus-dashboard",
-  "version": "13.0.0",
+  "version": "13.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cumulus/cumulus-dashboard",
-      "version": "13.0.0",
+      "version": "13.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.15.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cumulus/cumulus-dashboard",
-  "version": "13.0.0",
+  "version": "13.1.0",
   "description": "A dashboard for Cumulus API",
   "repository": {
     "type": "git",


### PR DESCRIPTION
**Summary:** Summary of changes

Cumulus Dashboard release 13.1.0 (https://bugs.earthdata.nasa.gov/browse/CUMULUS-4021)

## Changes
- Renamed cumulus-dashboard package name to `@cumulus/cumulus-dashboard`
- Upgraded axios and xml-crypto packages to fix audit issue

## Deleted
- Remove D3 and related libraries from dashboard.

## Fixed
- Updated the Dockerfile with improved NPM install command to prevent error messages.

## PR Checklist

- [x] Update CHANGELOG
- [x] Unit tests
- [ ] Adhoc testing
- [x] Integration tests