### PR TITLE
Update index.js for issue 1192 : Granules Page collection dropdown does not sort by modified time DESC

### DIFF
--- a/app/src/js/actions/index.js
+++ b/app/src/js/actions/index.js
@@ -427,7 +427,7 @@ export const getOptionsCollectionName = (options) => ({
     type: types.OPTIONS_COLLECTIONNAME,
     method: 'GET',
     url: new URL('collections', root).href,
-    params: { limit: 100, fields: 'name,version' }
+    params: { limit: 100, 'sort_key[]': '-updatedAt', fields: 'name,version' }
   }
 });
 


### PR DESCRIPTION
issue 1192

**Summary:** Summary of changes

issue 1192 : Granules Page collection dropdown does not sort by modified time DESC


## Changes

Added a query parameter

## PR Checklist

- [ ] Update CHANGELOG
- [ ] Unit tests
- [ ] Adhoc testing
- [ ] Integration tests